### PR TITLE
feat: deploy static site to qa and prod

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
     paths:
+      - app/**
       - api/**
       - packages/contracts/**
       - scripts/deploy/**
@@ -47,6 +48,9 @@ jobs:
           role-session-name: gha-prod-deploy
           aws-region: ap-southeast-2
 
+      - name: Deploy site to production
+        run: make deploy ENV=prod SERVICE=site
+
       - name: Deploy API health service to production
         env:
           SERVERLESS_ACCESS_KEY: ${{ secrets.SERVERLESS_ACCESS_KEY }}
@@ -86,6 +90,54 @@ jobs:
           {
             echo "SMOKE_ENDPOINT=${ENDPOINT}"
             echo "SMOKE_HTTP_CODE=${HTTP_CODE}"
+          } >> "$GITHUB_ENV"
+
+      - name: Smoke test deployed production site routes
+        run: |
+          MANIFEST_PATH="out/deploy/prod/site-deploy-manifest.json"
+
+          if [ ! -f "$MANIFEST_PATH" ]; then
+            echo "Expected deploy manifest at $MANIFEST_PATH"
+            exit 1
+          fi
+
+          SITE_URL="$(jq -r '.siteUrl // empty' "$MANIFEST_PATH")"
+          if [ -z "$SITE_URL" ]; then
+            echo "Deploy manifest did not include siteUrl."
+            exit 1
+          fi
+
+          ROOT_HTTP_CODE="$(curl -sS -o /tmp/prod-site-root.html -w '%{http_code}' "${SITE_URL}/")"
+          SIGNIN_HTTP_CODE="$(curl -sS -o /tmp/prod-site-signin.html -w '%{http_code}' "${SITE_URL}/sign-in")"
+          SETUP_HTTP_CODE="$(curl -sS -o /tmp/prod-site-setup.html -w '%{http_code}' "${SITE_URL}/setup")"
+
+          if [ "$ROOT_HTTP_CODE" != "200" ]; then
+            echo "Smoke test failed for ${SITE_URL}/ (HTTP ${ROOT_HTTP_CODE})"
+            cat /tmp/prod-site-root.html
+            exit 1
+          fi
+
+          if [ "$SIGNIN_HTTP_CODE" != "200" ]; then
+            echo "Smoke test failed for ${SITE_URL}/sign-in (HTTP ${SIGNIN_HTTP_CODE})"
+            cat /tmp/prod-site-signin.html
+            exit 1
+          fi
+
+          if [ "$SETUP_HTTP_CODE" != "200" ]; then
+            echo "Smoke test failed for ${SITE_URL}/setup (HTTP ${SETUP_HTTP_CODE})"
+            cat /tmp/prod-site-setup.html
+            exit 1
+          fi
+
+          grep -q "Dashboard" /tmp/prod-site-root.html
+          grep -q "Sign in before setup" /tmp/prod-site-signin.html
+          grep -q "Dashboard" /tmp/prod-site-setup.html
+
+          {
+            echo "SITE_URL=${SITE_URL}"
+            echo "SITE_ROOT_HTTP_CODE=${ROOT_HTTP_CODE}"
+            echo "SITE_SIGNIN_HTTP_CODE=${SIGNIN_HTTP_CODE}"
+            echo "SITE_SETUP_HTTP_CODE=${SETUP_HTTP_CODE}"
           } >> "$GITHUB_ENV"
 
       - name: Smoke test deployed production core endpoints
@@ -142,7 +194,11 @@ jobs:
             echo "## Production deploy complete"
             echo "- Branch: main"
             echo "- Commit: ${{ github.sha }}"
-            echo "- Services: api-health, api-core"
+            echo "- Services: site, api-health, api-core"
+            echo "- Site URL: ${SITE_URL}"
+            echo "- Site root status: HTTP ${SITE_ROOT_HTTP_CODE}"
+            echo "- Site sign-in status: HTTP ${SITE_SIGNIN_HTTP_CODE}"
+            echo "- Site setup status: HTTP ${SITE_SETUP_HTTP_CODE}"
             echo "- Smoke endpoint: ${SMOKE_ENDPOINT}"
             echo "- Smoke status: HTTP ${SMOKE_HTTP_CODE}"
             echo "- Core smoke endpoint: ${SMOKE_CORE_ENDPOINT}"

--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -49,6 +49,9 @@ jobs:
           role-session-name: gha-qa-deploy
           aws-region: ap-southeast-2
 
+      - name: Deploy site to QA
+        run: make deploy ENV=qa SERVICE=site
+
       - name: Deploy API health service to QA
         env:
           SERVERLESS_ACCESS_KEY: ${{ secrets.SERVERLESS_ACCESS_KEY }}
@@ -88,6 +91,54 @@ jobs:
           {
             echo "SMOKE_ENDPOINT=${ENDPOINT}"
             echo "SMOKE_HTTP_CODE=${HTTP_CODE}"
+          } >> "$GITHUB_ENV"
+
+      - name: Smoke test deployed QA site routes
+        run: |
+          MANIFEST_PATH="out/deploy/qa/site-deploy-manifest.json"
+
+          if [ ! -f "$MANIFEST_PATH" ]; then
+            echo "Expected deploy manifest at $MANIFEST_PATH"
+            exit 1
+          fi
+
+          SITE_URL="$(jq -r '.siteUrl // empty' "$MANIFEST_PATH")"
+          if [ -z "$SITE_URL" ]; then
+            echo "Deploy manifest did not include siteUrl."
+            exit 1
+          fi
+
+          ROOT_HTTP_CODE="$(curl -sS -o /tmp/qa-site-root.html -w '%{http_code}' "${SITE_URL}/")"
+          SIGNIN_HTTP_CODE="$(curl -sS -o /tmp/qa-site-signin.html -w '%{http_code}' "${SITE_URL}/sign-in")"
+          SETUP_HTTP_CODE="$(curl -sS -o /tmp/qa-site-setup.html -w '%{http_code}' "${SITE_URL}/setup")"
+
+          if [ "$ROOT_HTTP_CODE" != "200" ]; then
+            echo "Smoke test failed for ${SITE_URL}/ (HTTP ${ROOT_HTTP_CODE})"
+            cat /tmp/qa-site-root.html
+            exit 1
+          fi
+
+          if [ "$SIGNIN_HTTP_CODE" != "200" ]; then
+            echo "Smoke test failed for ${SITE_URL}/sign-in (HTTP ${SIGNIN_HTTP_CODE})"
+            cat /tmp/qa-site-signin.html
+            exit 1
+          fi
+
+          if [ "$SETUP_HTTP_CODE" != "200" ]; then
+            echo "Smoke test failed for ${SITE_URL}/setup (HTTP ${SETUP_HTTP_CODE})"
+            cat /tmp/qa-site-setup.html
+            exit 1
+          fi
+
+          grep -q "Dashboard" /tmp/qa-site-root.html
+          grep -q "Sign in before setup" /tmp/qa-site-signin.html
+          grep -q "Dashboard" /tmp/qa-site-setup.html
+
+          {
+            echo "SITE_URL=${SITE_URL}"
+            echo "SITE_ROOT_HTTP_CODE=${ROOT_HTTP_CODE}"
+            echo "SITE_SIGNIN_HTTP_CODE=${SIGNIN_HTTP_CODE}"
+            echo "SITE_SETUP_HTTP_CODE=${SETUP_HTTP_CODE}"
           } >> "$GITHUB_ENV"
 
       - name: Smoke test deployed QA core endpoints
@@ -144,7 +195,11 @@ jobs:
             echo "## QA deploy complete"
             echo "- PR: #${{ github.event.pull_request.number }}"
             echo "- Commit: ${{ github.event.pull_request.head.sha }}"
-            echo "- Services: api-health, api-core"
+            echo "- Services: site, api-health, api-core"
+            echo "- Site URL: ${SITE_URL}"
+            echo "- Site root status: HTTP ${SITE_ROOT_HTTP_CODE}"
+            echo "- Site sign-in status: HTTP ${SITE_SIGNIN_HTTP_CODE}"
+            echo "- Site setup status: HTTP ${SITE_SETUP_HTTP_CODE}"
             echo "- Smoke endpoint: ${SMOKE_ENDPOINT}"
             echo "- Smoke status: HTTP ${SMOKE_HTTP_CODE}"
             echo "- Core smoke endpoint: ${SMOKE_CORE_ENDPOINT}"

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ help:
 	@echo "  make dev                                Start local Docker Compose stack"
 	@echo "  make dev-down                           Stop local Docker Compose stack"
 	@echo "  make dev-logs                           Follow local Docker Compose logs"
-	@echo "  make deploy ENV=qa|prod [SERVICE=name]   Build and deploy a Serverless endpoint service"
+	@echo "  make deploy ENV=qa|prod [SERVICE=name]   Build and deploy a target (api-health, api-core, site)"
 	@echo ""
 	@echo "Backlog targets:"
 	@echo "  make backlog-validate                   Validate backlog JSON"
@@ -38,7 +38,11 @@ deploy:
 		echo "ENV must be set to qa or prod"; \
 		exit 1; \
 	fi
-	./scripts/deploy/deploy-app.sh $(ENV) $(SERVICE)
+	@if [ "$(SERVICE)" = "site" ]; then \
+		./scripts/deploy/deploy-site.sh $(ENV); \
+	else \
+		./scripts/deploy/deploy-app.sh $(ENV) $(SERVICE); \
+	fi
 
 install:
 	npm install

--- a/app/package.json
+++ b/app/package.json
@@ -7,6 +7,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json && mkdir -p dist/ui && cp src/ui/styles.css dist/ui/styles.css && cp src/ui/modal.js dist/ui/modal.js && cp src/ui/setup-flow.js dist/ui/setup-flow.js && cp src/ui/auth-flow.js dist/ui/auth-flow.js",
+    "export:static": "node dist/static-export.js",
     "start": "node dist/server.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test": "npm run build && rm -rf dist-tests && tsc -p tsconfig.test.json && node --test dist-tests/src/tests/**/*.test.js",

