### PR TITLE
feat(m1-01): add dynamodb single-table repository layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The project is in the delivery setup phase:
 - `infra/`: Terraform modules and environment wrappers (`qa`, `prod`)
 - `docs/`: product, spec, and backlog artifacts
 - `docs/local-development.md`: local stack usage and smoke checks
+- `docs/dynamodb-single-table.md`: key schema and repository access patterns
 - `scripts/github/`: backlog validation/export/sync helpers
 
 ## Tooling Requirements

--- a/api/src/data/index.ts
+++ b/api/src/data/index.ts
@@ -1,0 +1,3 @@
+export * from "./keys.js";
+export * from "./repository.js";
+export * from "./types.js";

--- a/api/src/data/keys.ts
+++ b/api/src/data/keys.ts
@@ -1,0 +1,64 @@
+export const ENTITY_PK_PREFIX = {
+  league: "LEAGUE#",
+  season: "SEASON#",
+  game: "GAME#",
+  session: "SESSION#",
+  player: "PLAYER#",
+} as const;
+
+export function leaguePk(leagueId: string): string {
+  return `${ENTITY_PK_PREFIX.league}${leagueId}`;
+}
+
+export function seasonPk(seasonId: string): string {
+  return `${ENTITY_PK_PREFIX.season}${seasonId}`;
+}
+
+export function seasonSk(seasonId: string): string {
+  return `SEASON#${seasonId}`;
+}
+
+export function teamSk(teamId: string): string {
+  return `TEAM#${teamId}`;
+}
+
+export function sessionSk(sessionId: string): string {
+  return `SESSION#${sessionId}`;
+}
+
+export function gamePk(gameId: string): string {
+  return `${ENTITY_PK_PREFIX.game}${gameId}`;
+}
+
+export function playerPk(playerId: string): string {
+  return `${ENTITY_PK_PREFIX.player}${playerId}`;
+}
+
+export function metadataSk(): string {
+  return "METADATA";
+}
+
+export function profileSk(): string {
+  return "PROFILE";
+}
+
+export function aclSk(userId: string): string {
+  return `ACL#USER#${userId}`;
+}
+
+export function rosterSk(teamId: string, playerId: string): string {
+  return `ROSTER#${teamId}#${playerId}`;
+}
+
+export function gameSessionIndexPk(sessionId: string): string {
+  return `${ENTITY_PK_PREFIX.session}${sessionId}`;
+}
+
+export function gameSessionIndexSk(gameStartTs: string, gameId: string): string {
+  return `GAME#${gameStartTs}#${gameId}`;
+}
+
+export function goalSk(third: 1 | 2 | 3, gameMinute: number, eventId: string): string {
+  const minuteSortable = String(gameMinute).padStart(4, "0");
+  return `GOAL#${third}#${minuteSortable}#${eventId}`;
+}

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -1,0 +1,557 @@
+import {
+  GetItemCommand,
+  type GetItemCommandOutput,
+  PutItemCommand,
+  QueryCommand,
+  type QueryCommandOutput,
+  type AttributeValue,
+} from "@aws-sdk/client-dynamodb";
+import { validateAssistPlayerIds } from "@3fc/contracts";
+
+import {
+  aclSk,
+  gamePk,
+  gameSessionIndexPk,
+  gameSessionIndexSk,
+  goalSk,
+  leaguePk,
+  metadataSk,
+  playerPk,
+  profileSk,
+  rosterSk,
+  seasonPk,
+  seasonSk,
+  sessionSk,
+  teamSk,
+} from "./keys.js";
+import type {
+  AssignRosterInput,
+  CreateGameInput,
+  CreateGoalEventInput,
+  CreateLeagueInput,
+  CreatePlayerInput,
+  CreateSeasonInput,
+  CreateSessionGameInput,
+  CreateSessionInput,
+  CreateTeamInput,
+  GameRecord,
+  GoalEventRecord,
+  LeagueAclRecord,
+  LeagueRecord,
+  PlayerRecord,
+  RosterAssignmentRecord,
+  SeasonRecord,
+  SessionGameRecord,
+  SessionRecord,
+  TeamRecord,
+  GrantLeagueAccessInput,
+} from "./types.js";
+
+const ENTITY_TYPE = {
+  league: "league",
+  season: "season",
+  team: "team",
+  session: "session",
+  game: "game",
+  sessionGame: "sessionGame",
+  player: "player",
+  acl: "acl",
+  roster: "roster",
+  goal: "goal",
+} as const;
+
+type EntityType = (typeof ENTITY_TYPE)[keyof typeof ENTITY_TYPE];
+
+type Item = Record<string, AttributeValue>;
+
+interface Clock {
+  now(): string;
+}
+
+interface DynamoCommandClient {
+  send(command: unknown): Promise<unknown>;
+}
+
+interface StoredEntity<T> {
+  pk: string;
+  sk: string;
+  entityType: EntityType;
+  createdAt: string;
+  updatedAt: string;
+  data: T;
+}
+
+class DefaultClock implements Clock {
+  now(): string {
+    return new Date().toISOString();
+  }
+}
+
+function requireNonEmpty(name: string, value: string): void {
+  if (value.trim().length === 0) {
+    throw new Error(`${name} must be a non-empty string.`);
+  }
+}
+
+function requireGameMinute(gameMinute: number): void {
+  if (!Number.isInteger(gameMinute) || gameMinute < 0) {
+    throw new Error("gameMinute must be an integer greater than or equal to zero.");
+  }
+}
+
+function readString(value: AttributeValue | undefined, field: string): string {
+  if (!value || value.S === undefined) {
+    throw new Error(`Missing string attribute \`${field}\`.`);
+  }
+
+  return value.S;
+}
+
+function buildItem<T>(
+  pk: string,
+  sk: string,
+  entityType: EntityType,
+  payload: T,
+  now: string,
+): Item {
+  return {
+    pk: { S: pk },
+    sk: { S: sk },
+    entityType: { S: entityType },
+    createdAt: { S: now },
+    updatedAt: { S: now },
+    data: { S: JSON.stringify(payload) },
+  };
+}
+
+function parseStoredEntity<T>(item: Item): StoredEntity<T> {
+  const rawData = readString(item.data, "data");
+  return {
+    pk: readString(item.pk, "pk"),
+    sk: readString(item.sk, "sk"),
+    entityType: readString(item.entityType, "entityType") as EntityType,
+    createdAt: readString(item.createdAt, "createdAt"),
+    updatedAt: readString(item.updatedAt, "updatedAt"),
+    data: JSON.parse(rawData) as T,
+  };
+}
+
+function withTimestamps<T extends object>(
+  payload: T,
+  createdAt: string,
+  updatedAt: string,
+): T & { createdAt: string; updatedAt: string } {
+  return {
+    ...payload,
+    createdAt,
+    updatedAt,
+  };
+}
+
+export class ThreeFcRepository {
+  constructor(
+    private readonly client: DynamoCommandClient,
+    private readonly tableName: string,
+    private readonly clock: Clock = new DefaultClock(),
+  ) {}
+
+  async createLeague(input: CreateLeagueInput): Promise<LeagueRecord> {
+    requireNonEmpty("leagueId", input.leagueId);
+    requireNonEmpty("name", input.name);
+    requireNonEmpty("createdByUserId", input.createdByUserId);
+
+    const now = this.clock.now();
+    const payload = {
+      leagueId: input.leagueId,
+      name: input.name,
+      slug: input.slug ?? null,
+      createdByUserId: input.createdByUserId,
+    };
+
+    await this.putEntity(leaguePk(input.leagueId), metadataSk(), ENTITY_TYPE.league, payload, now);
+    return withTimestamps(payload, now, now);
+  }
+
+  async getLeague(leagueId: string): Promise<LeagueRecord | null> {
+    requireNonEmpty("leagueId", leagueId);
+    const item = await this.getEntity(leaguePk(leagueId), metadataSk());
+
+    if (!item || item.entityType !== ENTITY_TYPE.league) {
+      return null;
+    }
+
+    return withTimestamps(item.data as Omit<LeagueRecord, "createdAt" | "updatedAt">, item.createdAt, item.updatedAt);
+  }
+
+  async createSeason(input: CreateSeasonInput): Promise<SeasonRecord> {
+    requireNonEmpty("leagueId", input.leagueId);
+    requireNonEmpty("seasonId", input.seasonId);
+    requireNonEmpty("name", input.name);
+
+    const now = this.clock.now();
+    const payload = {
+      leagueId: input.leagueId,
+      seasonId: input.seasonId,
+      name: input.name,
+      slug: input.slug ?? null,
+      startsOn: input.startsOn ?? null,
+      endsOn: input.endsOn ?? null,
+    };
+
+    await this.putEntity(leaguePk(input.leagueId), seasonSk(input.seasonId), ENTITY_TYPE.season, payload, now);
+    return withTimestamps(payload, now, now);
+  }
+
+  async listSeasonsForLeague(leagueId: string): Promise<SeasonRecord[]> {
+    requireNonEmpty("leagueId", leagueId);
+    const items = await this.queryByPrefix(leaguePk(leagueId), "SEASON#");
+
+    return items
+      .filter((item) => item.entityType === ENTITY_TYPE.season)
+      .map((item) =>
+        withTimestamps(
+          item.data as Omit<SeasonRecord, "createdAt" | "updatedAt">,
+          item.createdAt,
+          item.updatedAt,
+        ),
+      );
+  }
+
+  async createTeam(input: CreateTeamInput): Promise<TeamRecord> {
+    requireNonEmpty("seasonId", input.seasonId);
+    requireNonEmpty("name", input.name);
+
+    const now = this.clock.now();
+    const payload = {
+      seasonId: input.seasonId,
+      teamId: input.teamId,
+      name: input.name,
+      color: input.color ?? null,
+    };
+
+    await this.putEntity(seasonPk(input.seasonId), teamSk(input.teamId), ENTITY_TYPE.team, payload, now);
+    return withTimestamps(payload, now, now);
+  }
+
+  async listTeamsForSeason(seasonId: string): Promise<TeamRecord[]> {
+    requireNonEmpty("seasonId", seasonId);
+    const items = await this.queryByPrefix(seasonPk(seasonId), "TEAM#");
+
+    return items
+      .filter((item) => item.entityType === ENTITY_TYPE.team)
+      .map((item) =>
+        withTimestamps(
+          item.data as Omit<TeamRecord, "createdAt" | "updatedAt">,
+          item.createdAt,
+          item.updatedAt,
+        ),
+      );
+  }
+
+  async createSession(input: CreateSessionInput): Promise<SessionRecord> {
+    requireNonEmpty("seasonId", input.seasonId);
+    requireNonEmpty("sessionId", input.sessionId);
+    requireNonEmpty("sessionDate", input.sessionDate);
+
+    const now = this.clock.now();
+    const payload = {
+      seasonId: input.seasonId,
+      sessionId: input.sessionId,
+      sessionDate: input.sessionDate,
+    };
+
+    await this.putEntity(
+      seasonPk(input.seasonId),
+      sessionSk(input.sessionId),
+      ENTITY_TYPE.session,
+      payload,
+      now,
+    );
+    return withTimestamps(payload, now, now);
+  }
+
+  async listSessionsForSeason(seasonId: string): Promise<SessionRecord[]> {
+    requireNonEmpty("seasonId", seasonId);
+    const items = await this.queryByPrefix(seasonPk(seasonId), "SESSION#");
+
+    return items
+      .filter((item) => item.entityType === ENTITY_TYPE.session)
+      .map((item) =>
+        withTimestamps(
+          item.data as Omit<SessionRecord, "createdAt" | "updatedAt">,
+          item.createdAt,
+          item.updatedAt,
+        ),
+      );
+  }
+
+  async createGame(input: CreateGameInput): Promise<GameRecord> {
+    requireNonEmpty("gameId", input.gameId);
+    requireNonEmpty("leagueId", input.leagueId);
+    requireNonEmpty("seasonId", input.seasonId);
+    requireNonEmpty("sessionId", input.sessionId);
+    requireNonEmpty("gameStartTs", input.gameStartTs);
+
+    const now = this.clock.now();
+    const payload = {
+      gameId: input.gameId,
+      leagueId: input.leagueId,
+      seasonId: input.seasonId,
+      sessionId: input.sessionId,
+      status: input.status ?? "scheduled",
+      gameStartTs: input.gameStartTs,
+    };
+
+    await this.putEntity(gamePk(input.gameId), metadataSk(), ENTITY_TYPE.game, payload, now);
+    return withTimestamps(payload, now, now);
+  }
+
+  async getGame(gameId: string): Promise<GameRecord | null> {
+    requireNonEmpty("gameId", gameId);
+    const item = await this.getEntity(gamePk(gameId), metadataSk());
+
+    if (!item || item.entityType !== ENTITY_TYPE.game) {
+      return null;
+    }
+
+    return withTimestamps(item.data as Omit<GameRecord, "createdAt" | "updatedAt">, item.createdAt, item.updatedAt);
+  }
+
+  async createSessionGame(input: CreateSessionGameInput): Promise<SessionGameRecord> {
+    requireNonEmpty("sessionId", input.sessionId);
+    requireNonEmpty("gameId", input.gameId);
+    requireNonEmpty("gameStartTs", input.gameStartTs);
+    requireNonEmpty("leagueId", input.leagueId);
+    requireNonEmpty("seasonId", input.seasonId);
+
+    const now = this.clock.now();
+    const payload = {
+      sessionId: input.sessionId,
+      gameId: input.gameId,
+      gameStartTs: input.gameStartTs,
+      leagueId: input.leagueId,
+      seasonId: input.seasonId,
+    };
+
+    await this.putEntity(
+      gameSessionIndexPk(input.sessionId),
+      gameSessionIndexSk(input.gameStartTs, input.gameId),
+      ENTITY_TYPE.sessionGame,
+      payload,
+      now,
+    );
+
+    return withTimestamps(payload, now, now);
+  }
+
+  async listGamesForSession(sessionId: string): Promise<SessionGameRecord[]> {
+    requireNonEmpty("sessionId", sessionId);
+    const items = await this.queryByPrefix(gameSessionIndexPk(sessionId), "GAME#");
+
+    return items
+      .filter((item) => item.entityType === ENTITY_TYPE.sessionGame)
+      .map((item) =>
+        withTimestamps(
+          item.data as Omit<SessionGameRecord, "createdAt" | "updatedAt">,
+          item.createdAt,
+          item.updatedAt,
+        ),
+      );
+  }
+
+  async createPlayer(input: CreatePlayerInput): Promise<PlayerRecord> {
+    requireNonEmpty("playerId", input.playerId);
+    requireNonEmpty("nickname", input.nickname);
+
+    const now = this.clock.now();
+    const payload = {
+      playerId: input.playerId,
+      nickname: input.nickname,
+      claimedByUserId: input.claimedByUserId ?? null,
+    };
+
+    await this.putEntity(playerPk(input.playerId), profileSk(), ENTITY_TYPE.player, payload, now);
+    return withTimestamps(payload, now, now);
+  }
+
+  async getPlayer(playerId: string): Promise<PlayerRecord | null> {
+    requireNonEmpty("playerId", playerId);
+    const item = await this.getEntity(playerPk(playerId), profileSk());
+
+    if (!item || item.entityType !== ENTITY_TYPE.player) {
+      return null;
+    }
+
+    return withTimestamps(item.data as Omit<PlayerRecord, "createdAt" | "updatedAt">, item.createdAt, item.updatedAt);
+  }
+
+  async grantLeagueAccess(input: GrantLeagueAccessInput): Promise<LeagueAclRecord> {
+    requireNonEmpty("leagueId", input.leagueId);
+    requireNonEmpty("userId", input.userId);
+    requireNonEmpty("grantedByUserId", input.grantedByUserId);
+
+    const now = this.clock.now();
+    const payload = {
+      leagueId: input.leagueId,
+      userId: input.userId,
+      role: input.role,
+      grantedByUserId: input.grantedByUserId,
+    };
+
+    await this.putEntity(leaguePk(input.leagueId), aclSk(input.userId), ENTITY_TYPE.acl, payload, now);
+    return withTimestamps(payload, now, now);
+  }
+
+  async listLeagueAccess(leagueId: string): Promise<LeagueAclRecord[]> {
+    requireNonEmpty("leagueId", leagueId);
+    const items = await this.queryByPrefix(leaguePk(leagueId), "ACL#USER#");
+
+    return items
+      .filter((item) => item.entityType === ENTITY_TYPE.acl)
+      .map((item) =>
+        withTimestamps(
+          item.data as Omit<LeagueAclRecord, "createdAt" | "updatedAt">,
+          item.createdAt,
+          item.updatedAt,
+        ),
+      );
+  }
+
+  async assignRosterPlayer(input: AssignRosterInput): Promise<RosterAssignmentRecord> {
+    requireNonEmpty("gameId", input.gameId);
+    requireNonEmpty("playerId", input.playerId);
+
+    const now = this.clock.now();
+    const payload = {
+      gameId: input.gameId,
+      teamId: input.teamId,
+      playerId: input.playerId,
+    };
+
+    await this.putEntity(
+      gamePk(input.gameId),
+      rosterSk(input.teamId, input.playerId),
+      ENTITY_TYPE.roster,
+      payload,
+      now,
+    );
+    return withTimestamps(payload, now, now);
+  }
+
+  async listGameRoster(gameId: string): Promise<RosterAssignmentRecord[]> {
+    requireNonEmpty("gameId", gameId);
+    const items = await this.queryByPrefix(gamePk(gameId), "ROSTER#");
+
+    return items
+      .filter((item) => item.entityType === ENTITY_TYPE.roster)
+      .map((item) =>
+        withTimestamps(
+          item.data as Omit<RosterAssignmentRecord, "createdAt" | "updatedAt">,
+          item.createdAt,
+          item.updatedAt,
+        ),
+      );
+  }
+
+  async createGoalEvent(input: CreateGoalEventInput): Promise<GoalEventRecord> {
+    requireNonEmpty("gameId", input.gameId);
+    requireNonEmpty("eventId", input.eventId);
+    requireNonEmpty("scorerPlayerId", input.scorerPlayerId);
+    requireGameMinute(input.gameMinute);
+
+    validateAssistPlayerIds(input.scorerPlayerId, input.assistPlayerIds);
+
+    if (input.ownGoal && input.scoringTeamId !== null) {
+      throw new Error("ownGoal=true requires scoringTeamId to be null.");
+    }
+
+    if (!input.ownGoal && input.scoringTeamId === null) {
+      throw new Error("scoringTeamId is required when ownGoal=false.");
+    }
+
+    const now = this.clock.now();
+    const payload = {
+      gameId: input.gameId,
+      eventId: input.eventId,
+      third: input.third,
+      gameMinute: input.gameMinute,
+      scoringTeamId: input.scoringTeamId,
+      concedingTeamId: input.concedingTeamId,
+      scorerPlayerId: input.scorerPlayerId,
+      assistPlayerIds: input.assistPlayerIds,
+      ownGoal: input.ownGoal,
+    };
+
+    await this.putEntity(
+      gamePk(input.gameId),
+      goalSk(input.third, input.gameMinute, input.eventId),
+      ENTITY_TYPE.goal,
+      payload,
+      now,
+    );
+    return withTimestamps(payload, now, now);
+  }
+
+  async listGoalEvents(gameId: string): Promise<GoalEventRecord[]> {
+    requireNonEmpty("gameId", gameId);
+    const items = await this.queryByPrefix(gamePk(gameId), "GOAL#");
+
+    return items
+      .filter((item) => item.entityType === ENTITY_TYPE.goal)
+      .map((item) =>
+        withTimestamps(
+          item.data as Omit<GoalEventRecord, "createdAt" | "updatedAt">,
+          item.createdAt,
+          item.updatedAt,
+        ),
+      );
+  }
+
+  private async putEntity<T>(
+    pk: string,
+    sk: string,
+    entityType: EntityType,
+    payload: T,
+    now: string,
+  ): Promise<void> {
+    await this.client.send(
+      new PutItemCommand({
+        TableName: this.tableName,
+        Item: buildItem(pk, sk, entityType, payload, now),
+      }),
+    );
+  }
+
+  private async getEntity(pk: string, sk: string): Promise<StoredEntity<unknown> | null> {
+    const result = (await this.client.send(
+      new GetItemCommand({
+        TableName: this.tableName,
+        Key: {
+          pk: { S: pk },
+          sk: { S: sk },
+        },
+      }),
+    )) as GetItemCommandOutput;
+
+    if (!result.Item) {
+      return null;
+    }
+
+    return parseStoredEntity(result.Item);
+  }
+
+  private async queryByPrefix(pk: string, skPrefix: string): Promise<Array<StoredEntity<unknown>>> {
+    const result = (await this.client.send(
+      new QueryCommand({
+        TableName: this.tableName,
+        KeyConditionExpression: "pk = :pk and begins_with(sk, :skPrefix)",
+        ExpressionAttributeValues: {
+          ":pk": { S: pk },
+          ":skPrefix": { S: skPrefix },
+        },
+      }),
+    )) as QueryCommandOutput;
+
+    return (result.Items ?? []).map((item) => parseStoredEntity(item));
+  }
+}

