### PR TITLE
docs: strengthen repository README and add AGENTS defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,12 @@ For conflicts, resolve in this order:
 2. `docs/spec.md` (technical architecture and platform constraints)
 3. `docs/product.md` (user and product intent)
 
+## Domain Defaults
+
+- Production domain is `https://3fc.football`.
+- When documenting or implementing public URLs, use this domain as the canonical host.
+- If QA hostnames are needed, define them explicitly in docs/infra rather than assuming.
+
 ## Implementation Defaults
 
 ### API and Contracts

--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ Phone-first web application for managing and scoring Three Sided Football Club (
 
 This repository contains the product, technical, infrastructure, and delivery assets for the 3FC v0 build.
 
+## Domain
+
+- Production web domain: `https://3fc.football`
+- Public game URLs should resolve under this domain using `/{league}/{season}/{game}` paths.
+
 Primary source docs:
 
 - `docs/product.md`: product brief, UX flows, and game rules

--- a/docs/product.md
+++ b/docs/product.md
@@ -84,7 +84,7 @@ team.
 10. Finish game → compute winner + stats → send email summaries to claimed
 players.
 11. Share results via public game URL (suggested: /league/season/game, each as
-ID or human-friendly slug e.g. /melbourne-3fc/2025-26/20260222/).
+ID or human-friendly slug e.g. https://3fc.football/melbourne-3fc/2025-26/20260222/).
 
 ## Screens (v0)
 
@@ -135,4 +135,4 @@ ID or human-friendly slug e.g. /melbourne-3fc/2025-26/20260222/).
   only)?
     - /league/season/game
     - Each of these to be an ID or human friendly identifier eg
-      /Melbourne-3fc/2025-26/20260222/
+      https://3fc.football/melbourne-3fc/2025-26/20260222/

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -25,12 +25,12 @@ Clean, consolidated version of the technical spec. Canonical going forward.
 ## 3. Terraform resources (minimum set)
 
 - S3 (site + optional logs)
-- CloudFront + OAC; ACM; Route53 (if custom domain)
+- CloudFront + OAC; ACM; Route53 for `3fc.football`
 - Cognito User Pool, clients, IdPs (Google/Facebook)
 - API Gateway HTTP API + JWT authorizer
 - Lambda functions + IAM
 - DynamoDB PAY_PER_REQUEST + PITR
-- SES verified domain/from-address (+ optional SNS bounces)
+- SES verified domain/from-address for `3fc.football` (+ optional SNS bounces)
 - EventBridge/SQS optional for async notifications
 
 ## 4. ID + URL strategy
@@ -38,6 +38,7 @@ Clean, consolidated version of the technical spec. Canonical going forward.
 - IDs: ULID.
 - Public URLs: /{league}/{season}/{game} (league+season can be slug or id; game
   always accessible by gameId).
+- Production base URL: `https://3fc.football`.
 
 ## 5. Data model (DynamoDB single table)
 
@@ -154,6 +155,7 @@ POST  /v1/players/{playerId}/claim
 - The `production` environment application will be deployed to via github
   workflows and will reside in AWS. It will be automatically deployed to when a
   branch is merged to the `main` branch and will be fully automated.
+- Production site host/domain: `https://3fc.football`.
 - Infrastructure will be deployed via terraform from local shells to apply
   updates using AWS Developer accounts. State will be managed using S3 based
   state management in a bucket that will be used explicitly for this purpose


### PR DESCRIPTION
## Summary

- rewrite `README.md` with project purpose, architecture direction, repo layout, and working conventions
- add repo-level `AGENTS.md` with implementation defaults, guardrails, and quality expectations for 3FC
- update documentation to use the canonical production domain `https://3fc.football` (`README.md`, `AGENTS.md`, `docs/spec.md`, `docs/product.md`)
- switch PR body update workflow to file-based input so Markdown newlines render correctly in GitHub

## Validation

- `make backlog-validate`
