### PR TITLE
feat(infra): wire qa/prod app and api custom domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This repository contains the product, technical, infrastructure, and delivery as
 - Primary domain: `https://3fc.football`
 - Production app domain: `https://app.3fc.football`
 - QA app domain: `https://qa.3fc.football`
+- Production API domain: `https://api.3fc.football`
+- QA API domain: `https://qa-api.3fc.football`
 - Public game URLs should resolve under the production app domain using `/{league}/{season}/{game}` paths.
 
 Primary source docs:
@@ -165,3 +167,17 @@ Notes:
 - `lambda_execution_role_arn` is the runtime role used by Lambda functions and should not be used as the GitHub secret.
 - The GitHub OIDC provider is account-scoped and is created from `infra/qa`; run QA Terraform apply once before the first prod apply.
 - The GitHub OIDC provider resource is lifecycle-protected (`prevent_destroy`) to avoid accidental auth breakage across environments.
+
+## Domain Validation Checks
+
+After Terraform apply in both environments, validate DNS and API routing:
+
+```bash
+curl -i https://qa-api.3fc.football/v1/health
+curl -i https://api.3fc.football/v1/health
+```
+
+Expected result for both commands:
+
+- HTTP `200` response
+- JSON body from the health handler

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -155,7 +155,10 @@ POST  /v1/players/{playerId}/claim
 - The `production` environment application will be deployed to via github
   workflows and will reside in AWS. It will be automatically deployed to when a
   branch is merged to the `main` branch and will be fully automated.
-- Production site host/domain: `https://3fc.football`.
+- Production app host/domain: `https://app.3fc.football`.
+- QA app host/domain: `https://qa.3fc.football`.
+- Production API host/domain: `https://api.3fc.football`.
+- QA API host/domain: `https://qa-api.3fc.football`.
 - Infrastructure will be deployed via terraform from local shells to apply
   updates using AWS Developer accounts. State will be managed using S3 based
   state management in a bucket that will be used explicitly for this purpose

--- a/infra/application/variables.tf
+++ b/infra/application/variables.tf
@@ -32,6 +32,25 @@ variable "site_domain" {
   default     = "3fc.football"
 }
 
+variable "api_domain" {
+  description = "Optional API custom domain (for example api.3fc.football)"
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "hosted_zone_name" {
+  description = "Route53 public hosted zone name used for DNS validation and alias records"
+  type        = string
+  default     = "3fc.football"
+}
+
+variable "enable_custom_domains" {
+  description = "When true, provision ACM + Route53 + API/CloudFront custom domain wiring"
+  type        = bool
+  default     = true
+}
+
 variable "site_bucket_suffix" {
   description = "Suffix used when deriving the static site bucket name"
   type        = string

--- a/infra/prod/main.tf
+++ b/infra/prod/main.tf
@@ -9,5 +9,7 @@ module "app" {
   github_repository           = "ajfisher/3fc"
   github_environment_name     = "production"
   site_domain                 = "app.3fc.football"
+  api_domain                  = "api.3fc.football"
+  hosted_zone_name            = "3fc.football"
   ses_from_email              = "noreply@3fc.football"
 }

--- a/infra/prod/outputs.tf
+++ b/infra/prod/outputs.tf
@@ -28,6 +28,16 @@ output "api_execution_arn" {
   value       = module.app.api_execution_arn
 }
 
+output "site_custom_domain_url" {
+  description = "HTTPS URL for the site custom domain"
+  value       = module.app.site_custom_domain_url
+}
+
+output "api_custom_domain_url" {
+  description = "HTTPS URL for the API custom domain"
+  value       = module.app.api_custom_domain_url
+}
+
 output "cognito_user_pool_id" {
   description = "Cognito user pool ID"
   value       = module.app.cognito_user_pool_id

--- a/infra/qa/main.tf
+++ b/infra/qa/main.tf
@@ -9,5 +9,7 @@ module "app" {
   github_repository           = "ajfisher/3fc"
   github_environment_name     = "qa"
   site_domain                 = "qa.3fc.football"
+  api_domain                  = "qa-api.3fc.football"
+  hosted_zone_name            = "3fc.football"
   ses_from_email              = "noreply@3fc.football"
 }

--- a/infra/qa/outputs.tf
+++ b/infra/qa/outputs.tf
@@ -28,6 +28,16 @@ output "api_execution_arn" {
   value       = module.app.api_execution_arn
 }
 
+output "site_custom_domain_url" {
+  description = "HTTPS URL for the site custom domain"
+  value       = module.app.site_custom_domain_url
+}
+
+output "api_custom_domain_url" {
+  description = "HTTPS URL for the API custom domain"
+  value       = module.app.api_custom_domain_url
+}
+
 output "cognito_user_pool_id" {
   description = "Cognito user pool ID"
   value       = module.app.cognito_user_pool_id


### PR DESCRIPTION
## Summary
- add Terraform custom-domain wiring for both app and API in QA/prod
- provision ACM certificates and DNS validation records for:
  - `qa.3fc.football`, `app.3fc.football` (CloudFront/us-east-1 certs)
  - `qa-api.3fc.football`, `api.3fc.football` (API Gateway regional certs)
- add Route53 alias records (A + AAAA) for app and API subdomains
- attach API Gateway custom domains to `$default` stage mappings
- expose custom-domain outputs in QA/prod Terraform outputs
- update docs for environment domain endpoints and validation checks

## Validation
- `terraform -chdir=infra/application validate`
- `AWS_PROFILE=3fc-agent terraform -chdir=infra/qa validate`
- `AWS_PROFILE=3fc-agent terraform -chdir=infra/prod validate`
- `AWS_PROFILE=3fc-agent terraform -chdir=infra/qa plan -input=false -lock=false -no-color`
- `AWS_PROFILE=3fc-agent terraform -chdir=infra/prod plan -input=false -lock=false -no-color`
- `AWS_PROFILE=3fc-agent terraform -chdir=infra/qa apply -input=false -auto-approve -no-color`
- `AWS_PROFILE=3fc-agent terraform -chdir=infra/prod apply -input=false -auto-approve -no-color`
- `curl -sS -i https://qa-api.3fc.football/v1/health` (HTTP 200)
- `curl -sS -i https://api.3fc.football/v1/health` (HTTP 200)
- `curl -sS -I https://qa.3fc.football` (CloudFront response)
- `curl -sS -I https://app.3fc.football` (CloudFront response)
- post-apply drift check:
  - `AWS_PROFILE=3fc-agent terraform -chdir=infra/qa plan -input=false -lock=false -no-color` => no changes
  - `AWS_PROFILE=3fc-agent terraform -chdir=infra/prod plan -input=false -lock=false -no-color` => no changes

Closes #50
Closes #5