--- a/api/src/data/types.ts
+++ b/api/src/data/types.ts
@@ -1,0 +1,178 @@
+import type { TeamId } from "@3fc/contracts";
+
+export type GameStatus = "scheduled" | "live" | "finished";
+export type LeagueRole = "admin" | "scorekeeper" | "viewer";
+
+export interface LeagueRecord {
+  leagueId: string;
+  name: string;
+  slug: string | null;
+  createdByUserId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SeasonRecord {
+  leagueId: string;
+  seasonId: string;
+  name: string;
+  slug: string | null;
+  startsOn: string | null;
+  endsOn: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TeamRecord {
+  seasonId: string;
+  teamId: TeamId;
+  name: string;
+  color: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SessionRecord {
+  seasonId: string;
+  sessionId: string;
+  sessionDate: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GameRecord {
+  gameId: string;
+  leagueId: string;
+  seasonId: string;
+  sessionId: string;
+  status: GameStatus;
+  gameStartTs: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface SessionGameRecord {
+  sessionId: string;
+  gameId: string;
+  gameStartTs: string;
+  leagueId: string;
+  seasonId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PlayerRecord {
+  playerId: string;
+  nickname: string;
+  claimedByUserId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface LeagueAclRecord {
+  leagueId: string;
+  userId: string;
+  role: LeagueRole;
+  grantedByUserId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RosterAssignmentRecord {
+  gameId: string;
+  teamId: TeamId;
+  playerId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GoalEventRecord {
+  gameId: string;
+  eventId: string;
+  third: 1 | 2 | 3;
+  gameMinute: number;
+  scoringTeamId: TeamId | null;
+  concedingTeamId: TeamId;
+  scorerPlayerId: string;
+  assistPlayerIds: string[];
+  ownGoal: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateLeagueInput {
+  leagueId: string;
+  name: string;
+  slug?: string | null;
+  createdByUserId: string;
+}
+
+export interface CreateSeasonInput {
+  leagueId: string;
+  seasonId: string;
+  name: string;
+  slug?: string | null;
+  startsOn?: string | null;
+  endsOn?: string | null;
+}
+
+export interface CreateTeamInput {
+  seasonId: string;
+  teamId: TeamId;
+  name: string;
+  color?: string | null;
+}
+
+export interface CreateSessionInput {
+  seasonId: string;
+  sessionId: string;
+  sessionDate: string;
+}
+
+export interface CreateGameInput {
+  gameId: string;
+  leagueId: string;
+  seasonId: string;
+  sessionId: string;
+  status?: GameStatus;
+  gameStartTs: string;
+}
+
+export interface CreateSessionGameInput {
+  sessionId: string;
+  gameId: string;
+  gameStartTs: string;
+  leagueId: string;
+  seasonId: string;
+}
+
+export interface CreatePlayerInput {
+  playerId: string;
+  nickname: string;
+  claimedByUserId?: string | null;
+}
+
+export interface GrantLeagueAccessInput {
+  leagueId: string;
+  userId: string;
+  role: LeagueRole;
+  grantedByUserId: string;
+}
+
+export interface AssignRosterInput {
+  gameId: string;
+  teamId: TeamId;
+  playerId: string;
+}
+
+export interface CreateGoalEventInput {
+  gameId: string;
+  eventId: string;
+  third: 1 | 2 | 3;
+  gameMinute: number;
+  scoringTeamId: TeamId | null;
+  concedingTeamId: TeamId;
+  scorerPlayerId: string;
+  assistPlayerIds: string[];
+  ownGoal: boolean;
+}

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -19,6 +19,7 @@ const TABLE_NAME = process.env.DYNAMODB_TABLE ?? "threefc_local";
 const DYNAMODB_ENDPOINT = process.env.DYNAMODB_ENDPOINT ?? "http://localhost:8000";
 const FAKE_SES_URL = process.env.FAKE_SES_URL ?? "http://localhost:4025/send-email";
 const FAKE_SES_FROM = process.env.FAKE_SES_FROM ?? "noreply@3fc.football";
+const DEV_ITEM_SK = "METADATA";
 
 const ddbClient = new DynamoDBClient({
   region: REGION,
@@ -35,8 +36,14 @@ async function ensureTable(): Promise<void> {
       new CreateTableCommand({
         TableName: TABLE_NAME,
         BillingMode: "PAY_PER_REQUEST",
-        AttributeDefinitions: [{ AttributeName: "pk", AttributeType: "S" }],
-        KeySchema: [{ AttributeName: "pk", KeyType: "HASH" }],
+        AttributeDefinitions: [
+          { AttributeName: "pk", AttributeType: "S" },
+          { AttributeName: "sk", AttributeType: "S" },
+        ],
+        KeySchema: [
+          { AttributeName: "pk", KeyType: "HASH" },
+          { AttributeName: "sk", KeyType: "RANGE" },
+        ],
       }),
     );
   } catch (error) {
@@ -95,6 +102,7 @@ async function handleCreateDevItem(
       TableName: TABLE_NAME,
       Item: {
         pk: { S: body.id },
+        sk: { S: DEV_ITEM_SK },
         data: { S: JSON.stringify(record) },
       },
     }),
@@ -110,6 +118,7 @@ async function handleGetDevItem(itemId: string, response: ServerResponse): Promi
       TableName: TABLE_NAME,
       Key: {
         pk: { S: itemId },
+        sk: { S: DEV_ITEM_SK },
       },
     }),
   );

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -1,0 +1,272 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  GetItemCommand,
+  type AttributeValue,
+  PutItemCommand,
+  QueryCommand,
+} from "@aws-sdk/client-dynamodb";
+
+import { ThreeFcRepository } from "../data/repository.js";
+
+type Item = Record<string, AttributeValue>;
+
+class InMemoryDynamoClient {
+  private readonly items = new Map<string, Item>();
+
+  async send(command: unknown): Promise<unknown> {
+    if (command instanceof PutItemCommand) {
+      const item = command.input.Item;
+      if (!item) {
+        throw new Error("PutItemCommand is missing Item.");
+      }
+
+      const pk = this.readString(item.pk, "pk");
+      const sk = this.readString(item.sk, "sk");
+      this.items.set(`${pk}|${sk}`, item);
+      return {};
+    }
+
+    if (command instanceof GetItemCommand) {
+      const key = command.input.Key;
+      if (!key) {
+        throw new Error("GetItemCommand is missing Key.");
+      }
+
+      const pk = this.readString(key.pk, "pk");
+      const sk = this.readString(key.sk, "sk");
+      const item = this.items.get(`${pk}|${sk}`);
+      return { Item: item };
+    }
+
+    if (command instanceof QueryCommand) {
+      const values = command.input.ExpressionAttributeValues ?? {};
+      const pk = this.readString(values[":pk"], ":pk");
+      const prefix = this.readString(values[":skPrefix"], ":skPrefix");
+
+      const items = [...this.items.values()]
+        .filter((item) => this.readString(item.pk, "pk") === pk)
+        .filter((item) => this.readString(item.sk, "sk").startsWith(prefix))
+        .sort((left, right) =>
+          this.readString(left.sk, "sk").localeCompare(this.readString(right.sk, "sk")),
+        );
+
+      return { Items: items };
+    }
+
+    throw new Error(`Unsupported command: ${(command as { constructor?: { name?: string } }).constructor?.name ?? "unknown"}`);
+  }
+
+  private readString(value: AttributeValue | undefined, name: string): string {
+    if (!value || value.S === undefined) {
+      throw new Error(`Missing string attribute ${name}`);
+    }
+
+    return value.S;
+  }
+}
+
+class IncrementingClock {
+  private offset = 0;
+
+  now(): string {
+    const stamp = new Date(Date.UTC(2026, 1, 22, 0, 0, this.offset));
+    this.offset += 1;
+    return stamp.toISOString();
+  }
+}
+
+function createRepository(): ThreeFcRepository {
+  return new ThreeFcRepository(new InMemoryDynamoClient(), "threefc_test", new IncrementingClock());
+}
+
+test("repository supports round-trip create/read for core entities", async () => {
+  const repository = createRepository();
+
+  const league = await repository.createLeague({
+    leagueId: "league-1",
+    name: "Three FC",
+    slug: "three-fc",
+    createdByUserId: "user-admin",
+  });
+  const readLeague = await repository.getLeague("league-1");
+  assert.deepEqual(readLeague, league);
+
+  const season = await repository.createSeason({
+    leagueId: "league-1",
+    seasonId: "2026",
+    name: "2026 Season",
+    slug: "2026",
+  });
+  assert.deepEqual(await repository.listSeasonsForLeague("league-1"), [season]);
+
+  const team = await repository.createTeam({
+    seasonId: "2026",
+    teamId: "red",
+    name: "Red",
+    color: "#ff0000",
+  });
+  assert.deepEqual(await repository.listTeamsForSeason("2026"), [team]);
+
+  const session = await repository.createSession({
+    seasonId: "2026",
+    sessionId: "20260222",
+    sessionDate: "2026-02-22",
+  });
+  assert.deepEqual(await repository.listSessionsForSeason("2026"), [session]);
+
+  const game = await repository.createGame({
+    gameId: "game-1",
+    leagueId: "league-1",
+    seasonId: "2026",
+    sessionId: "20260222",
+    status: "scheduled",
+    gameStartTs: "2026-02-22T10:00:00Z",
+  });
+  assert.deepEqual(await repository.getGame("game-1"), game);
+
+  const player = await repository.createPlayer({
+    playerId: "player-1",
+    nickname: "AJ",
+  });
+  assert.deepEqual(await repository.getPlayer("player-1"), player);
+
+  const accessGrant = await repository.grantLeagueAccess({
+    leagueId: "league-1",
+    userId: "user-scorekeeper",
+    role: "scorekeeper",
+    grantedByUserId: "user-admin",
+  });
+  assert.deepEqual(await repository.listLeagueAccess("league-1"), [accessGrant]);
+
+  const rosterAssignment = await repository.assignRosterPlayer({
+    gameId: "game-1",
+    teamId: "red",
+    playerId: "player-1",
+  });
+  assert.deepEqual(await repository.listGameRoster("game-1"), [rosterAssignment]);
+});
+
+test("repository query supports deterministic session->games ordering", async () => {
+  const repository = createRepository();
+
+  await repository.createSessionGame({
+    sessionId: "session-a",
+    gameId: "game-late",
+    gameStartTs: "2026-02-22T12:00:00Z",
+    leagueId: "league-1",
+    seasonId: "2026",
+  });
+  await repository.createSessionGame({
+    sessionId: "session-a",
+    gameId: "game-early",
+    gameStartTs: "2026-02-22T09:00:00Z",
+    leagueId: "league-1",
+    seasonId: "2026",
+  });
+
+  const games = await repository.listGamesForSession("session-a");
+  assert.equal(games.length, 2);
+  assert.equal(games[0].gameId, "game-early");
+  assert.equal(games[1].gameId, "game-late");
+});
+
+test("repository query supports deterministic game timeline ordering", async () => {
+  const repository = createRepository();
+
+  await repository.createGoalEvent({
+    gameId: "game-1",
+    eventId: "goal-3",
+    third: 2,
+    gameMinute: 10,
+    scoringTeamId: "yellow",
+    concedingTeamId: "blue",
+    scorerPlayerId: "player-3",
+    assistPlayerIds: [],
+    ownGoal: false,
+  });
+
+  await repository.createGoalEvent({
+    gameId: "game-1",
+    eventId: "goal-1",
+    third: 1,
+    gameMinute: 2,
+    scoringTeamId: "red",
+    concedingTeamId: "yellow",
+    scorerPlayerId: "player-1",
+    assistPlayerIds: [],
+    ownGoal: false,
+  });
+
+  await repository.createGoalEvent({
+    gameId: "game-1",
+    eventId: "goal-2",
+    third: 1,
+    gameMinute: 8,
+    scoringTeamId: "blue",
+    concedingTeamId: "red",
+    scorerPlayerId: "player-2",
+    assistPlayerIds: ["player-4"],
+    ownGoal: false,
+  });
+
+  const timeline = await repository.listGoalEvents("game-1");
+  assert.equal(timeline.length, 3);
+  assert.deepEqual(
+    timeline.map((goal) => goal.eventId),
+    ["goal-1", "goal-2", "goal-3"],
+  );
+});
+
+test("repository rejects missing partition-key inputs", async () => {
+  const repository = createRepository();
+
+  await assert.rejects(
+    repository.createLeague({
+      leagueId: "",
+      name: "Bad League",
+      createdByUserId: "user-admin",
+    }),
+    /leagueId must be a non-empty string/,
+  );
+
+  await assert.rejects(
+    repository.listGamesForSession(""),
+    /sessionId must be a non-empty string/,
+  );
+});
+
+test("repository enforces goal validation rules", async () => {
+  const repository = createRepository();
+
+  await assert.rejects(
+    repository.createGoalEvent({
+      gameId: "game-1",
+      eventId: "goal-invalid",
+      third: 1,
+      gameMinute: 1,
+      scoringTeamId: "red",
+      concedingTeamId: "blue",
+      scorerPlayerId: "player-1",
+      assistPlayerIds: ["player-1"],
+      ownGoal: false,
+    }),
+    /Scorer cannot be listed as an assister/,
+  );
+
+  await assert.rejects(
+    repository.createGoalEvent({
+      gameId: "game-1",
+      eventId: "goal-own",
+      third: 1,
+      gameMinute: 1,
+      scoringTeamId: "red",
+      concedingTeamId: "blue",
+      scorerPlayerId: "player-1",
+      assistPlayerIds: [],
+      ownGoal: true,
+    }),
+    /ownGoal=true requires scoringTeamId to be null/,
+  );
+});

--- a/docs/dynamodb-single-table.md
+++ b/docs/dynamodb-single-table.md
@@ -1,0 +1,85 @@
+# DynamoDB Single-Table Design (M1-01)
+
+This document defines the baseline key structure and access patterns for the
+3FC application table.
+
+## Table
+
+- Table name: environment-specific (`3fc-<env>-app`)
+- Partition key: `pk` (string)
+- Sort key: `sk` (string)
+- Billing mode: on-demand
+
+## Core Key Patterns
+
+- League metadata:
+  - `pk=LEAGUE#{leagueId}`
+  - `sk=METADATA`
+- Season:
+  - `pk=LEAGUE#{leagueId}`
+  - `sk=SEASON#{seasonId}`
+- Team:
+  - `pk=SEASON#{seasonId}`
+  - `sk=TEAM#{teamId}`
+- Session:
+  - `pk=SEASON#{seasonId}`
+  - `sk=SESSION#{sessionId}`
+- Game metadata:
+  - `pk=GAME#{gameId}`
+  - `sk=METADATA`
+- Goal event timeline:
+  - `pk=GAME#{gameId}`
+  - `sk=GOAL#{third}#{gameMinuteSortable}#{eventId}`
+- Roster assignment:
+  - `pk=GAME#{gameId}`
+  - `sk=ROSTER#{teamId}#{playerId}`
+- Session -> game index:
+  - `pk=SESSION#{sessionId}`
+  - `sk=GAME#{gameStartTs}#{gameId}`
+- League ACL grants:
+  - `pk=LEAGUE#{leagueId}`
+  - `sk=ACL#USER#{userId}`
+- Player profile:
+  - `pk=PLAYER#{playerId}`
+  - `sk=PROFILE`
+
+`gameMinuteSortable` is zero-padded to preserve lexical ordering.
+
+## Item Envelope
+
+Repository-managed records are written with:
+
+- `pk`
+- `sk`
+- `entityType`
+- `createdAt`
+- `updatedAt`
+- `data` (JSON payload string)
+
+This keeps key semantics explicit while allowing entity payload evolution
+without schema rewrites at this stage.
+
+## Supported Access Patterns (M1 Baseline)
+
+- Create/read league metadata.
+- Create/list seasons for a league.
+- Create/list teams for a season.
+- Create/list sessions for a season.
+- Create/read game metadata.
+- Link/list games for a session (`SESSION#{sessionId}` query).
+- Create/read player profile.
+- Grant/list league ACL entries.
+- Assign/list game roster entries.
+- Create/list goal events for a game in deterministic timeline order.
+
+## Repository
+
+Implementation lives in:
+
+- `api/src/data/repository.ts`
+- `api/src/data/keys.ts`
+- `api/src/data/types.ts`
+
+Tests live in:
+
+- `api/src/tests/repository.test.ts`


### PR DESCRIPTION
## Summary
- implement a typed DynamoDB single-table repository for core entities under `api/src/data`
- document PK/SK schema and access patterns in `docs/dynamodb-single-table.md`
- add repository tests for round-trip create/read, session->games query ordering, goal timeline ordering, and invalid-key/validation paths
- align local DynamoDB table bootstrap in `api/src/server.ts` to `pk/sk`

## Changes
- added `api/src/data/repository.ts` with create/read/query methods for:
  - leagues, seasons, sessions, teams, games
  - session->game index
  - players, league ACL grants, roster assignments
  - goal timeline events (including assist and own-goal validation)
- added `api/src/data/keys.ts` key builder helpers and `api/src/data/types.ts` record/input types
- added `api/src/tests/repository.test.ts`
- added `docs/dynamodb-single-table.md`
- updated `README.md` docs index for new data-model doc

## Validation
- `npm run lint`
- `npm run test`

## Linked
- Refs #16
