### PR TITLE
chore(git): ignore local codex config directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ local/fake-ses/*
 
 # Local deploy artifacts
 out/
+
+# Local Codex config (machine/user specific)
+.codex/


### PR DESCRIPTION
## Summary
- add `.codex/` to repository `.gitignore`
- keep local Codex runtime config out of git history
- retain local editability of `3fc/.codex/config.toml`

## Testing
- not run (gitignore-only change)
