### PR TITLE
feat(m0-01): bootstrap monorepo runtime and tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@ coverage
 # TypeScript cache
 *.tsbuildinfo
 
+# Node workspace artifacts
+node_modules/
+dist/
+
 # Optional npm cache directory
 .npm
 
@@ -52,4 +56,3 @@ coverage
 
 # DynamoDB Local files
 .dynamodb/
-

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,13 @@ REPO ?=
 help:
 	@echo "Usage: make [target]"
 	@echo ""
+	@echo "Core targets:"
+	@echo "  make install                            Install workspace dependencies"
+	@echo "  make build                              Build all workspaces"
+	@echo "  make test                               Run tests for all workspaces"
+	@echo "  make clean                              Remove workspace build artifacts"
+	@echo "  make deploy ENV=qa|prod                 Guarded deploy entrypoint"
+	@echo ""
 	@echo "Backlog targets:"
 	@echo "  make backlog-validate                   Validate backlog JSON"
 	@echo "  make backlog-export                     Generate docs/backlog/backlog.md from backlog JSON"
@@ -13,13 +20,13 @@ help:
 	@echo "  make backlog-sync REPO=owner/repo      Create labels/milestones/issues in GitHub"
 
 clean:
-	@echo "Not implemented yet"
+	npm run clean
 
 build:
-	@echo "Not implemented yet"
+	npm run build
 
 test:
-	@echo "Not implemented yet"
+	npm run test
 
 deploy:
 	@if [ -z "$(ENV)" ] || { [ "$(ENV)" != "qa" ] && [ "$(ENV)" != "prod" ]; }; then \
@@ -29,7 +36,7 @@ deploy:
 	@echo "Not implemented yet"
 
 install:
-	@echo "Not implemented yet"
+	npm install
 
 backlog-validate:
 	./scripts/github/validate_backlog.sh $(BACKLOG_FILE)
@@ -50,4 +57,3 @@ backlog-sync:
 		exit 1; \
 	fi
 	./scripts/github/create_backlog_issues.sh --repo $(REPO) --backlog-file $(BACKLOG_FILE)
-

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The project is in the delivery setup phase:
 
 - Milestone backlog is defined and ready to seed into GitHub issues.
 - Infrastructure skeleton exists under `infra/`.
-- `app/` and `api/` runtime implementation is still to be built.
+- Monorepo runtime bootstrap is in place for `app`, `api`, and shared contracts.
 
 ## Architecture Direction (v0)
 
@@ -36,11 +36,27 @@ The project is in the delivery setup phase:
 
 ## Repository Layout
 
-- `app/`: frontend application (to be implemented)
-- `api/`: backend application (to be implemented)
+- `app/`: frontend package scaffold (TypeScript)
+- `api/`: backend package scaffold (TypeScript)
+- `packages/contracts/`: shared TypeScript contracts and core domain types
 - `infra/`: Terraform modules and environment wrappers (`qa`, `prod`)
 - `docs/`: product, spec, and backlog artifacts
 - `scripts/github/`: backlog validation/export/sync helpers
+
+## Tooling Requirements
+
+- Node.js `>=22.0.0`
+- npm `>=10.0.0`
+
+## Local Setup
+
+```bash
+make install
+make build
+make test
+```
+
+These run against npm workspaces at the repository root.
 
 ## Workflow Conventions
 
@@ -80,7 +96,7 @@ Notes:
 
 ## Make Targets
 
-`Makefile` includes placeholders for future build/test/deploy automation and currently provides working backlog targets plus deploy env guardrails.
+`Makefile` provides working install/build/test targets for the npm workspace, backlog automation targets, and deploy env guardrails.
 
 Run help:
 

--- a/api/package.json
+++ b/api/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@3fc/api",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "npm run typecheck",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@3fc/contracts": "0.1.0"
+  }
+}

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,0 +1,9 @@
+import type { GameHealth } from "@3fc/contracts";
+
+export function buildHealthResponse(now = new Date()): GameHealth {
+  return {
+    status: "ok",
+    service: "api",
+    timestamp: now.toISOString(),
+  };
+}

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo"
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "references": [
+    { "path": "../packages/contracts" }
+  ]
+}

--- a/app/package.json
+++ b/app/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@3fc/app",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "npm run typecheck",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@3fc/contracts": "0.1.0"
+  }
+}