--- a/app/src/static-export.ts
+++ b/app/src/static-export.ts
@@ -1,0 +1,130 @@
+import { copyFileSync, existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  renderComponentShowcasePage,
+  renderGamePage,
+  renderLeaguePage,
+  renderMagicLinkCallbackPage,
+  renderSeasonPage,
+  renderSetupHomePage,
+  renderSignInPage,
+} from "./ui/layout.js";
+
+export interface StaticSiteBuildOptions {
+  apiBaseUrl: string;
+  outputDir: string;
+}
+
+interface StaticRoute {
+  path: string;
+  html: string;
+}
+
+interface StaticAsset {
+  outputPath: string;
+  candidateSources: string[];
+}
+
+const STATIC_ASSETS: StaticAsset[] = [
+  {
+    outputPath: "ui/styles.css",
+    candidateSources: [
+      fileURLToPath(new URL("./ui/styles.css", import.meta.url)),
+      resolve(process.cwd(), "dist/ui/styles.css"),
+      resolve(process.cwd(), "app/dist/ui/styles.css"),
+      resolve(process.cwd(), "src/ui/styles.css"),
+      resolve(process.cwd(), "app/src/ui/styles.css"),
+    ],
+  },
+  {
+    outputPath: "ui/modal.js",
+    candidateSources: [
+      fileURLToPath(new URL("./ui/modal.js", import.meta.url)),
+      resolve(process.cwd(), "dist/ui/modal.js"),
+      resolve(process.cwd(), "app/dist/ui/modal.js"),
+      resolve(process.cwd(), "src/ui/modal.js"),
+      resolve(process.cwd(), "app/src/ui/modal.js"),
+    ],
+  },
+  {
+    outputPath: "ui/setup-flow.js",
+    candidateSources: [
+      fileURLToPath(new URL("./ui/setup-flow.js", import.meta.url)),
+      resolve(process.cwd(), "dist/ui/setup-flow.js"),
+      resolve(process.cwd(), "app/dist/ui/setup-flow.js"),
+      resolve(process.cwd(), "src/ui/setup-flow.js"),
+      resolve(process.cwd(), "app/src/ui/setup-flow.js"),
+    ],
+  },
+  {
+    outputPath: "ui/auth-flow.js",
+    candidateSources: [
+      fileURLToPath(new URL("./ui/auth-flow.js", import.meta.url)),
+      resolve(process.cwd(), "dist/ui/auth-flow.js"),
+      resolve(process.cwd(), "app/dist/ui/auth-flow.js"),
+      resolve(process.cwd(), "src/ui/auth-flow.js"),
+      resolve(process.cwd(), "app/src/ui/auth-flow.js"),
+    ],
+  },
+];
+
+function writeRoute(outputDir: string, routePath: string, html: string): void {
+  const normalizedRoute = routePath.replace(/^\/+/, "").replace(/\/+$/, "");
+  const targetPath =
+    normalizedRoute.length === 0
+      ? resolve(outputDir, "index.html")
+      : resolve(outputDir, normalizedRoute, "index.html");
+
+  mkdirSync(dirname(targetPath), { recursive: true });
+  writeFileSync(targetPath, html, "utf8");
+}
+
+export function buildStaticSite(options: StaticSiteBuildOptions): string {
+  const outputDir = resolve(options.outputDir);
+  const routes: StaticRoute[] = [
+    { path: "/", html: renderSetupHomePage(options.apiBaseUrl) },
+    { path: "/setup", html: renderSetupHomePage(options.apiBaseUrl) },
+    { path: "/sign-in", html: renderSignInPage(options.apiBaseUrl, "/setup") },
+    { path: "/auth/callback", html: renderMagicLinkCallbackPage(options.apiBaseUrl) },
+    { path: "/ui/components", html: renderComponentShowcasePage(options.apiBaseUrl) },
+    { path: "/leagues", html: renderLeaguePage(options.apiBaseUrl, "") },
+    { path: "/seasons", html: renderSeasonPage(options.apiBaseUrl, "") },
+    { path: "/games", html: renderGamePage(options.apiBaseUrl, { gameId: "" }) },
+  ];
+
+  rmSync(outputDir, { recursive: true, force: true });
+  mkdirSync(outputDir, { recursive: true });
+
+  for (const asset of STATIC_ASSETS) {
+    const sourcePath = asset.candidateSources.find((candidate) => existsSync(candidate));
+    if (!sourcePath) {
+      throw new Error(`Missing static asset source for ${asset.outputPath}.`);
+    }
+
+    const targetPath = resolve(outputDir, asset.outputPath);
+    mkdirSync(dirname(targetPath), { recursive: true });
+    copyFileSync(sourcePath, targetPath);
+  }
+
+  for (const route of routes) {
+    writeRoute(outputDir, route.path, route.html);
+  }
+
+  return outputDir;
+}
+
+const invokedDirectly = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (invokedDirectly) {
+  const apiBaseUrl = process.env.API_BASE_URL ?? "http://localhost:3001";
+  const outputDir = process.env.STATIC_SITE_OUTPUT_DIR ?? resolve(process.cwd(), "dist-static");
+
+  const builtOutputDir = buildStaticSite({
+    apiBaseUrl,
+    outputDir,
+  });
+
+  process.stdout.write(`${builtOutputDir}\n`);
+}

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -656,3 +656,68 @@ test("setup happy path runs from sign-in to created game context", async () => {
   assert.equal(seasonId?.textContent, "autumn-cup");
   assert.equal(createAnotherLink?.getAttribute("href"), "/seasons/autumn-cup");
 });
