### PR TITLE
fix(infra): suppress cognito google idp drift

### DIFF
--- a/infra/application/main.tf
+++ b/infra/application/main.tf
@@ -378,10 +378,20 @@ resource "aws_cognito_identity_provider" "google" {
   }
 
   attribute_mapping = {
-    email = "email"
+    email    = "email"
+    username = "sub"
   }
 
   lifecycle {
+    ignore_changes = [
+      provider_details["attributes_url"],
+      provider_details["attributes_url_add_attributes"],
+      provider_details["authorize_url"],
+      provider_details["oidc_issuer"],
+      provider_details["token_request_method"],
+      provider_details["token_url"],
+    ]
+
     precondition {
       condition     = local.google_oauth_client_secret != null
       error_message = "google_oauth_client_secret must be set when google_oauth_client_id is provided."


### PR DESCRIPTION
## Summary
- preserve the live Google IdP username mapping in Terraform
- ignore Cognito/AWS-returned Google provider metadata that Terraform should not own
- keep Terraform managing Google OAuth scopes, client ID, and client secret

## Validation
- terraform fmt -check -recursive infra
- terraform -chdir=infra/application validate
- AWS_PROFILE=3fc-agent terraform -chdir=infra/qa plan -input=false -no-color
- AWS_PROFILE=3fc-agent terraform -chdir=infra/prod plan -input=false -no-color

## Result
- QA plan reports no changes
- Prod plan reports no changes
- No Terraform apply is required because live Cognito already matches the intended shape