### PR TITLE
chore(infra): add oidc provider lifecycle guardrail

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,3 +163,4 @@ Notes:
 - `github_actions_deploy_role_arn` is the CI deploy role (OIDC-assumable by GitHub Actions).
 - `lambda_execution_role_arn` is the runtime role used by Lambda functions and should not be used as the GitHub secret.
 - The GitHub OIDC provider is account-scoped and is created from `infra/qa`; run QA Terraform apply once before the first prod apply.
+- The GitHub OIDC provider resource is lifecycle-protected (`prevent_destroy`) to avoid accidental auth breakage across environments.

--- a/infra/application/main.tf
+++ b/infra/application/main.tf
@@ -219,6 +219,10 @@ resource "aws_iam_openid_connect_provider" "github_actions" {
   url             = local.github_oidc_provider_url
   client_id_list  = var.github_oidc_client_id_list
   thumbprint_list = var.github_oidc_thumbprint_list
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 data "aws_iam_policy_document" "github_actions_deploy_assume" {


### PR DESCRIPTION
## Summary
- add lifecycle protection for the account-scoped GitHub OIDC provider
- document the guardrail in README to avoid accidental cross-environment auth breakage

## Changes
- `infra/application/main.tf`
  - adds `lifecycle { prevent_destroy = true }` to `aws_iam_openid_connect_provider.github_actions`
- `README.md`
  - adds note that OIDC provider is lifecycle protected

## Validation
- `AWS_PROFILE=3fc-agent terraform -chdir=infra/qa validate`
- `AWS_PROFILE=3fc-agent terraform -chdir=infra/qa plan -input=false -lock=false -no-color`
- `AWS_PROFILE=3fc-agent terraform -chdir=infra/prod validate`
- `AWS_PROFILE=3fc-agent terraform -chdir=infra/prod plan -input=false -lock=false -no-color`
- both plans report no changes

## Linked
- Refs #52