+
+test("setup flow resolves route ids from static shells", async () => {
+  const apiState = createMockApiState();
+  apiState.session = {
+    sessionId: "session-1",
+    email: "organizer@3fc.football",
+    createdAt: "2026-03-28T11:00:00.000Z",
+    expiresAt: "2026-03-29T11:00:00.000Z",
+  };
+  apiState.cookieJar = "threefc_session=session-1";
+
+  apiState.leagues.set("autumn-league", {
+    leagueId: "autumn-league",
+    name: "Autumn League",
+    slug: "autumn-league",
+    createdByUserId: apiState.session.email,
+    createdAt: "2026-03-28T11:00:01.000Z",
+    updatedAt: "2026-03-28T11:00:01.000Z",
+  });
+  apiState.seasons.set("autumn-cup", {
+    leagueId: "autumn-league",
+    seasonId: "autumn-cup",
+    name: "Autumn Cup",
+    slug: "autumn-cup",
+    startsOn: "2026-03-01",
+    endsOn: "2026-05-31",
+    createdAt: "2026-03-28T11:00:02.000Z",
+    updatedAt: "2026-03-28T11:00:02.000Z",
+  });
+  apiState.games.set("game-20260328-abc123", {
+    gameId: "game-20260328-abc123",
+    leagueId: "autumn-league",
+    seasonId: "autumn-cup",
+    sessionId: "20260328",
+    status: "scheduled",
+    gameStartTs: "2026-03-28T10:00:00.000Z",
+    createdAt: "2026-03-28T11:00:03.000Z",
+    updatedAt: "2026-03-28T11:00:03.000Z",
+  });
+
+  const leaguePage = await bootPage({
+    html: renderLeaguePage("http://localhost:3001", ""),
+    url: "http://localhost:3000/leagues/autumn-league",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+  assert.equal(leaguePage.document.getElementById("league-title")?.textContent, "Autumn League");
+
+  const seasonPage = await bootPage({
+    html: renderSeasonPage("http://localhost:3001", ""),
+    url: "http://localhost:3000/seasons/autumn-cup",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+  assert.equal(seasonPage.document.getElementById("season-title")?.textContent, "Autumn Cup");
+
+  const gamePage = await bootPage({
+    html: renderGamePage("http://localhost:3001", { gameId: "" }),
+    url: "http://localhost:3000/games/game-20260328-abc123",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+  assert.equal(gamePage.document.getElementById("game-title")?.textContent, "game-20260328-abc123");
+  assert.equal(gamePage.document.getElementById("game-id-value")?.textContent, "game-20260328-abc123");
+});

--- a/app/src/tests/static-export.test.ts
+++ b/app/src/tests/static-export.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import test from "node:test";
+
+import { buildStaticSite } from "../static-export.js";
+
+test("buildStaticSite exports static route shells and ui assets", () => {
+  const outputDir = mkdtempSync(resolve(tmpdir(), "3fc-static-site-"));
+
+  try {
+    const builtDir = buildStaticSite({
+      apiBaseUrl: "https://qa-api.3fc.football",
+      outputDir,
+    });
+
+    assert.equal(builtDir, resolve(outputDir));
+    assert.equal(existsSync(resolve(outputDir, "index.html")), true);
+    assert.equal(existsSync(resolve(outputDir, "setup/index.html")), true);
+    assert.equal(existsSync(resolve(outputDir, "sign-in/index.html")), true);
+    assert.equal(existsSync(resolve(outputDir, "auth/callback/index.html")), true);
+    assert.equal(existsSync(resolve(outputDir, "leagues/index.html")), true);
+    assert.equal(existsSync(resolve(outputDir, "seasons/index.html")), true);
+    assert.equal(existsSync(resolve(outputDir, "games/index.html")), true);
+    assert.equal(existsSync(resolve(outputDir, "ui/styles.css")), true);
+    assert.equal(existsSync(resolve(outputDir, "ui/setup-flow.js")), true);
+    assert.equal(existsSync(resolve(outputDir, "ui/auth-flow.js")), true);
+
+    const rootHtml = readFileSync(resolve(outputDir, "index.html"), "utf8");
+    assert.match(rootHtml, /data-page="dashboard"/);
+
+    const signInHtml = readFileSync(resolve(outputDir, "sign-in/index.html"), "utf8");
+    assert.match(signInHtml, /id="auth-magic-form"/);
+
+    const leagueHtml = readFileSync(resolve(outputDir, "leagues/index.html"), "utf8");
+    assert.match(leagueHtml, /data-page="league"/);
+    assert.match(leagueHtml, /data-league-id=""/);
+  } finally {
+    rmSync(outputDir, { recursive: true, force: true });
+  }
+});

--- a/app/src/ui/auth-flow.js
+++ b/app/src/ui/auth-flow.js
@@ -37,6 +37,25 @@
     return new URL(normalizedPath, normalizedBase).toString();
   }
 
+  function resolveReturnTo(fallback = "/setup") {
+    const hiddenInput = document.getElementById("auth-return-to");
+    const hiddenValue =
+      hiddenInput instanceof HTMLInputElement && hiddenInput.value.trim().length > 0
+        ? hiddenInput.value.trim()
+        : fallback;
+
+    try {
+      const requested = new URL(window.location.href).searchParams.get("returnTo");
+      if (requested && requested.trim().length > 0) {
+        return requested.trim();
+      }
+    } catch {
+      // Fall back to hidden input value when URL parsing fails.
+    }
+
+    return hiddenValue;
+  }
+
   async function requestJson(path, init) {
     const response = await fetch(buildApiUrl(path), init);
     const text = await response.text();
@@ -171,10 +190,7 @@
     const sessionEmail = document.getElementById("auth-session-email");
     const submitButton = form.querySelector('[data-action="send-magic-link"]');
 
-    const returnTo =
-      returnToInput instanceof HTMLInputElement && returnToInput.value.trim().length > 0
-        ? returnToInput.value.trim()
-        : "/setup";
+    const returnTo = resolveReturnTo("/setup");
 
     function showError(message) {
       if (!errorElement) {

--- a/app/src/ui/layout.ts
+++ b/app/src/ui/layout.ts
@@ -217,6 +217,7 @@ export function renderSetupHomePage(apiBaseUrl: string): string {
 
 export function renderLeaguePage(apiBaseUrl: string, leagueId: string): string {
   const safeLeagueId = escapeHtml(leagueId);
+  const leagueHeading = safeLeagueId.length > 0 ? safeLeagueId : "League";
   const createSeasonPanel = renderPanel(
     "Create season",
     "Create a season inside this league.",
@@ -273,7 +274,7 @@ export function renderLeaguePage(apiBaseUrl: string, leagueId: string): string {
     <main data-ui="app-shell" data-testid="league-shell" data-api-base-url="${escapeHtml(apiBaseUrl)}">
       <section data-ui="hero">
         <span data-ui="hero-kicker"><a href="/setup">Dashboard</a> / League</span>
-        <h1 id="league-title">${safeLeagueId}</h1>
+        <h1 id="league-title">${leagueHeading}</h1>
         <p data-ui="hero-copy" id="league-subtitle">Loading league details…</p>
         <div data-ui="button-row">${renderButton("Delete league", "danger", {
           type: "button",
@@ -297,6 +298,7 @@ export function renderLeaguePage(apiBaseUrl: string, leagueId: string): string {
 
 export function renderSeasonPage(apiBaseUrl: string, seasonId: string): string {
   const safeSeasonId = escapeHtml(seasonId);
+  const seasonHeading = safeSeasonId.length > 0 ? safeSeasonId : "Season";
   const createGamePanel = renderPanel(
     "Create game",
     "Add a game into this season.",
@@ -345,7 +347,7 @@ export function renderSeasonPage(apiBaseUrl: string, seasonId: string): string {
     <main data-ui="app-shell" data-testid="season-shell" data-api-base-url="${escapeHtml(apiBaseUrl)}">
       <section data-ui="hero">
         <span data-ui="hero-kicker"><a href="/setup">Dashboard</a> / <a id="season-league-link" href="/setup">League</a> / Season</span>
-        <h1 id="season-title">${safeSeasonId}</h1>
+        <h1 id="season-title">${seasonHeading}</h1>
         <p data-ui="hero-copy" id="season-subtitle">Loading season details…</p>
         <div data-ui="button-row">${renderButton("Delete season", "danger", {
           type: "button",
@@ -632,6 +634,7 @@ export interface GameContextPageInput {
 
 export function renderGamePage(apiBaseUrl: string, input: GameContextPageInput): string {
   const gameId = escapeHtml(input.gameId);
+  const gameHeading = gameId.length > 0 ? gameId : "Game";
 
   return `<!doctype html>
 <html lang="en">
@@ -645,7 +648,7 @@ export function renderGamePage(apiBaseUrl: string, input: GameContextPageInput):
     <main data-ui="app-shell" data-testid="game-shell" data-api-base-url="${escapeHtml(apiBaseUrl)}">
       <section data-ui="hero">
         <span data-ui="hero-kicker"><a href="/setup">Dashboard</a> / <a id="game-league-link" href="/setup">League</a> / <a id="game-season-link" href="/setup">Season</a> / Game</span>
-        <h1 id="game-title">${gameId}</h1>
+        <h1 id="game-title">${gameHeading}</h1>
         <p data-ui="hero-copy" id="game-subtitle">Loading game details…</p>
       </section>
       <section data-ui="setup-flow" id="setup-flow-root" data-testid="setup-flow-root" data-page="game" data-api-base-url="${escapeHtml(apiBaseUrl)}" data-game-id="${gameId}">
@@ -656,7 +659,7 @@ export function renderGamePage(apiBaseUrl: string, input: GameContextPageInput):
             "Game details",
             "Edit core game metadata.",
             `<dl data-ui="id-preview" data-testid="game-context-details">
-              <div><dt>Game ID</dt><dd id="game-id-value">${gameId}</dd></div>
+              <div><dt>Game ID</dt><dd id="game-id-value">${gameHeading}</dd></div>
               <div><dt>League ID</dt><dd id="game-league-id">Loading…</dd></div>
               <div><dt>Season ID</dt><dd id="game-season-id">Loading…</dd></div>
             </dl>

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -149,6 +149,29 @@
     return new URL(normalizedPath, normalizedBase).toString();
   }
 
+  function resolveRouteEntityId(attributeName, collectionName) {
+    const attributeValue = root.getAttribute(attributeName);
+    if (attributeValue && attributeValue.trim().length > 0) {
+      return attributeValue.trim();
+    }
+
+    const pathSegments = window.location.pathname
+      .split("/")
+      .map((segment) => segment.trim())
+      .filter((segment) => segment.length > 0);
+
+    const collectionIndex = pathSegments.indexOf(collectionName);
+    if (collectionIndex < 0 || pathSegments.length <= collectionIndex + 1) {
+      return null;
+    }
+
+    try {
+      return decodeURIComponent(pathSegments[collectionIndex + 1]);
+    } catch {
+      return pathSegments[collectionIndex + 1];
+    }
+  }
+
   function createIdempotencyKey(prefix, stablePart) {
     const safeStable = stablePart.replace(/[^a-zA-Z0-9-]+/g, "-").slice(0, 56);
     return `${prefix}-${safeStable}-${Date.now().toString(36)}`;
@@ -426,7 +449,7 @@
   }
 
   async function initLeaguePage() {
-    const leagueId = root.getAttribute("data-league-id");
+    const leagueId = resolveRouteEntityId("data-league-id", "leagues");
     if (!leagueId) {
       return;
     }
@@ -633,7 +656,7 @@
   }
 
   async function initSeasonPage() {
-    const seasonId = root.getAttribute("data-season-id");
+    const seasonId = resolveRouteEntityId("data-season-id", "seasons");
     if (!seasonId) {
       return;
     }
@@ -890,7 +913,7 @@
   }
 
   async function initGamePage() {
-    const gameId = root.getAttribute("data-game-id");
+    const gameId = resolveRouteEntityId("data-game-id", "games");
     if (!gameId) {
       return;
     }
@@ -900,6 +923,7 @@
     const gameLeagueLink = document.getElementById("game-league-link");
     const gameSeasonLink = document.getElementById("game-season-link");
 
+    const gameIdValue = document.getElementById("game-id-value");
     const gameLeagueId = document.getElementById("game-league-id");
     const gameSeasonId = document.getElementById("game-season-id");
 
@@ -941,6 +965,9 @@
         subtitle.innerHTML = `Kickoff (UTC): <code>${escapeHtml(game.gameStartTs)}</code>`;
       }
 
+      if (gameIdValue) {
+        gameIdValue.textContent = game.gameId;
+      }
       if (gameLeagueId) {
         gameLeagueId.textContent = game.leagueId;
       }

--- a/infra/application/cloudfront-site-router.js
+++ b/infra/application/cloudfront-site-router.js
@@ -1,0 +1,51 @@
+function hasFileExtension(uri) {
+  return uri.lastIndexOf(".") > uri.lastIndexOf("/");
+}
+
+function rewriteToShell(uri) {
+  if (uri === "" || uri === "/") {
+    return "/index.html";
+  }
+
+  if (uri === "/setup" || uri === "/setup/") {
+    return "/setup/index.html";
+  }
+
+  if (uri === "/sign-in" || uri === "/sign-in/") {
+    return "/sign-in/index.html";
+  }
+
+  if (uri === "/auth/callback" || uri === "/auth/callback/") {
+    return "/auth/callback/index.html";
+  }
+
+  if (uri === "/ui/components" || uri === "/ui/components/") {
+    return "/ui/components/index.html";
+  }
+
+  if (uri === "/leagues" || uri.indexOf("/leagues/") === 0) {
+    return "/leagues/index.html";
+  }
+
+  if (uri === "/seasons" || uri.indexOf("/seasons/") === 0) {
+    return "/seasons/index.html";
+  }
+
+  if (uri === "/games" || uri.indexOf("/games/") === 0) {
+    return "/games/index.html";
+  }
+
+  return uri;
+}
+
+function handler(event) {
+  var request = event.request;
+  var uri = request.uri || "/";
+
+  if (hasFileExtension(uri)) {
+    return request;
+  }
+
+  request.uri = rewriteToShell(uri);
+  return request;
+}

--- a/infra/application/main.tf
+++ b/infra/application/main.tf
@@ -82,6 +82,16 @@ resource "aws_cloudfront_origin_access_control" "site" {
   signing_protocol                  = "sigv4"
 }
 
+resource "aws_cloudfront_function" "site_router" {
+  count = var.create_baseline_resources ? 1 : 0
+
+  name    = "${local.name_prefix}-site-router"
+  runtime = "cloudfront-js-2.0"
+  comment = "Route static 3FC app paths to exported HTML shells"
+  publish = true
+  code    = file("${path.module}/cloudfront-site-router.js")
+}
+
 resource "aws_cloudfront_distribution" "site" {
   count = var.create_baseline_resources ? 1 : 0
 
@@ -109,6 +119,11 @@ resource "aws_cloudfront_distribution" "site" {
       cookies {
         forward = "none"
       }
+    }
+
+    function_association {
+      event_type   = "viewer-request"
+      function_arn = aws_cloudfront_function.site_router[0].arn
     }
   }
 
@@ -640,6 +655,25 @@ data "aws_iam_policy_document" "github_actions_deploy_permissions" {
       values   = ["lambda.amazonaws.com"]
     }
   }
+
+  statement {
+    sid    = "ListCloudFrontDistributions"
+    effect = "Allow"
+    actions = [
+      "cloudfront:ListDistributions",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "InvalidateSiteDistribution"
+    effect = "Allow"
+    actions = [
+      "cloudfront:CreateInvalidation",
+      "cloudfront:GetInvalidation",
+    ]
+    resources = [aws_cloudfront_distribution.site[0].arn]
+  }
 }
 
 resource "aws_iam_role_policy" "github_actions_deploy" {
@@ -664,6 +698,11 @@ output "baseline_resources_enabled" {
 output "site_bucket_name" {
   description = "Name of the static site bucket"
   value       = try(aws_s3_bucket.site[0].id, null)
+}
+
+output "site_cloudfront_distribution_id" {
+  description = "CloudFront distribution ID serving the static site"
+  value       = try(aws_cloudfront_distribution.site[0].id, null)
 }
 
 output "dynamodb_table_name" {

--- a/infra/application/main.tf
+++ b/infra/application/main.tf
@@ -143,6 +143,41 @@ resource "aws_cloudfront_distribution" "site" {
   tags = local.app_tags
 }
 
+data "aws_iam_policy_document" "site_bucket_access" {
+  count = var.create_baseline_resources ? 1 : 0
+
+  statement {
+    sid    = "AllowCloudFrontReadAccess"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudfront.amazonaws.com"]
+    }
+
+    actions = [
+      "s3:GetObject",
+    ]
+
+    resources = [
+      "${aws_s3_bucket.site[0].arn}/*",
+    ]
+
+    condition {
+      test     = "StringEquals"
+      variable = "AWS:SourceArn"
+      values   = [aws_cloudfront_distribution.site[0].arn]
+    }
+  }
+}
+
+resource "aws_s3_bucket_policy" "site" {
+  count = var.create_baseline_resources ? 1 : 0
+
+  bucket = aws_s3_bucket.site[0].id
+  policy = data.aws_iam_policy_document.site_bucket_access[0].json
+}
+
 resource "aws_acm_certificate" "site" {
   count    = local.site_custom_domain_enabled ? 1 : 0
   provider = aws.us_east_1

--- a/scripts/deploy/deploy-site.sh
+++ b/scripts/deploy/deploy-site.sh
@@ -46,6 +46,10 @@ STATIC_SITE_OUTPUT_DIR="${STATIC_SITE_OUTPUT_DIR:-out/site/${ENV}}"
 ARTIFACT_DIR="out/deploy/${ENV}"
 DEPLOY_MANIFEST_PATH="${ARTIFACT_DIR}/site-deploy-manifest.json"
 
+if [[ "$STATIC_SITE_OUTPUT_DIR" != /* ]]; then
+  STATIC_SITE_OUTPUT_DIR="${ROOT_DIR}/${STATIC_SITE_OUTPUT_DIR}"
+fi
+
 echo "[deploy] Building workspaces"
 make build >/dev/null
 

--- a/scripts/deploy/deploy-site.sh
+++ b/scripts/deploy/deploy-site.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <qa|prod>" >&2
+  exit 1
+fi
+
+ENV="$1"
+
+if [[ "$ENV" != "qa" && "$ENV" != "prod" ]]; then
+  echo "ENV must be one of: qa, prod" >&2
+  exit 1
+fi
+
+require_command() {
+  local command_name="$1"
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "$command_name is required but was not found in PATH" >&2
+    exit 1
+  fi
+}
+
+require_command aws
+require_command make
+require_command npm
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+PROJECT_NAME="${PROJECT_NAME:-3fc}"
+
+case "$ENV" in
+  qa)
+    SITE_DOMAIN="${SITE_DOMAIN:-qa.3fc.football}"
+    API_BASE_URL="${API_BASE_URL:-https://qa-api.3fc.football}"
+    ;;
+  prod)
+    SITE_DOMAIN="${SITE_DOMAIN:-app.3fc.football}"
+    API_BASE_URL="${API_BASE_URL:-https://api.3fc.football}"
+    ;;
+esac
+
+SITE_BUCKET_NAME="${SITE_BUCKET_NAME:-${PROJECT_NAME}-${ENV}-site}"
+STATIC_SITE_OUTPUT_DIR="${STATIC_SITE_OUTPUT_DIR:-out/site/${ENV}}"
+ARTIFACT_DIR="out/deploy/${ENV}"
+DEPLOY_MANIFEST_PATH="${ARTIFACT_DIR}/site-deploy-manifest.json"
+
+echo "[deploy] Building workspaces"
+make build >/dev/null
+
+echo "[deploy] Exporting static site for ${ENV}"
+API_BASE_URL="$API_BASE_URL" STATIC_SITE_OUTPUT_DIR="$STATIC_SITE_OUTPUT_DIR" npm run export:static -w @3fc/app >/dev/null
+
+if [[ ! -f "${STATIC_SITE_OUTPUT_DIR}/index.html" ]]; then
+  echo "Static site export did not produce ${STATIC_SITE_OUTPUT_DIR}/index.html" >&2
+  exit 1
+fi
+
+echo "[deploy] Resolving CloudFront distribution for ${SITE_DOMAIN}"
+SITE_DISTRIBUTION_ID="$(
+  aws cloudfront list-distributions \
+    --query "DistributionList.Items[?Aliases.Quantity > \`0\` && contains(Aliases.Items, '${SITE_DOMAIN}')].Id | [0]" \
+    --output text
+)"
+
+if [[ -z "$SITE_DISTRIBUTION_ID" || "$SITE_DISTRIBUTION_ID" == "None" ]]; then
+  echo "Could not resolve a CloudFront distribution for ${SITE_DOMAIN}" >&2
+  exit 1
+fi
+
+echo "[deploy] Uploading static assets to s3://${SITE_BUCKET_NAME}"
+aws s3 sync "${STATIC_SITE_OUTPUT_DIR}/" "s3://${SITE_BUCKET_NAME}/" --delete
+
+echo "[deploy] Re-uploading HTML with no-cache headers"
+aws s3 cp "${STATIC_SITE_OUTPUT_DIR}/" "s3://${SITE_BUCKET_NAME}/" \
+  --recursive \
+  --exclude "*" \
+  --include "*.html" \
+  --cache-control "no-cache, no-store, must-revalidate" \
+  --content-type "text/html; charset=utf-8"
+
+echo "[deploy] Creating CloudFront invalidation for ${SITE_DISTRIBUTION_ID}"
+INVALIDATION_ID="$(
+  aws cloudfront create-invalidation \
+    --distribution-id "$SITE_DISTRIBUTION_ID" \
+    --paths "/*" \
+    --query 'Invalidation.Id' \
+    --output text
+)"
+
+if [[ -z "$INVALIDATION_ID" || "$INVALIDATION_ID" == "None" ]]; then
+  echo "CloudFront invalidation did not return an ID." >&2
+  exit 1
+fi
+
+echo "[deploy] Waiting for CloudFront invalidation ${INVALIDATION_ID}"
+aws cloudfront wait invalidation-completed \
+  --distribution-id "$SITE_DISTRIBUTION_ID" \
+  --id "$INVALIDATION_ID"
+
+COMMIT_SHA="$(git rev-parse --short HEAD)"
+TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+SITE_URL="https://${SITE_DOMAIN}"
+
+mkdir -p "$ARTIFACT_DIR"
+
+cat > "$DEPLOY_MANIFEST_PATH" <<JSON
+{
+  "env": "$ENV",
+  "service": "site",
+  "deployedAtUtc": "$TIMESTAMP",
+  "gitCommit": "$COMMIT_SHA",
+  "siteBucketName": "$SITE_BUCKET_NAME",
+  "siteDomain": "$SITE_DOMAIN",
+  "siteUrl": "$SITE_URL",
+  "cloudFrontDistributionId": "$SITE_DISTRIBUTION_ID",
+  "cloudFrontInvalidationId": "$INVALIDATION_ID",
+  "staticSiteOutputDir": "$STATIC_SITE_OUTPUT_DIR"
+}
+JSON
+
+echo "[deploy] Deployment complete"
+echo "[deploy] Env:          $ENV"
+echo "[deploy] Site bucket:  $SITE_BUCKET_NAME"
+echo "[deploy] Site domain:  $SITE_DOMAIN"
+echo "[deploy] Distribution: $SITE_DISTRIBUTION_ID"
+echo "[deploy] Invalidation: $INVALIDATION_ID"
+echo "[deploy] Manifest:     $DEPLOY_MANIFEST_PATH"


### PR DESCRIPTION
## Summary
- add a static export path for the app and route-aware shell loading for deployable site pages
- add site deploy plumbing for QA and prod, including S3 upload, CloudFront invalidation, and workflow smoke checks
- add CloudFront viewer-request routing and deploy-role permissions needed to publish the static site

## Validation
- npm run test -w @3fc/app -- --runInBand
- npm run test
- npm run lint
- make build
- STATIC_SITE_OUTPUT_DIR=/tmp/3fc-static-export API_BASE_URL=https://qa-api.3fc.football npm run export:static -w @3fc/app
- terraform -chdir=infra/application validate
- AWS_PROFILE=3fc-agent terraform -chdir=infra/qa validate && AWS_PROFILE=3fc-agent terraform -chdir=infra/prod validate
- AWS_PROFILE=3fc-agent terraform -chdir=infra/qa apply -input=false -auto-approve -no-color
- AWS_PROFILE=3fc-agent terraform -chdir=infra/prod apply -input=false -auto-approve -no-color

## Risks / Follow-up
- QA deploy will now validate the site host as well as the API, so any hosted-content or CloudFront regression should surface immediately.
- Production deploy now includes the static app path and corresponding smoke checks.

Fixes #76