--- a/app/src/index.ts
+++ b/app/src/index.ts
@@ -1,0 +1,7 @@
+import type { TeamId } from "@3fc/contracts";
+
+const DEFAULT_TEAMS: TeamId[] = ["red", "blue", "yellow"];
+
+export function getDefaultTeams(): TeamId[] {
+  return DEFAULT_TEAMS;
+}

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo"
+  },
+  "include": [
+    "src/**/*.ts"
+  ],
+  "references": [
+    { "path": "../packages/contracts" }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,86 @@
+{
+  "name": "3fc",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "3fc",
+      "version": "0.1.0",
+      "workspaces": [
+        "app",
+        "api",
+        "packages/contracts"
+      ],
+      "devDependencies": {
+        "@types/node": "^22.13.14",
+        "typescript": "^5.7.3"
+      },
+      "engines": {
+        "node": ">=22.0.0",
+        "npm": ">=10.0.0"
+      }
+    },
+    "api": {
+      "name": "@3fc/api",
+      "version": "0.1.0",
+      "dependencies": {
+        "@3fc/contracts": "0.1.0"
+      }
+    },
+    "app": {
+      "name": "@3fc/app",
+      "version": "0.1.0",
+      "dependencies": {
+        "@3fc/contracts": "0.1.0"
+      }
+    },
+    "node_modules/@3fc/api": {
+      "resolved": "api",
+      "link": true
+    },
+    "node_modules/@3fc/app": {
+      "resolved": "app",
+      "link": true
+    },
+    "node_modules/@3fc/contracts": {
+      "resolved": "packages/contracts",
+      "link": true
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
+      "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "packages/contracts": {
+      "name": "@3fc/contracts",
+      "version": "0.1.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "3fc",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Three Sided Football Club web app monorepo",
+  "engines": {
+    "node": ">=22.0.0",
+    "npm": ">=10.0.0"
+  },
+  "workspaces": [
+    "app",
+    "api",
+    "packages/contracts"
+  ],
+  "scripts": {
+    "build": "npm run build --workspaces",
+    "test": "npm run test --workspaces",
+    "typecheck": "npm run typecheck --workspaces",
+    "clean": "npm run clean --workspaces --if-present"
+  },
+  "devDependencies": {
+    "@types/node": "^22.13.14",
+    "typescript": "^5.7.3"
+  }
+}

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@3fc/contracts",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "npm run typecheck",
+    "clean": "rm -rf dist"
+  }
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,0 +1,38 @@
+export type TeamId = "red" | "blue" | "yellow";
+
+export interface GoalEventInput {
+  gameId: string;
+  third: 1 | 2 | 3;
+  scoringTeamId: TeamId | null;
+  concedingTeamId: TeamId;
+  scorerPlayerId: string;
+  assistPlayerIds: string[];
+  ownGoal: boolean;
+}
+
+export interface GameHealth {
+  status: "ok";
+  service: "api";
+  timestamp: string;
+}
+
+export const MAX_ASSISTS = 3;
+
+export function validateAssistPlayerIds(
+  scorerPlayerId: string,
+  assistPlayerIds: string[],
+): void {
+  const uniqueAssistIds = new Set(assistPlayerIds);
+
+  if (assistPlayerIds.length > MAX_ASSISTS) {
+    throw new Error(`No more than ${MAX_ASSISTS} assists are allowed.`);
+  }
+
+  if (uniqueAssistIds.size !== assistPlayerIds.length) {
+    throw new Error("Assist player IDs must be unique.");
+  }
+
+  if (uniqueAssistIds.has(scorerPlayerId)) {
+    throw new Error("Scorer cannot be listed as an assister.");
+  }
+}

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "tsBuildInfoFile": "dist/tsconfig.tsbuildinfo"
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "verbatimModuleSyntax": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "files": [],
+  "references": [
+    { "path": "packages/contracts" },
+    { "path": "api" },
+    { "path": "app" }
+  ]
+}


### PR DESCRIPTION
## Summary

Implements `M0-01` by bootstrapping a working Node/npm monorepo foundation for `app`, `api`, and shared contracts.

### What changed

- add root npm workspace config and lockfile:
  - `package.json`
  - `package-lock.json`
- add shared TypeScript config:
  - `tsconfig.base.json`
  - `tsconfig.json` project references
- scaffold package workspaces:
  - `app/` (`@3fc/app`)
  - `api/` (`@3fc/api`)
  - `packages/contracts/` (`@3fc/contracts`)
- add initial shared contracts/types and validation helper:
  - `TeamId`, `GoalEventInput`, `GameHealth`, assist validation constraints
- wire `make` core developer targets to npm workspace scripts:
  - `make install`
  - `make build`
  - `make test`
  - `make clean`
- update docs for runtime/tooling expectations and local setup commands.

## Why

This establishes the baseline runtime/tooling expected by backlog issue `M0-01`, and unblocks follow-on tickets (API health endpoint, CI workflow, Docker local stack, etc.).

## Validation

- `make install`
- `make build`
- `make test`

