### PR TITLE
feat(infra): manage ses sender domain in terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,19 @@ Expected result for both commands:
 - HTTP `200` response
 - JSON body from the health handler
 
+## Email Delivery Setup
+
+SES sender identity infrastructure is managed in Terraform for the `3fc.football`
+domain and the `noreply@3fc.football` from-address. Because SES identities are
+shared at the AWS account and region level, the shared domain identity is owned
+by the QA environment wrapper and reused by production.
+
+Manual SES steps still remain:
+
+- Request SES production access for the AWS account/region when ready.
+- While SES remains in sandbox, verify any recipient email addresses you want to
+  use for QA magic-link testing.
+
 ## Social Auth Credentials (Local)
 
 To enable Google social sign-in in Cognito, add local-only credentials per environment:

--- a/infra/application/main.tf
+++ b/infra/application/main.tf
@@ -29,6 +29,7 @@ locals {
   google_oauth_client_id                = var.google_oauth_client_id != null && trimspace(var.google_oauth_client_id) != "" ? trimspace(var.google_oauth_client_id) : null
   google_oauth_client_secret            = var.google_oauth_client_secret != null && trimspace(var.google_oauth_client_secret) != "" ? trimspace(var.google_oauth_client_secret) : null
   google_identity_provider_enabled      = local.google_oauth_client_id != null
+  shared_ses_domain_identity_enabled    = var.create_baseline_resources && var.manage_shared_ses_domain_identity
 
   app_tags = merge(
     {
@@ -572,8 +573,11 @@ data "aws_iam_policy_document" "lambda_data_access" {
       "ses:SendEmail",
       "ses:SendRawEmail",
     ]
+    # SES sandbox testing can authorize against verified recipient identities as
+    # well as the configured sender identity, so scope this to account-local
+    # identities instead of a single mailbox identity ARN.
     resources = [
-      "arn:${data.aws_partition.current.partition}:ses:${var.region}:${data.aws_caller_identity.current.account_id}:identity/${var.ses_from_email}",
+      "arn:${data.aws_partition.current.partition}:ses:${var.region}:${data.aws_caller_identity.current.account_id}:identity/*",
     ]
   }
 }
@@ -719,10 +723,36 @@ resource "aws_iam_role_policy" "github_actions_deploy" {
   policy = data.aws_iam_policy_document.github_actions_deploy_permissions[0].json
 }
 
-resource "aws_ses_email_identity" "from_address" {
-  count = var.create_baseline_resources ? 1 : 0
+resource "aws_ses_domain_identity" "from_domain" {
+  count = local.shared_ses_domain_identity_enabled ? 1 : 0
 
-  email = var.ses_from_email
+  domain = var.ses_from_domain
+}
+
+resource "aws_route53_record" "ses_domain_verification" {
+  count = local.shared_ses_domain_identity_enabled ? 1 : 0
+
+  zone_id = data.aws_route53_zone.primary[0].zone_id
+  name    = "_amazonses.${var.ses_from_domain}"
+  type    = "TXT"
+  ttl     = 600
+  records = [aws_ses_domain_identity.from_domain[0].verification_token]
+}
+
+resource "aws_ses_domain_dkim" "from_domain" {
+  count = local.shared_ses_domain_identity_enabled ? 1 : 0
+
+  domain = aws_ses_domain_identity.from_domain[0].domain
+}
+
+resource "aws_route53_record" "ses_domain_dkim" {
+  count = local.shared_ses_domain_identity_enabled ? 3 : 0
+
+  zone_id = data.aws_route53_zone.primary[0].zone_id
+  name    = "${aws_ses_domain_dkim.from_domain[0].dkim_tokens[count.index]}._domainkey.${var.ses_from_domain}"
+  type    = "CNAME"
+  ttl     = 600
+  records = ["${aws_ses_domain_dkim.from_domain[0].dkim_tokens[count.index]}.dkim.amazonses.com"]
 }
 
 output "baseline_resources_enabled" {

--- a/infra/application/variables.tf
+++ b/infra/application/variables.tf
@@ -109,6 +109,12 @@ variable "ses_from_email" {
   default     = "noreply@3fc.football"
 }
 
+variable "ses_from_domain" {
+  description = "SES verified domain identity used for sender addresses"
+  type        = string
+  default     = "3fc.football"
+}
+
 variable "github_repository" {
   description = "GitHub repository allowed to assume deploy role (owner/repo)"
   type        = string
@@ -122,6 +128,12 @@ variable "github_environment_name" {
 
 variable "create_github_oidc_provider" {
   description = "When true, create the GitHub OIDC provider in this environment stack"
+  type        = bool
+  default     = false
+}
+
+variable "manage_shared_ses_domain_identity" {
+  description = "When true, manage the shared SES sender domain identity in this environment stack"
   type        = bool
   default     = false
 }

--- a/infra/prod/main.tf
+++ b/infra/prod/main.tf
@@ -1,18 +1,28 @@
 module "app" {
   source = "../application"
 
-  env                         = "prod"
-  region                      = "ap-southeast-2"
-  project_name                = "3fc"
-  create_baseline_resources   = true
-  create_github_oidc_provider = false
-  github_repository           = "ajfisher/3fc"
-  github_environment_name     = "production"
-  site_domain                 = "app.3fc.football"
-  api_domain                  = "api.3fc.football"
-  cognito_domain              = "auth.app.3fc.football"
-  google_oauth_client_id      = var.google_oauth_client_id
-  google_oauth_client_secret  = var.google_oauth_client_secret
-  hosted_zone_name            = "3fc.football"
-  ses_from_email              = "noreply@3fc.football"
+  env                               = "prod"
+  region                            = "ap-southeast-2"
+  project_name                      = "3fc"
+  create_baseline_resources         = true
+  create_github_oidc_provider       = false
+  manage_shared_ses_domain_identity = false
+  github_repository                 = "ajfisher/3fc"
+  github_environment_name           = "production"
+  site_domain                       = "app.3fc.football"
+  api_domain                        = "api.3fc.football"
+  cognito_domain                    = "auth.app.3fc.football"
+  google_oauth_client_id            = var.google_oauth_client_id
+  google_oauth_client_secret        = var.google_oauth_client_secret
+  hosted_zone_name                  = "3fc.football"
+  ses_from_email                    = "noreply@3fc.football"
+  ses_from_domain                   = "3fc.football"
+}
+
+removed {
+  from = module.app.aws_ses_email_identity.from_address
+
+  lifecycle {
+    destroy = false
+  }
 }

--- a/infra/qa/main.tf
+++ b/infra/qa/main.tf
@@ -1,18 +1,28 @@
 module "app" {
   source = "../application"
 
-  env                         = "qa"
-  region                      = "ap-southeast-2"
-  project_name                = "3fc"
-  create_baseline_resources   = true
-  create_github_oidc_provider = true
-  github_repository           = "ajfisher/3fc"
-  github_environment_name     = "qa"
-  site_domain                 = "qa.3fc.football"
-  api_domain                  = "qa-api.3fc.football"
-  cognito_domain              = "auth.qa.3fc.football"
-  google_oauth_client_id      = var.google_oauth_client_id
-  google_oauth_client_secret  = var.google_oauth_client_secret
-  hosted_zone_name            = "3fc.football"
-  ses_from_email              = "noreply@3fc.football"
+  env                               = "qa"
+  region                            = "ap-southeast-2"
+  project_name                      = "3fc"
+  create_baseline_resources         = true
+  create_github_oidc_provider       = true
+  manage_shared_ses_domain_identity = true
+  github_repository                 = "ajfisher/3fc"
+  github_environment_name           = "qa"
+  site_domain                       = "qa.3fc.football"
+  api_domain                        = "qa-api.3fc.football"
+  cognito_domain                    = "auth.qa.3fc.football"
+  google_oauth_client_id            = var.google_oauth_client_id
+  google_oauth_client_secret        = var.google_oauth_client_secret
+  hosted_zone_name                  = "3fc.football"
+  ses_from_email                    = "noreply@3fc.football"
+  ses_from_domain                   = "3fc.football"
+}
+
+removed {
+  from = module.app.aws_ses_email_identity.from_address
+
+  lifecycle {
+    destroy = false
+  }
 }


### PR DESCRIPTION
## Summary
- manage the shared SES sender domain in Terraform using a domain identity and DKIM records
- make QA the single owner of the shared SES domain identity while prod reuses it without conflicting
- remove the stale shared SES email identity from both Terraform states without destroying the underlying AWS object
- document the remaining manual SES steps for sandbox and production access

## Validation
- terraform -chdir=infra/application validate
- AWS_PROFILE=3fc-agent terraform -chdir=infra/qa validate && AWS_PROFILE=3fc-agent terraform -chdir=infra/qa plan -input=false -lock=false -no-color
- AWS_PROFILE=3fc-agent terraform -chdir=infra/prod validate && AWS_PROFILE=3fc-agent terraform -chdir=infra/prod plan -input=false -lock=false -no-color
- terraform fmt -recursive infra
- git diff --check

## Known Risks / Follow-ups
- apply QA before prod so the shared SES domain identity and Route53 verification records are created before prod drops the old email-identity state entry
- SES production access is still a manual AWS account step
- while SES remains in sandbox, recipient verification is still required for QA magic-link testing
- existing Cognito Google IdP drift still appears in plan output and is unrelated to this slice

Closes #79
