### PR TITLE
chore(m0-03): implement make deploy workflow scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ local/dynamodb/*
 local/fake-ses/*
 !local/dynamodb/.gitkeep
 !local/fake-ses/.gitkeep
+
+# Local deploy artifacts
+out/

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ help:
 
 clean:
 	npm run clean
+	rm -rf out
 
 build:
 	npm run build
@@ -36,7 +37,7 @@ deploy:
 		echo "ENV must be set to qa or prod"; \
 		exit 1; \
 	fi
-	@echo "Not implemented yet"
+	./scripts/deploy/deploy-app.sh $(ENV)
 
 install:
 	npm install

--- a/README.md
+++ b/README.md
@@ -117,6 +117,15 @@ Notes:
 
 `Makefile` provides working install/build/test targets for the npm workspace, backlog automation targets, and deploy env guardrails.
 
+Deploy scaffold examples:
+
+```bash
+make deploy ENV=qa
+make deploy ENV=prod
+```
+
+`make deploy` currently prepares a versioned application artifact bundle and manifest under `out/deploy/<env>/` (without creating cloud resources directly).
+
 Run help:
 
 ```bash

--- a/scripts/deploy/deploy-app.sh
+++ b/scripts/deploy/deploy-app.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <qa|prod>" >&2
+  exit 1
+fi
+
+ENV="$1"
+
+if [[ "$ENV" != "qa" && "$ENV" != "prod" ]]; then
+  echo "ENV must be one of: qa, prod" >&2
+  exit 1
+fi
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "npm is required but was not found in PATH" >&2
+  exit 1
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+COMMIT_SHA="$(git rev-parse --short HEAD)"
+BRANCH_NAME="$(git rev-parse --abbrev-ref HEAD)"
+TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+ARTIFACT_DIR="out/deploy/$ENV"
+ARTIFACT_NAME="3fc-app-${ENV}-${COMMIT_SHA}.tar.gz"
+ARTIFACT_PATH="$ARTIFACT_DIR/$ARTIFACT_NAME"
+MANIFEST_PATH="$ARTIFACT_DIR/manifest.json"
+
+mkdir -p "$ARTIFACT_DIR"
+
+echo "[deploy] Building workspaces"
+npm run build >/dev/null
+
+echo "[deploy] Packaging application artifacts"
+tar -czf "$ARTIFACT_PATH" \
+  app/dist \
+  api/dist \
+  packages/contracts/dist \
+  package.json \
+  compose.yaml
+
+cat > "$MANIFEST_PATH" <<JSON
+{
+  "env": "$ENV",
+  "generatedAtUtc": "$TIMESTAMP",
+  "git": {
+    "branch": "$BRANCH_NAME",
+    "commit": "$COMMIT_SHA"
+  },
+  "artifact": {
+    "path": "$ARTIFACT_PATH",
+    "name": "$ARTIFACT_NAME"
+  }
+}
+JSON
+
+echo "[deploy] Prepared deployment bundle"
+echo "[deploy] Env:       $ENV"
+echo "[deploy] Artifact:  $ARTIFACT_PATH"
+echo "[deploy] Manifest:  $MANIFEST_PATH"


### PR DESCRIPTION
## Summary

Implements backlog issue `M0-03` by replacing the remaining `make deploy` placeholder with a deterministic deploy scaffold and tightening core make workflow behavior.

Closes #12.

### What changed

- update `Makefile`:
  - `clean` now removes workspace outputs and local deploy artifacts (`out/`)
  - `deploy` now invokes a real script path after strict `ENV=qa|prod` validation
- add deploy scaffold script:
  - `scripts/deploy/deploy-app.sh`
  - builds workspace packages
  - packages deploy bundle as `out/deploy/<env>/3fc-app-<env>-<sha>.tar.gz`
  - writes deploy manifest `out/deploy/<env>/manifest.json`
- update docs in `README.md` for deploy usage and artifact behavior
- ignore local deploy outputs via `.gitignore` (`out/`)

## Why

This satisfies `M0-03` acceptance criteria by ensuring all required make targets are meaningful and executable, while keeping cloud deployment internals out of scope for now.

## Validation

- `make test`
- `make deploy ENV=qa`
- `make deploy ENV=foo` (fails with explicit ENV error)
- `make deploy` (fails with explicit ENV error)
- `ls out/deploy/qa`
- `cat out/deploy/qa/manifest.json`

