### PR TITLE
[codex] Add M2 roster foundation

### DIFF
--- a/api/src/auth/acl.ts
+++ b/api/src/auth/acl.ts
@@ -1,34 +1,44 @@
-import type { LeagueAclRecord, SeasonRecord, SessionRecord } from "../data/types.js";
+import type { GameRecord, LeagueAclRecord, SeasonRecord, SessionRecord } from "../data/types.js";
 
 const ROUTES = {
   createLeague: /^\/v1\/leagues$/,
   createSeason: /^\/v1\/leagues\/([^/]+)\/seasons$/,
   createSession: /^\/v1\/seasons\/([^/]+)\/sessions$/,
   createGame: /^\/v1\/sessions\/([^/]+)\/games$/,
+  updateSeasonTeam: /^\/v1\/seasons\/([^/]+)\/teams\/([^/]+)$/,
+  updateGameTeam: /^\/v1\/games\/([^/]+)\/teams\/([^/]+)$/,
+  createGamePlayer: /^\/v1\/games\/([^/]+)\/players$/,
+  assignRosterPlayer: /^\/v1\/games\/([^/]+)\/roster\/([^/]+)$/,
 } as const;
 
 export type ProtectedMutationOperation =
   | "createLeague"
   | "createSeason"
   | "createSession"
-  | "createGame";
+  | "createGame"
+  | "updateSeasonTeam"
+  | "updateGameTeam"
+  | "createGamePlayer"
+  | "assignRosterPlayer";
 
 export interface ProtectedMutationRoute {
   operation: ProtectedMutationOperation;
   leagueId?: string;
   seasonId?: string;
   sessionId?: string;
+  gameId?: string;
 }
 
 export interface AclLookup {
   getLeagueAccess(leagueId: string, userId: string): Promise<LeagueAclRecord | null>;
   getSeason(seasonId: string): Promise<SeasonRecord | null>;
   getSession(sessionId: string): Promise<SessionRecord | null>;
+  getGame(gameId: string): Promise<GameRecord | null>;
 }
 
 export interface AclErrorResponse {
   error: "forbidden" | "not_found";
-  code: "admin_required" | "acl_scope_not_found";
+  code: "admin_required" | "scorekeeper_required" | "acl_scope_not_found";
   message: string;
 }
 
@@ -49,15 +59,11 @@ export function resolveProtectedMutationRoute(
   route: string,
 ): ProtectedMutationRoute | null {
   const upperMethod = method.toUpperCase();
-  if (upperMethod !== "POST") {
-    return null;
-  }
-
-  if (ROUTES.createLeague.test(route)) {
+  if (upperMethod === "POST" && ROUTES.createLeague.test(route)) {
     return { operation: "createLeague" };
   }
 
-  const seasonMatch = route.match(ROUTES.createSeason);
+  const seasonMatch = upperMethod === "POST" ? route.match(ROUTES.createSeason) : null;
   if (seasonMatch) {
     return {
       operation: "createSeason",
@@ -65,7 +71,7 @@ export function resolveProtectedMutationRoute(
     };
   }
 
-  const sessionMatch = route.match(ROUTES.createSession);
+  const sessionMatch = upperMethod === "POST" ? route.match(ROUTES.createSession) : null;
   if (sessionMatch) {
     return {
       operation: "createSession",
@@ -73,11 +79,43 @@ export function resolveProtectedMutationRoute(
     };
   }
 
-  const gameMatch = route.match(ROUTES.createGame);
-  if (gameMatch) {
+  const createGameMatch = upperMethod === "POST" ? route.match(ROUTES.createGame) : null;
+  if (createGameMatch) {
     return {
       operation: "createGame",
-      sessionId: decodeRouteParam(gameMatch[1]),
+      sessionId: decodeRouteParam(createGameMatch[1]),
+    };
+  }
+
+  const updateSeasonTeamMatch = upperMethod === "PUT" ? route.match(ROUTES.updateSeasonTeam) : null;
+  if (updateSeasonTeamMatch) {
+    return {
+      operation: "updateSeasonTeam",
+      seasonId: decodeRouteParam(updateSeasonTeamMatch[1]),
+    };
+  }
+
+  const updateGameTeamMatch = upperMethod === "PUT" ? route.match(ROUTES.updateGameTeam) : null;
+  if (updateGameTeamMatch) {
+    return {
+      operation: "updateGameTeam",
+      gameId: decodeRouteParam(updateGameTeamMatch[1]),
+    };
+  }
+
+  const createGamePlayerMatch = upperMethod === "POST" ? route.match(ROUTES.createGamePlayer) : null;
+  if (createGamePlayerMatch) {
+    return {
+      operation: "createGamePlayer",
+      gameId: decodeRouteParam(createGamePlayerMatch[1]),
+    };
+  }
+
+  const assignRosterPlayerMatch = upperMethod === "PUT" ? route.match(ROUTES.assignRosterPlayer) : null;
+  if (assignRosterPlayerMatch) {
+    return {
+      operation: "assignRosterPlayer",
+      gameId: decodeRouteParam(assignRosterPlayerMatch[1]),
     };
   }
 
@@ -98,7 +136,21 @@ function forbiddenAdminRequired(leagueId: string): AclAuthorizationResult {
   };
 }
 
-function missingScope(scopeType: "season" | "session", scopeId: string): AclAuthorizationResult {
+function forbiddenScorekeeperRequired(leagueId: string): AclAuthorizationResult {
+  return {
+    allowed: false,
+    statusCode: 403,
+    operation: null,
+    scope: null,
+    error: {
+      error: "forbidden",
+      code: "scorekeeper_required",
+      message: `Admin or scorekeeper role is required for league ${leagueId}.`,
+    },
+  };
+}
+
+function missingScope(scopeType: "game" | "season" | "session", scopeId: string): AclAuthorizationResult {
   return {
     allowed: false,
     statusCode: 404,
@@ -119,6 +171,42 @@ async function verifyLeagueAdmin(
 ): Promise<boolean> {
   const access = await aclLookup.getLeagueAccess(leagueId, userId);
   return access?.role === "admin";
+}
+
+async function verifyLeagueRole(
+  userId: string,
+  leagueId: string,
+  aclLookup: AclLookup,
+  allowedRoles: ReadonlySet<LeagueAclRecord["role"]>,
+): Promise<boolean> {
+  const access = await aclLookup.getLeagueAccess(leagueId, userId);
+  return access ? allowedRoles.has(access.role) : false;
+}
+
+async function resolveGameScope(
+  gameId: string,
+  aclLookup: AclLookup,
+): Promise<
+  | { found: true; game: GameRecord; leagueId: string; seasonId: string; sessionId: string }
+  | { found: false; scopeType: "game" | "season"; scopeId: string }
+> {
+  const game = await aclLookup.getGame(gameId);
+  if (!game) {
+    return { found: false, scopeType: "game", scopeId: gameId };
+  }
+
+  const season = await aclLookup.getSeason(game.seasonId);
+  if (!season) {
+    return { found: false, scopeType: "season", scopeId: game.seasonId };
+  }
+
+  return {
+    found: true,
+    game,
+    leagueId: game.leagueId,
+    seasonId: game.seasonId,
+    sessionId: game.sessionId,
+  };
 }
 
 export async function authorizeProtectedMutation(
@@ -190,20 +278,92 @@ export async function authorizeProtectedMutation(
     };
   }
 
-  const sessionId = resolvedRoute.sessionId as string;
-  const session = await aclLookup.getSession(sessionId);
-  if (!session) {
-    return missingScope("session", sessionId);
+  if (resolvedRoute.operation === "createGame") {
+    const sessionId = resolvedRoute.sessionId as string;
+    const session = await aclLookup.getSession(sessionId);
+    if (!session) {
+      return missingScope("session", sessionId);
+    }
+
+    const season = await aclLookup.getSeason(session.seasonId);
+    if (!season) {
+      return missingScope("season", session.seasonId);
+    }
+
+    const isAdmin = await verifyLeagueAdmin(userId, season.leagueId, aclLookup);
+    if (!isAdmin) {
+      return forbiddenAdminRequired(season.leagueId);
+    }
+
+    return {
+      allowed: true,
+      statusCode: 200,
+      operation: resolvedRoute.operation,
+      scope: {
+        leagueId: season.leagueId,
+        seasonId: session.seasonId,
+        sessionId,
+      },
+      error: null,
+    };
   }
 
-  const season = await aclLookup.getSeason(session.seasonId);
-  if (!season) {
-    return missingScope("season", session.seasonId);
+  if (resolvedRoute.operation === "updateSeasonTeam") {
+    const seasonId = resolvedRoute.seasonId as string;
+    const season = await aclLookup.getSeason(seasonId);
+    if (!season) {
+      return missingScope("season", seasonId);
+    }
+
+    const isAdmin = await verifyLeagueAdmin(userId, season.leagueId, aclLookup);
+    if (!isAdmin) {
+      return forbiddenAdminRequired(season.leagueId);
+    }
+
+    return {
+      allowed: true,
+      statusCode: 200,
+      operation: resolvedRoute.operation,
+      scope: {
+        leagueId: season.leagueId,
+        seasonId,
+      },
+      error: null,
+    };
   }
 
-  const isAdmin = await verifyLeagueAdmin(userId, season.leagueId, aclLookup);
-  if (!isAdmin) {
-    return forbiddenAdminRequired(season.leagueId);
+  const gameScope = await resolveGameScope(resolvedRoute.gameId as string, aclLookup);
+  if (!gameScope.found) {
+    return missingScope(gameScope.scopeType, gameScope.scopeId);
+  }
+
+  if (resolvedRoute.operation === "updateGameTeam") {
+    const isAdmin = await verifyLeagueAdmin(userId, gameScope.leagueId, aclLookup);
+    if (!isAdmin) {
+      return forbiddenAdminRequired(gameScope.leagueId);
+    }
+
+    return {
+      allowed: true,
+      statusCode: 200,
+      operation: resolvedRoute.operation,
+      scope: {
+        leagueId: gameScope.leagueId,
+        seasonId: gameScope.seasonId,
+        sessionId: gameScope.sessionId,
+      },
+      error: null,
+    };
+  }
+
+  const canOperateRoster = await verifyLeagueRole(
+    userId,
+    gameScope.leagueId,
+    aclLookup,
+    new Set(["admin", "scorekeeper"]),
+  );
+  if (!canOperateRoster) {
+    return forbiddenScorekeeperRequired(gameScope.leagueId);
   }
 
   return {
@@ -211,9 +371,9 @@ export async function authorizeProtectedMutation(
     statusCode: 200,
     operation: resolvedRoute.operation,
     scope: {
-      leagueId: season.leagueId,
-      seasonId: session.seasonId,
-      sessionId,
+      leagueId: gameScope.leagueId,
+      seasonId: gameScope.seasonId,
+      sessionId: gameScope.sessionId,
     },
     error: null,
   };

--- a/api/src/auth/http-security.ts
+++ b/api/src/auth/http-security.ts
@@ -63,7 +63,7 @@ export function buildCorsHeaders(
     "Access-Control-Allow-Origin": origin as string,
     "Access-Control-Allow-Credentials": "true",
     "Access-Control-Allow-Headers": "content-type,x-csrf-token,idempotency-key",
-    "Access-Control-Allow-Methods": "GET,POST,PATCH,DELETE,OPTIONS",
+    "Access-Control-Allow-Methods": "GET,POST,PATCH,PUT,DELETE,OPTIONS",
     Vary: "Origin",
   };
 }

--- a/api/src/auth/session.ts
+++ b/api/src/auth/session.ts
@@ -55,6 +55,14 @@ export function isAuthenticatedApiRoute(method: string, route: string): boolean 
     return true;
   }
 
+  if (method === "GET" && /^\/v1\/seasons\/[^/]+\/teams$/.test(route)) {
+    return true;
+  }
+
+  if (method === "PUT" && /^\/v1\/seasons\/[^/]+\/teams\/[^/]+$/.test(route)) {
+    return true;
+  }
+
   if (method === "DELETE" && /^\/v1\/seasons\/[^/]+$/.test(route)) {
     return true;
   }
@@ -68,6 +76,30 @@ export function isAuthenticatedApiRoute(method: string, route: string): boolean 
   }
 
   if (method === "DELETE" && /^\/v1\/games\/[^/]+$/.test(route)) {
+    return true;
+  }
+
+  if (method === "GET" && /^\/v1\/games\/[^/]+\/teams$/.test(route)) {
+    return true;
+  }
+
+  if (method === "PUT" && /^\/v1\/games\/[^/]+\/teams\/[^/]+$/.test(route)) {
+    return true;
+  }
+
+  if (method === "GET" && /^\/v1\/games\/[^/]+\/players$/.test(route)) {
+    return true;
+  }
+
+  if (method === "POST" && /^\/v1\/games\/[^/]+\/players$/.test(route)) {
+    return true;
+  }
+
+  if (method === "GET" && /^\/v1\/games\/[^/]+\/roster$/.test(route)) {
+    return true;
+  }
+
+  if (method === "PUT" && /^\/v1\/games\/[^/]+\/roster\/[^/]+$/.test(route)) {
     return true;
   }
 

--- a/api/src/contracts/core-write.ts
+++ b/api/src/contracts/core-write.ts
@@ -1,7 +1,9 @@
 import { z } from "zod";
+import { TEAM_IDS } from "@3fc/contracts";
 
 const nonEmptyTrimmedString = z.string().trim().min(1, "must be a non-empty string");
 const optionalNullableString = z.string().nullable().optional();
+const teamIdSchema = z.enum(TEAM_IDS);
 
 export const idempotencyKeyHeaderSchema = z
   .string()
@@ -42,10 +44,33 @@ export const createGameRequestSchema = z
   })
   .strict();
 
+export const upsertTeamRequestSchema = z
+  .object({
+    name: nonEmptyTrimmedString,
+    color: optionalNullableString,
+  })
+  .strict();
+
+export const quickCreateGamePlayerRequestSchema = z
+  .object({
+    playerId: nonEmptyTrimmedString.optional(),
+    nickname: nonEmptyTrimmedString,
+  })
+  .strict();
+
+export const assignRosterPlayerRequestSchema = z
+  .object({
+    teamId: teamIdSchema,
+  })
+  .strict();
+
 export type CreateLeagueRequest = z.infer<typeof createLeagueRequestSchema>;
 export type CreateSeasonRequest = z.infer<typeof createSeasonRequestSchema>;
 export type CreateSessionRequest = z.infer<typeof createSessionRequestSchema>;
 export type CreateGameRequest = z.infer<typeof createGameRequestSchema>;
+export type UpsertTeamRequest = z.infer<typeof upsertTeamRequestSchema>;
+export type QuickCreateGamePlayerRequest = z.infer<typeof quickCreateGamePlayerRequestSchema>;
+export type AssignRosterPlayerRequest = z.infer<typeof assignRosterPlayerRequestSchema>;
 
 export function formatSchemaValidationError(error: z.ZodError): string {
   if (error.issues.length === 0) {

--- a/api/src/data/keys.ts
+++ b/api/src/data/keys.ts
@@ -59,6 +59,10 @@ export function rosterSk(teamId: string, playerId: string): string {
   return `ROSTER#${teamId}#${playerId}`;
 }
 
+export function gamePlayerSk(playerId: string): string {
+  return `PLAYER#${playerId}`;
+}
+
 export function gameSessionIndexPk(sessionId: string): string {
   return sessionPk(sessionId);
 }

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -14,6 +14,7 @@ import { validateAssistPlayerIds } from "@3fc/contracts";
 import {
   aclSk,
   gamePk,
+  gamePlayerSk,
   gameSessionIndexPk,
   gameSessionIndexSk,
   goalSk,
@@ -31,6 +32,7 @@ import {
 } from "./keys.js";
 import type {
   AssignRosterInput,
+  CreateGameTeamInput,
   CreateGameInput,
   CreateGoalEventInput,
   CreateIdempotencyRecordInput,
@@ -40,11 +42,15 @@ import type {
   CreateSessionGameInput,
   CreateSessionInput,
   CreateTeamInput,
+  GameTeamRecord,
+  GamePlayerRecord,
   GameRecord,
   GoalEventRecord,
   IdempotencyRecord,
   LeagueAclRecord,
   LeagueRecord,
+  ListPlayersInput,
+  LinkGamePlayerInput,
   PlayerRecord,
   RosterAssignmentRecord,
   SeasonRecord,
@@ -60,6 +66,8 @@ const ENTITY_TYPE = {
   team: "team",
   session: "session",
   game: "game",
+  gameTeam: "gameTeam",
+  gamePlayer: "gamePlayer",
   sessionGame: "sessionGame",
   player: "player",
   acl: "acl",
@@ -333,6 +341,45 @@ export class ThreeFcRepository {
       .map((item) =>
         withTimestamps(
           item.data as Omit<TeamRecord, "createdAt" | "updatedAt">,
+          item.createdAt,
+          item.updatedAt,
+        ),
+      );
+  }
+
+  async createGameTeamOverride(input: CreateGameTeamInput): Promise<GameTeamRecord> {
+    requireNonEmpty("gameId", input.gameId);
+    requireNonEmpty("name", input.name);
+
+    const now = this.clock.now();
+    const existing = await this.getEntity(gamePk(input.gameId), teamSk(input.teamId));
+    const payload = {
+      gameId: input.gameId,
+      teamId: input.teamId,
+      name: input.name,
+      color: input.color ?? null,
+    };
+
+    await this.putEntityWithTimestamps(
+      gamePk(input.gameId),
+      teamSk(input.teamId),
+      ENTITY_TYPE.gameTeam,
+      payload,
+      existing?.createdAt ?? now,
+      now,
+    );
+    return withTimestamps(payload, existing?.createdAt ?? now, now);
+  }
+
+  async listTeamsForGame(gameId: string): Promise<GameTeamRecord[]> {
+    requireNonEmpty("gameId", gameId);
+    const items = await this.queryByPrefix(gamePk(gameId), "TEAM#");
+
+    return items
+      .filter((item) => item.entityType === ENTITY_TYPE.gameTeam)
+      .map((item) =>
+        withTimestamps(
+          item.data as Omit<GameTeamRecord, "createdAt" | "updatedAt">,
           item.createdAt,
           item.updatedAt,
         ),
@@ -648,6 +695,69 @@ export class ThreeFcRepository {
     return withTimestamps(item.data as Omit<PlayerRecord, "createdAt" | "updatedAt">, item.createdAt, item.updatedAt);
   }
 
+  async listPlayers(input: ListPlayersInput = {}): Promise<PlayerRecord[]> {
+    const rawSearch = input.search?.trim().toLowerCase() ?? "";
+    const limit = Math.max(1, Math.min(input.limit ?? 20, 50));
+    const scanResult = (await this.client.send(
+      new ScanCommand({
+        TableName: this.tableName,
+      }),
+    )) as ScanCommandOutput;
+
+    return (scanResult.Items ?? [])
+      .filter((item) => item.entityType?.S === ENTITY_TYPE.player)
+      .map((item) => parseStoredEntity<Omit<PlayerRecord, "createdAt" | "updatedAt">>(item))
+      .map((item) => withTimestamps(item.data, item.createdAt, item.updatedAt))
+      .filter((player) => rawSearch.length === 0 || player.nickname.toLowerCase().includes(rawSearch))
+      .sort((left, right) => {
+        const updatedSort = right.updatedAt.localeCompare(left.updatedAt);
+        if (updatedSort !== 0) {
+          return updatedSort;
+        }
+
+        return left.nickname.localeCompare(right.nickname);
+      })
+      .slice(0, limit);
+  }
+
+  async linkGamePlayer(input: LinkGamePlayerInput): Promise<GamePlayerRecord> {
+    requireNonEmpty("gameId", input.gameId);
+    requireNonEmpty("playerId", input.playerId);
+
+    const now = this.clock.now();
+    const existing = await this.getEntity(gamePk(input.gameId), gamePlayerSk(input.playerId));
+    const payload = {
+      gameId: input.gameId,
+      playerId: input.playerId,
+    };
+
+    await this.putEntityWithTimestamps(
+      gamePk(input.gameId),
+      gamePlayerSk(input.playerId),
+      ENTITY_TYPE.gamePlayer,
+      payload,
+      existing?.createdAt ?? now,
+      now,
+    );
+
+    return withTimestamps(payload, existing?.createdAt ?? now, now);
+  }
+
+  async listGamePlayers(gameId: string): Promise<GamePlayerRecord[]> {
+    requireNonEmpty("gameId", gameId);
+    const items = await this.queryByPrefix(gamePk(gameId), "PLAYER#");
+
+    return items
+      .filter((item) => item.entityType === ENTITY_TYPE.gamePlayer)
+      .map((item) =>
+        withTimestamps(
+          item.data as Omit<GamePlayerRecord, "createdAt" | "updatedAt">,
+          item.createdAt,
+          item.updatedAt,
+        ),
+      );
+  }
+
   async grantLeagueAccess(input: GrantLeagueAccessInput): Promise<LeagueAclRecord> {
     requireNonEmpty("leagueId", input.leagueId);
     requireNonEmpty("userId", input.userId);
@@ -700,6 +810,17 @@ export class ThreeFcRepository {
     requireNonEmpty("gameId", input.gameId);
     requireNonEmpty("playerId", input.playerId);
 
+    const existingAssignments = await this.listGameRoster(input.gameId);
+    const currentAssignmentsForPlayer = existingAssignments.filter(
+      (assignment) => assignment.playerId === input.playerId,
+    );
+    const existingAssignment = currentAssignmentsForPlayer.find(
+      (assignment) => assignment.teamId === input.teamId,
+    );
+    if (existingAssignment) {
+      return existingAssignment;
+    }
+
     const now = this.clock.now();
     const payload = {
       gameId: input.gameId,
@@ -707,6 +828,15 @@ export class ThreeFcRepository {
       playerId: input.playerId,
     };
 
+    await Promise.all(
+      currentAssignmentsForPlayer.map((assignment) =>
+        this.deleteEntity(gamePk(input.gameId), rosterSk(assignment.teamId, assignment.playerId)),
+      ),
+    );
+    await this.linkGamePlayer({
+      gameId: input.gameId,
+      playerId: input.playerId,
+    });
     await this.putEntity(
       gamePk(input.gameId),
       rosterSk(input.teamId, input.playerId),

--- a/api/src/data/types.ts
+++ b/api/src/data/types.ts
@@ -32,6 +32,15 @@ export interface TeamRecord {
   updatedAt: string;
 }
 
+export interface GameTeamRecord {
+  gameId: string;
+  teamId: TeamId;
+  name: string;
+  color: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface SessionRecord {
   seasonId: string;
   sessionId: string;
@@ -65,6 +74,13 @@ export interface PlayerRecord {
   playerId: string;
   nickname: string;
   claimedByUserId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GamePlayerRecord {
+  gameId: string;
+  playerId: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -133,6 +149,13 @@ export interface CreateTeamInput {
   color?: string | null;
 }
 
+export interface CreateGameTeamInput {
+  gameId: string;
+  teamId: TeamId;
+  name: string;
+  color?: string | null;
+}
+
 export interface CreateSessionInput {
   seasonId: string;
   sessionId: string;
@@ -160,6 +183,16 @@ export interface CreatePlayerInput {
   playerId: string;
   nickname: string;
   claimedByUserId?: string | null;
+}
+
+export interface ListPlayersInput {
+  search?: string | null;
+  limit?: number;
+}
+
+export interface LinkGamePlayerInput {
+  gameId: string;
+  playerId: string;
 }
 
 export interface GrantLeagueAccessInput {

--- a/api/src/lambda-core.ts
+++ b/api/src/lambda-core.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { SESv2Client, SendEmailCommand } from "@aws-sdk/client-sesv2";
+import { DEFAULT_TEAMS, TEAM_IDS, type TeamId } from "@3fc/contracts";
 
 import { authorizeProtectedMutation } from "./auth/acl.js";
 import {
@@ -32,8 +33,11 @@ import {
   createLeagueRequestSchema,
   createSeasonRequestSchema,
   createSessionRequestSchema,
+  assignRosterPlayerRequestSchema,
   formatSchemaValidationError,
   idempotencyKeyHeaderSchema,
+  quickCreateGamePlayerRequestSchema,
+  upsertTeamRequestSchema,
 } from "./contracts/core-write.js";
 import { ThreeFcRepository } from "./data/repository.js";
 import type { GameStatus } from "./data/types.js";
@@ -41,6 +45,7 @@ import { logAuthRateLimit, logRequest, logRequestError } from "./logging.js";
 
 export interface ApiGatewayHttpEvent {
   rawPath?: string;
+  rawQueryString?: string;
   body?: string | null;
   cookies?: string[];
   headers?: Record<string, string | undefined>;
@@ -144,7 +149,62 @@ interface RepositoryContract {
     slug?: string | null;
     startsOn?: string | null;
     endsOn?: string | null;
-  }): Promise<unknown>;
+  }): Promise<{
+    leagueId: string;
+    seasonId: string;
+    name: string;
+    slug: string | null;
+    startsOn: string | null;
+    endsOn: string | null;
+    createdAt: string;
+    updatedAt: string;
+  }>;
+  createTeam(input: {
+    seasonId: string;
+    teamId: TeamId;
+    name: string;
+    color?: string | null;
+  }): Promise<{
+    seasonId: string;
+    teamId: TeamId;
+    name: string;
+    color: string | null;
+    createdAt: string;
+    updatedAt: string;
+  }>;
+  listTeamsForSeason(seasonId: string): Promise<
+    Array<{
+      seasonId: string;
+      teamId: TeamId;
+      name: string;
+      color: string | null;
+      createdAt: string;
+      updatedAt: string;
+    }>
+  >;
+  createGameTeamOverride(input: {
+    gameId: string;
+    teamId: TeamId;
+    name: string;
+    color?: string | null;
+  }): Promise<{
+    gameId: string;
+    teamId: TeamId;
+    name: string;
+    color: string | null;
+    createdAt: string;
+    updatedAt: string;
+  }>;
+  listTeamsForGame(gameId: string): Promise<
+    Array<{
+      gameId: string;
+      teamId: TeamId;
+      name: string;
+      color: string | null;
+      createdAt: string;
+      updatedAt: string;
+    }>
+  >;
   createSession(input: { seasonId: string; sessionId: string; sessionDate: string }): Promise<unknown>;
   createGame(input: {
     gameId: string;
@@ -216,6 +276,78 @@ interface RepositoryContract {
   deleteGame(gameId: string): Promise<boolean>;
   deleteSeason(seasonId: string): Promise<boolean>;
   deleteLeague(leagueId: string): Promise<boolean>;
+  createPlayer(input: {
+    playerId: string;
+    nickname: string;
+    claimedByUserId?: string | null;
+  }): Promise<{
+    playerId: string;
+    nickname: string;
+    claimedByUserId: string | null;
+    createdAt: string;
+    updatedAt: string;
+  }>;
+  getPlayer(
+    playerId: string,
+  ): Promise<
+    | {
+        playerId: string;
+        nickname: string;
+        claimedByUserId: string | null;
+        createdAt: string;
+        updatedAt: string;
+      }
+    | null
+  >;
+  listPlayers(input?: {
+    search?: string | null;
+    limit?: number;
+  }): Promise<
+    Array<{
+      playerId: string;
+      nickname: string;
+      claimedByUserId: string | null;
+      createdAt: string;
+      updatedAt: string;
+    }>
+  >;
+  linkGamePlayer(input: {
+    gameId: string;
+    playerId: string;
+  }): Promise<{
+    gameId: string;
+    playerId: string;
+    createdAt: string;
+    updatedAt: string;
+  }>;
+  listGamePlayers(gameId: string): Promise<
+    Array<{
+      gameId: string;
+      playerId: string;
+      createdAt: string;
+      updatedAt: string;
+    }>
+  >;
+  assignRosterPlayer(input: {
+    gameId: string;
+    teamId: TeamId;
+    playerId: string;
+  }): Promise<{
+    gameId: string;
+    teamId: TeamId;
+    playerId: string;
+    createdAt: string;
+    updatedAt: string;
+  }>;
+  listGameRoster(gameId: string): Promise<
+    Array<{
+      gameId: string;
+      teamId: TeamId;
+      playerId: string;
+      createdAt: string;
+      updatedAt: string;
+    }>
+  >;
   getLeagueAccess(
     leagueId: string,
     userId: string,
@@ -322,6 +454,15 @@ function getCookieHeader(event: ApiGatewayHttpEvent): string | undefined {
   }
 
   return undefined;
+}
+
+function getQueryParam(event: ApiGatewayHttpEvent, name: string): string | null {
+  const query = event.rawQueryString ?? "";
+  if (query.length === 0) {
+    return null;
+  }
+
+  return new URLSearchParams(query).get(name);
 }
 
 function getClientIp(event: ApiGatewayHttpEvent): string {
@@ -511,6 +652,219 @@ async function ensureLeagueAdmin(
 ): Promise<boolean> {
   const access = await repository.getLeagueAccess(leagueId, userId);
   return access?.role === "admin";
+}
+
+async function ensureLeagueRole(
+  repository: RepositoryContract,
+  leagueId: string,
+  userId: string,
+  allowedRoles: ReadonlySet<"admin" | "scorekeeper" | "viewer">,
+): Promise<boolean> {
+  const access = await repository.getLeagueAccess(leagueId, userId);
+  return access ? allowedRoles.has(access.role) : false;
+}
+
+function parseTeamId(value: string): TeamId | null {
+  return TEAM_IDS.includes(value as TeamId) ? (value as TeamId) : null;
+}
+
+function compareTeamIds(left: TeamId, right: TeamId): number {
+  return TEAM_IDS.indexOf(left) - TEAM_IDS.indexOf(right);
+}
+
+function sortTeams<T extends { teamId: TeamId }>(teams: T[]): T[] {
+  return [...teams].sort((left, right) => compareTeamIds(left.teamId, right.teamId));
+}
+
+function toPublicPlayer(player: {
+  playerId: string;
+  nickname: string;
+  createdAt: string;
+  updatedAt: string;
+}) {
+  return {
+    playerId: player.playerId,
+    nickname: player.nickname,
+    createdAt: player.createdAt,
+    updatedAt: player.updatedAt,
+  };
+}
+
+function buildReadOnlySeasonTeams(
+  season: {
+    seasonId: string;
+    createdAt: string;
+    updatedAt: string;
+  },
+  existingTeams: Array<{
+    seasonId: string;
+    teamId: TeamId;
+    name: string;
+    color: string | null;
+    createdAt: string;
+    updatedAt: string;
+  }>,
+) {
+  const teamsById = new Map(existingTeams.map((team) => [team.teamId, team]));
+
+  for (const defaultTeam of DEFAULT_TEAMS) {
+    if (teamsById.has(defaultTeam.teamId)) {
+      continue;
+    }
+
+    teamsById.set(defaultTeam.teamId, {
+      seasonId: season.seasonId,
+      teamId: defaultTeam.teamId,
+      name: defaultTeam.name,
+      color: defaultTeam.color,
+      createdAt: season.createdAt,
+      updatedAt: season.updatedAt,
+    });
+  }
+
+  return sortTeams([...teamsById.values()]);
+}
+
+async function readSeasonTeams(
+  repository: RepositoryContract,
+  season: {
+    seasonId: string;
+    createdAt: string;
+    updatedAt: string;
+  },
+) {
+  const existingTeams = await repository.listTeamsForSeason(season.seasonId);
+  return buildReadOnlySeasonTeams(season, existingTeams);
+}
+
+async function ensureSeasonDefaultTeams(repository: RepositoryContract, seasonId: string) {
+  const existingTeams = await repository.listTeamsForSeason(seasonId);
+  const teamsById = new Map(existingTeams.map((team) => [team.teamId, team]));
+
+  for (const defaultTeam of DEFAULT_TEAMS) {
+    if (teamsById.has(defaultTeam.teamId)) {
+      continue;
+    }
+
+    const createdTeam = await repository.createTeam({
+      seasonId,
+      teamId: defaultTeam.teamId,
+      name: defaultTeam.name,
+      color: defaultTeam.color,
+    });
+    teamsById.set(createdTeam.teamId, createdTeam);
+  }
+
+  return sortTeams([...teamsById.values()]);
+}
+
+async function ensureGameTeamsForGame(
+  repository: RepositoryContract,
+  game: {
+    gameId: string;
+    seasonId: string;
+  },
+) {
+  const seasonTeams = await ensureSeasonDefaultTeams(repository, game.seasonId);
+  const existingGameTeams = await repository.listTeamsForGame(game.gameId);
+  const gameTeamsById = new Map(existingGameTeams.map((team) => [team.teamId, team]));
+
+  for (const seasonTeam of seasonTeams) {
+    if (gameTeamsById.has(seasonTeam.teamId)) {
+      continue;
+    }
+
+    const gameTeam = await repository.createGameTeamOverride({
+      gameId: game.gameId,
+      teamId: seasonTeam.teamId,
+      name: seasonTeam.name,
+      color: seasonTeam.color,
+    });
+    gameTeamsById.set(gameTeam.teamId, gameTeam);
+  }
+
+  return sortTeams([...gameTeamsById.values()]);
+}
+
+async function readGameTeams(
+  repository: RepositoryContract,
+  game: {
+    gameId: string;
+    seasonId: string;
+    createdAt: string;
+    updatedAt: string;
+  },
+) {
+  const season = await repository.getSeason(game.seasonId);
+  const existingGameTeams = await repository.listTeamsForGame(game.gameId);
+  const gameTeamsById = new Map(existingGameTeams.map((team) => [team.teamId, team]));
+  const seasonTeams = season
+    ? await readSeasonTeams(repository, season)
+    : DEFAULT_TEAMS.map((team) => ({
+        seasonId: game.seasonId,
+        teamId: team.teamId,
+        name: team.name,
+        color: team.color,
+        createdAt: game.createdAt,
+        updatedAt: game.updatedAt,
+      }));
+
+  for (const seasonTeam of seasonTeams) {
+    if (gameTeamsById.has(seasonTeam.teamId)) {
+      continue;
+    }
+
+    gameTeamsById.set(seasonTeam.teamId, {
+      gameId: game.gameId,
+      teamId: seasonTeam.teamId,
+      name: seasonTeam.name,
+      color: seasonTeam.color,
+      createdAt: game.createdAt,
+      updatedAt: game.updatedAt,
+    });
+  }
+
+  return sortTeams([...gameTeamsById.values()]);
+}
+
+async function buildRosterResponse(repository: RepositoryContract, game: {
+  gameId: string;
+  seasonId: string;
+  createdAt: string;
+  updatedAt: string;
+}) {
+  const teams = await readGameTeams(repository, game);
+  const roster = await repository.listGameRoster(game.gameId);
+  const playersById = new Map(
+    (
+      await Promise.all(
+        [...new Set(roster.map((assignment) => assignment.playerId))].map((playerId) =>
+          repository.getPlayer(playerId),
+        ),
+      )
+    )
+      .filter((player) => player !== null)
+      .map((player) => [player.playerId, toPublicPlayer(player)]),
+  );
+
+  return {
+    teams,
+    roster: roster
+      .map((assignment) => ({
+        ...assignment,
+        player: playersById.get(assignment.playerId) ?? null,
+      }))
+      .sort((left, right) => {
+        const teamSort = compareTeamIds(left.teamId, right.teamId);
+        if (teamSort !== 0) {
+          return teamSort;
+        }
+
+        const leftName = left.player?.nickname ?? left.playerId;
+        const rightName = right.player?.nickname ?? right.playerId;
+        return leftName.localeCompare(rightName);
+      }),
+  };
 }
 
 function parseGamePatchBody(rawBody: Record<string, unknown>): {
@@ -1076,6 +1430,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
                 startsOn: parsedBody.data.startsOn ?? null,
                 endsOn: parsedBody.data.endsOn ?? null,
               });
+              await ensureSeasonDefaultTeams(dependencies.repository, createdSeason.seasonId);
 
               return createJsonResponse(
                 201,
@@ -1266,6 +1621,83 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
           );
         }
 
+        const listSeasonTeamsMatch = route.match(/^\/v1\/seasons\/([^/]+)\/teams$/);
+        if (method === "GET" && listSeasonTeamsMatch) {
+          const seasonId = decodeRouteParam(listSeasonTeamsMatch[1]);
+          const season = await dependencies.repository.getSeason(seasonId);
+          if (!season) {
+            status = 404;
+            return notFound(origin, dependencies.corsAllowedOrigins, `Season ${seasonId} was not found.`);
+          }
+
+          const access = await ensureLeagueAccess(
+            dependencies.repository,
+            season.leagueId,
+            session.email,
+          );
+          if (!access.allowed) {
+            status = 403;
+            return forbidden(
+              origin,
+              dependencies.corsAllowedOrigins,
+              "league_access_required",
+              `Access to league ${season.leagueId} is required.`,
+            );
+          }
+
+          const teams = await readSeasonTeams(dependencies.repository, season);
+          status = 200;
+          return createJsonResponse(
+            status,
+            {
+              teams,
+            },
+            buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
+          );
+        }
+
+        const updateSeasonTeamMatch = route.match(/^\/v1\/seasons\/([^/]+)\/teams\/([^/]+)$/);
+        if (method === "PUT" && updateSeasonTeamMatch) {
+          const seasonId = decodeRouteParam(updateSeasonTeamMatch[1]);
+          const teamId = parseTeamId(decodeRouteParam(updateSeasonTeamMatch[2]));
+          if (!teamId) {
+            status = 400;
+            return badRequest(origin, dependencies.corsAllowedOrigins, "Team ID must be red, blue, or yellow.");
+          }
+
+          let rawBody: Record<string, unknown>;
+          try {
+            rawBody = parseJsonBody(event);
+          } catch {
+            status = 400;
+            return badRequest(origin, dependencies.corsAllowedOrigins, "Request body must be valid JSON.");
+          }
+
+          const parsedBody = upsertTeamRequestSchema.safeParse(rawBody);
+          if (!parsedBody.success) {
+            status = 400;
+            return badRequest(
+              origin,
+              dependencies.corsAllowedOrigins,
+              formatSchemaValidationError(parsedBody.error),
+            );
+          }
+
+          await ensureSeasonDefaultTeams(dependencies.repository, seasonId);
+          const team = await dependencies.repository.createTeam({
+            seasonId,
+            teamId,
+            name: parsedBody.data.name,
+            color: parsedBody.data.color ?? null,
+          });
+          status = 200;
+          return createJsonResponse(
+            status,
+            team,
+            buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
+          );
+        }
+
         const deleteSeasonMatch = route.match(/^\/v1\/seasons\/([^/]+)$/);
         if (method === "DELETE" && deleteSeasonMatch) {
           const seasonId = decodeRouteParam(deleteSeasonMatch[1]);
@@ -1364,6 +1796,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
                 leagueId: createdGame.leagueId,
                 seasonId: createdGame.seasonId,
               });
+              await ensureGameTeamsForGame(dependencies.repository, createdGame);
 
               return createJsonResponse(
                 201,
@@ -1405,6 +1838,296 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
           return createJsonResponse(
             status,
             game,
+            buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
+          );
+        }
+
+        const listGameTeamsMatch = route.match(/^\/v1\/games\/([^/]+)\/teams$/);
+        if (method === "GET" && listGameTeamsMatch) {
+          const gameId = decodeRouteParam(listGameTeamsMatch[1]);
+          const game = await dependencies.repository.getGame(gameId);
+          if (!game) {
+            status = 404;
+            return notFound(origin, dependencies.corsAllowedOrigins, `Game ${gameId} was not found.`);
+          }
+
+          const access = await ensureLeagueAccess(
+            dependencies.repository,
+            game.leagueId,
+            session.email,
+          );
+          if (!access.allowed) {
+            status = 403;
+            return forbidden(
+              origin,
+              dependencies.corsAllowedOrigins,
+              "league_access_required",
+              `Access to league ${game.leagueId} is required.`,
+            );
+          }
+
+          const teams = await readGameTeams(dependencies.repository, game);
+          status = 200;
+          return createJsonResponse(
+            status,
+            {
+              teams,
+            },
+            buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
+          );
+        }
+
+        const updateGameTeamMatch = route.match(/^\/v1\/games\/([^/]+)\/teams\/([^/]+)$/);
+        if (method === "PUT" && updateGameTeamMatch) {
+          const gameId = decodeRouteParam(updateGameTeamMatch[1]);
+          const teamId = parseTeamId(decodeRouteParam(updateGameTeamMatch[2]));
+          if (!teamId) {
+            status = 400;
+            return badRequest(origin, dependencies.corsAllowedOrigins, "Team ID must be red, blue, or yellow.");
+          }
+
+          const game = await dependencies.repository.getGame(gameId);
+          if (!game) {
+            status = 404;
+            return notFound(origin, dependencies.corsAllowedOrigins, `Game ${gameId} was not found.`);
+          }
+
+          let rawBody: Record<string, unknown>;
+          try {
+            rawBody = parseJsonBody(event);
+          } catch {
+            status = 400;
+            return badRequest(origin, dependencies.corsAllowedOrigins, "Request body must be valid JSON.");
+          }
+
+          const parsedBody = upsertTeamRequestSchema.safeParse(rawBody);
+          if (!parsedBody.success) {
+            status = 400;
+            return badRequest(
+              origin,
+              dependencies.corsAllowedOrigins,
+              formatSchemaValidationError(parsedBody.error),
+            );
+          }
+
+          await ensureGameTeamsForGame(dependencies.repository, game);
+          const team = await dependencies.repository.createGameTeamOverride({
+            gameId,
+            teamId,
+            name: parsedBody.data.name,
+            color: parsedBody.data.color ?? null,
+          });
+          status = 200;
+          return createJsonResponse(
+            status,
+            team,
+            buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
+          );
+        }
+
+        const listGamePlayersMatch = route.match(/^\/v1\/games\/([^/]+)\/players$/);
+        if (method === "GET" && listGamePlayersMatch) {
+          const gameId = decodeRouteParam(listGamePlayersMatch[1]);
+          const game = await dependencies.repository.getGame(gameId);
+          if (!game) {
+            status = 404;
+            return notFound(origin, dependencies.corsAllowedOrigins, `Game ${gameId} was not found.`);
+          }
+
+          const canManageRoster = await ensureLeagueRole(
+            dependencies.repository,
+            game.leagueId,
+            session.email,
+            new Set(["admin", "scorekeeper"]),
+          );
+          if (!canManageRoster) {
+            status = 403;
+            return forbidden(
+              origin,
+              dependencies.corsAllowedOrigins,
+              "scorekeeper_required",
+              `Admin or scorekeeper role is required for league ${game.leagueId}.`,
+            );
+          }
+
+          const search = getQueryParam(event, "search")?.trim().toLowerCase() ?? "";
+          const playerLinks = await dependencies.repository.listGamePlayers(gameId);
+          const players = (
+            await Promise.all(
+              playerLinks.map(async (link) => ({
+                link,
+                player: await dependencies.repository.getPlayer(link.playerId),
+              })),
+            )
+          )
+            .flatMap((entry) => (entry.player ? [{ link: entry.link, player: entry.player }] : []))
+            .filter((entry) =>
+              search.length === 0 ? true : entry.player.nickname.toLowerCase().includes(search),
+            )
+            .sort((left, right) => {
+              const updatedSort = right.link.updatedAt.localeCompare(left.link.updatedAt);
+              if (updatedSort !== 0) {
+                return updatedSort;
+              }
+
+              return left.player.nickname.localeCompare(right.player.nickname);
+            })
+            .slice(0, 20)
+            .map((entry) => toPublicPlayer(entry.player));
+          status = 200;
+          return createJsonResponse(
+            status,
+            {
+              players,
+            },
+            buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
+          );
+        }
+
+        const createGamePlayerMatch = route.match(/^\/v1\/games\/([^/]+)\/players$/);
+        if (method === "POST" && createGamePlayerMatch) {
+          const gameId = decodeRouteParam(createGamePlayerMatch[1]);
+          const game = await dependencies.repository.getGame(gameId);
+          if (!game) {
+            status = 404;
+            return notFound(origin, dependencies.corsAllowedOrigins, `Game ${gameId} was not found.`);
+          }
+
+          let rawBody: Record<string, unknown>;
+          try {
+            rawBody = parseJsonBody(event);
+          } catch {
+            status = 400;
+            return badRequest(origin, dependencies.corsAllowedOrigins, "Request body must be valid JSON.");
+          }
+
+          const parsedBody = quickCreateGamePlayerRequestSchema.safeParse(rawBody);
+          if (!parsedBody.success) {
+            status = 400;
+            return badRequest(
+              origin,
+              dependencies.corsAllowedOrigins,
+              formatSchemaValidationError(parsedBody.error),
+            );
+          }
+
+          const playerId = parsedBody.data.playerId ?? `player-${randomUUID()}`;
+          const mutationResponse = await executeIdempotentMutation({
+            repository: dependencies.repository,
+            idempotencyKey,
+            sessionEmail: session.email,
+            method,
+            route,
+            requestPayload: parsedBody.data,
+            origin,
+            allowedOrigins: dependencies.corsAllowedOrigins,
+            execute: async () => {
+              const player = await dependencies.repository.createPlayer({
+                playerId,
+                nickname: parsedBody.data.nickname,
+              });
+              await dependencies.repository.linkGamePlayer({
+                gameId,
+                playerId: player.playerId,
+              });
+
+              return createJsonResponse(
+                201,
+                toPublicPlayer(player),
+                buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
+              );
+            },
+          });
+
+          status = mutationResponse.statusCode;
+          return mutationResponse;
+        }
+
+        const listGameRosterMatch = route.match(/^\/v1\/games\/([^/]+)\/roster$/);
+        if (method === "GET" && listGameRosterMatch) {
+          const gameId = decodeRouteParam(listGameRosterMatch[1]);
+          const game = await dependencies.repository.getGame(gameId);
+          if (!game) {
+            status = 404;
+            return notFound(origin, dependencies.corsAllowedOrigins, `Game ${gameId} was not found.`);
+          }
+
+          const access = await ensureLeagueAccess(
+            dependencies.repository,
+            game.leagueId,
+            session.email,
+          );
+          if (!access.allowed) {
+            status = 403;
+            return forbidden(
+              origin,
+              dependencies.corsAllowedOrigins,
+              "league_access_required",
+              `Access to league ${game.leagueId} is required.`,
+            );
+          }
+
+          const rosterResponse = await buildRosterResponse(dependencies.repository, game);
+          status = 200;
+          return createJsonResponse(
+            status,
+            rosterResponse,
+            buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
+          );
+        }
+
+        const assignRosterPlayerMatch = route.match(/^\/v1\/games\/([^/]+)\/roster\/([^/]+)$/);
+        if (method === "PUT" && assignRosterPlayerMatch) {
+          const gameId = decodeRouteParam(assignRosterPlayerMatch[1]);
+          const playerId = decodeRouteParam(assignRosterPlayerMatch[2]);
+          const game = await dependencies.repository.getGame(gameId);
+          if (!game) {
+            status = 404;
+            return notFound(origin, dependencies.corsAllowedOrigins, `Game ${gameId} was not found.`);
+          }
+
+          let rawBody: Record<string, unknown>;
+          try {
+            rawBody = parseJsonBody(event);
+          } catch {
+            status = 400;
+            return badRequest(origin, dependencies.corsAllowedOrigins, "Request body must be valid JSON.");
+          }
+
+          const parsedBody = assignRosterPlayerRequestSchema.safeParse(rawBody);
+          if (!parsedBody.success) {
+            status = 400;
+            return badRequest(
+              origin,
+              dependencies.corsAllowedOrigins,
+              formatSchemaValidationError(parsedBody.error),
+            );
+          }
+
+          const teams = await ensureGameTeamsForGame(dependencies.repository, game);
+          if (!teams.some((team) => team.teamId === parsedBody.data.teamId)) {
+            status = 400;
+            return badRequest(origin, dependencies.corsAllowedOrigins, "Team ID must be active for this game.");
+          }
+
+          const player = await dependencies.repository.getPlayer(playerId);
+          if (!player) {
+            status = 404;
+            return notFound(origin, dependencies.corsAllowedOrigins, `Player ${playerId} was not found.`);
+          }
+
+          const assignment = await dependencies.repository.assignRosterPlayer({
+            gameId,
+            teamId: parsedBody.data.teamId,
+            playerId,
+          });
+          status = 200;
+          return createJsonResponse(
+            status,
+            {
+              ...assignment,
+              player: toPublicPlayer(player),
+            },
             buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
           );
         }

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -9,6 +9,7 @@ import {
   GetItemCommand,
   PutItemCommand,
 } from "@aws-sdk/client-dynamodb";
+import { DEFAULT_TEAMS, TEAM_IDS, type TeamId } from "@3fc/contracts";
 
 import {
   isMagicLinkEmailLike,
@@ -42,8 +43,11 @@ import {
   createLeagueRequestSchema,
   createSeasonRequestSchema,
   createSessionRequestSchema,
+  assignRosterPlayerRequestSchema,
   formatSchemaValidationError,
   idempotencyKeyHeaderSchema,
+  quickCreateGamePlayerRequestSchema,
+  upsertTeamRequestSchema,
 } from "./contracts/core-write.js";
 import { ThreeFcRepository } from "./data/repository.js";
 import { buildHealthResponse } from "./index.js";
@@ -293,6 +297,206 @@ async function ensureLeagueAccess(
 async function ensureLeagueAdmin(leagueId: string, userId: string): Promise<boolean> {
   const access = await repository.getLeagueAccess(leagueId, userId);
   return access?.role === "admin";
+}
+
+async function ensureLeagueRole(
+  leagueId: string,
+  userId: string,
+  allowedRoles: ReadonlySet<"admin" | "scorekeeper" | "viewer">,
+): Promise<boolean> {
+  const access = await repository.getLeagueAccess(leagueId, userId);
+  return access ? allowedRoles.has(access.role) : false;
+}
+
+function parseTeamId(value: string): TeamId | null {
+  return TEAM_IDS.includes(value as TeamId) ? (value as TeamId) : null;
+}
+
+function compareTeamIds(left: TeamId, right: TeamId): number {
+  return TEAM_IDS.indexOf(left) - TEAM_IDS.indexOf(right);
+}
+
+function sortTeams<T extends { teamId: TeamId }>(teams: T[]): T[] {
+  return [...teams].sort((left, right) => compareTeamIds(left.teamId, right.teamId));
+}
+
+function toPublicPlayer(player: {
+  playerId: string;
+  nickname: string;
+  createdAt: string;
+  updatedAt: string;
+}) {
+  return {
+    playerId: player.playerId,
+    nickname: player.nickname,
+    createdAt: player.createdAt,
+    updatedAt: player.updatedAt,
+  };
+}
+
+function buildReadOnlySeasonTeams(
+  season: {
+    seasonId: string;
+    createdAt: string;
+    updatedAt: string;
+  },
+  existingTeams: Array<{
+    seasonId: string;
+    teamId: TeamId;
+    name: string;
+    color: string | null;
+    createdAt: string;
+    updatedAt: string;
+  }>,
+) {
+  const teamsById = new Map(existingTeams.map((team) => [team.teamId, team]));
+
+  for (const defaultTeam of DEFAULT_TEAMS) {
+    if (teamsById.has(defaultTeam.teamId)) {
+      continue;
+    }
+
+    teamsById.set(defaultTeam.teamId, {
+      seasonId: season.seasonId,
+      teamId: defaultTeam.teamId,
+      name: defaultTeam.name,
+      color: defaultTeam.color,
+      createdAt: season.createdAt,
+      updatedAt: season.updatedAt,
+    });
+  }
+
+  return sortTeams([...teamsById.values()]);
+}
+
+async function readSeasonTeams(season: {
+  seasonId: string;
+  createdAt: string;
+  updatedAt: string;
+}) {
+  const existingTeams = await repository.listTeamsForSeason(season.seasonId);
+  return buildReadOnlySeasonTeams(season, existingTeams);
+}
+
+async function ensureSeasonDefaultTeams(seasonId: string) {
+  const existingTeams = await repository.listTeamsForSeason(seasonId);
+  const teamsById = new Map(existingTeams.map((team) => [team.teamId, team]));
+
+  for (const defaultTeam of DEFAULT_TEAMS) {
+    if (teamsById.has(defaultTeam.teamId)) {
+      continue;
+    }
+
+    const createdTeam = await repository.createTeam({
+      seasonId,
+      teamId: defaultTeam.teamId,
+      name: defaultTeam.name,
+      color: defaultTeam.color,
+    });
+    teamsById.set(createdTeam.teamId, createdTeam);
+  }
+
+  return sortTeams([...teamsById.values()]);
+}
+
+async function ensureGameTeamsForGame(game: { gameId: string; seasonId: string }) {
+  const seasonTeams = await ensureSeasonDefaultTeams(game.seasonId);
+  const existingGameTeams = await repository.listTeamsForGame(game.gameId);
+  const gameTeamsById = new Map(existingGameTeams.map((team) => [team.teamId, team]));
+
+  for (const seasonTeam of seasonTeams) {
+    if (gameTeamsById.has(seasonTeam.teamId)) {
+      continue;
+    }
+
+    const gameTeam = await repository.createGameTeamOverride({
+      gameId: game.gameId,
+      teamId: seasonTeam.teamId,
+      name: seasonTeam.name,
+      color: seasonTeam.color,
+    });
+    gameTeamsById.set(gameTeam.teamId, gameTeam);
+  }
+
+  return sortTeams([...gameTeamsById.values()]);
+}
+
+async function readGameTeams(game: {
+  gameId: string;
+  seasonId: string;
+  createdAt: string;
+  updatedAt: string;
+}) {
+  const season = await repository.getSeason(game.seasonId);
+  const existingGameTeams = await repository.listTeamsForGame(game.gameId);
+  const gameTeamsById = new Map(existingGameTeams.map((team) => [team.teamId, team]));
+  const seasonTeams = season
+    ? await readSeasonTeams(season)
+    : DEFAULT_TEAMS.map((team) => ({
+        seasonId: game.seasonId,
+        teamId: team.teamId,
+        name: team.name,
+        color: team.color,
+        createdAt: game.createdAt,
+        updatedAt: game.updatedAt,
+      }));
+
+  for (const seasonTeam of seasonTeams) {
+    if (gameTeamsById.has(seasonTeam.teamId)) {
+      continue;
+    }
+
+    gameTeamsById.set(seasonTeam.teamId, {
+      gameId: game.gameId,
+      teamId: seasonTeam.teamId,
+      name: seasonTeam.name,
+      color: seasonTeam.color,
+      createdAt: game.createdAt,
+      updatedAt: game.updatedAt,
+    });
+  }
+
+  return sortTeams([...gameTeamsById.values()]);
+}
+
+async function buildRosterResponse(game: {
+  gameId: string;
+  seasonId: string;
+  createdAt: string;
+  updatedAt: string;
+}) {
+  const teams = await readGameTeams(game);
+  const roster = await repository.listGameRoster(game.gameId);
+  const playersById = new Map(
+    (
+      await Promise.all(
+        [...new Set(roster.map((assignment) => assignment.playerId))].map((playerId) =>
+          repository.getPlayer(playerId),
+        ),
+      )
+    )
+      .filter((player) => player !== null)
+      .map((player) => [player.playerId, toPublicPlayer(player)]),
+  );
+
+  return {
+    teams,
+    roster: roster
+      .map((assignment) => ({
+        ...assignment,
+        player: playersById.get(assignment.playerId) ?? null,
+      }))
+      .sort((left, right) => {
+        const teamSort = compareTeamIds(left.teamId, right.teamId);
+        if (teamSort !== 0) {
+          return teamSort;
+        }
+
+        const leftName = left.player?.nickname ?? left.playerId;
+        const rightName = right.player?.nickname ?? right.playerId;
+        return leftName.localeCompare(rightName);
+      }),
+  };
 }
 
 function parseGamePatchBody(rawBody: Record<string, unknown>): {
@@ -584,6 +788,7 @@ async function handleCreateSeason(
         startsOn: parsedBody.data.startsOn ?? null,
         endsOn: parsedBody.data.endsOn ?? null,
       });
+      await ensureSeasonDefaultTeams(season.seasonId);
 
       return {
         statusCode: 201,
@@ -681,6 +886,7 @@ async function handleCreateGame(
         leagueId: game.leagueId,
         seasonId: game.seasonId,
       });
+      await ensureGameTeamsForGame(game);
 
       return {
         statusCode: 201,
@@ -1310,6 +1516,78 @@ async function start(): Promise<void> {
         return;
       }
 
+      const listSeasonTeamsMatch = route.match(/^\/v1\/seasons\/([^/]+)\/teams$/);
+      if (method === "GET" && listSeasonTeamsMatch) {
+        if (!authGate.session) {
+          status = 500;
+          sendJsonWithCors(request, response, status, {
+            error: "internal_error",
+            message: "Session should be available for authenticated route.",
+          });
+          return;
+        }
+
+        const seasonId = decodeURIComponent(listSeasonTeamsMatch[1]);
+        const season = await repository.getSeason(seasonId);
+        if (!season) {
+          status = notFound(request, response, `Season ${seasonId} was not found.`);
+          return;
+        }
+
+        const access = await ensureLeagueAccess(season.leagueId, authGate.session.email);
+        if (!access.allowed) {
+          status = forbidden(
+            request,
+            response,
+            "league_access_required",
+            `Access to league ${season.leagueId} is required.`,
+          );
+          return;
+        }
+
+        const teams = await readSeasonTeams(season);
+        status = 200;
+        sendJsonWithCors(request, response, status, {
+          teams,
+        });
+        return;
+      }
+
+      const updateSeasonTeamMatch = route.match(/^\/v1\/seasons\/([^/]+)\/teams\/([^/]+)$/);
+      if (method === "PUT" && updateSeasonTeamMatch) {
+        const seasonId = decodeURIComponent(updateSeasonTeamMatch[1]);
+        const teamId = parseTeamId(decodeURIComponent(updateSeasonTeamMatch[2]));
+        if (!teamId) {
+          status = badRequest(request, response, "Team ID must be red, blue, or yellow.");
+          return;
+        }
+
+        let rawBody: Record<string, unknown>;
+        try {
+          rawBody = await parseJsonBody(request);
+        } catch {
+          status = badRequest(request, response, "Request body must be valid JSON.");
+          return;
+        }
+
+        const parsedBody = upsertTeamRequestSchema.safeParse(rawBody);
+        if (!parsedBody.success) {
+          status = badRequest(request, response, formatSchemaValidationError(parsedBody.error));
+          return;
+        }
+
+        await ensureSeasonDefaultTeams(seasonId);
+        const team = await repository.createTeam({
+          seasonId,
+          teamId,
+          name: parsedBody.data.name,
+          color: parsedBody.data.color ?? null,
+        });
+        status = 200;
+        sendJsonWithCors(request, response, status, team);
+        return;
+      }
+
       const deleteSeasonMatch = route.match(/^\/v1\/seasons\/([^/]+)$/);
       if (method === "DELETE" && deleteSeasonMatch) {
         if (!authGate.session) {
@@ -1413,6 +1691,291 @@ async function start(): Promise<void> {
 
         status = 200;
         sendJsonWithCors(request, response, status, game);
+        return;
+      }
+
+      const listGameTeamsMatch = route.match(/^\/v1\/games\/([^/]+)\/teams$/);
+      if (method === "GET" && listGameTeamsMatch) {
+        if (!authGate.session) {
+          status = 500;
+          sendJsonWithCors(request, response, status, {
+            error: "internal_error",
+            message: "Session should be available for authenticated route.",
+          });
+          return;
+        }
+
+        const gameId = decodeURIComponent(listGameTeamsMatch[1]);
+        const game = await repository.getGame(gameId);
+        if (!game) {
+          status = notFound(request, response, `Game ${gameId} was not found.`);
+          return;
+        }
+
+        const access = await ensureLeagueAccess(game.leagueId, authGate.session.email);
+        if (!access.allowed) {
+          status = forbidden(
+            request,
+            response,
+            "league_access_required",
+            `Access to league ${game.leagueId} is required.`,
+          );
+          return;
+        }
+
+        const teams = await readGameTeams(game);
+        status = 200;
+        sendJsonWithCors(request, response, status, {
+          teams,
+        });
+        return;
+      }
+
+      const updateGameTeamMatch = route.match(/^\/v1\/games\/([^/]+)\/teams\/([^/]+)$/);
+      if (method === "PUT" && updateGameTeamMatch) {
+        const gameId = decodeURIComponent(updateGameTeamMatch[1]);
+        const teamId = parseTeamId(decodeURIComponent(updateGameTeamMatch[2]));
+        if (!teamId) {
+          status = badRequest(request, response, "Team ID must be red, blue, or yellow.");
+          return;
+        }
+
+        const game = await repository.getGame(gameId);
+        if (!game) {
+          status = notFound(request, response, `Game ${gameId} was not found.`);
+          return;
+        }
+
+        let rawBody: Record<string, unknown>;
+        try {
+          rawBody = await parseJsonBody(request);
+        } catch {
+          status = badRequest(request, response, "Request body must be valid JSON.");
+          return;
+        }
+
+        const parsedBody = upsertTeamRequestSchema.safeParse(rawBody);
+        if (!parsedBody.success) {
+          status = badRequest(request, response, formatSchemaValidationError(parsedBody.error));
+          return;
+        }
+
+        await ensureGameTeamsForGame(game);
+        const team = await repository.createGameTeamOverride({
+          gameId,
+          teamId,
+          name: parsedBody.data.name,
+          color: parsedBody.data.color ?? null,
+        });
+        status = 200;
+        sendJsonWithCors(request, response, status, team);
+        return;
+      }
+
+      const listGamePlayersMatch = route.match(/^\/v1\/games\/([^/]+)\/players$/);
+      if (method === "GET" && listGamePlayersMatch) {
+        if (!authGate.session) {
+          status = 500;
+          sendJsonWithCors(request, response, status, {
+            error: "internal_error",
+            message: "Session should be available for authenticated route.",
+          });
+          return;
+        }
+
+        const gameId = decodeURIComponent(listGamePlayersMatch[1]);
+        const game = await repository.getGame(gameId);
+        if (!game) {
+          status = notFound(request, response, `Game ${gameId} was not found.`);
+          return;
+        }
+
+        const canManageRoster = await ensureLeagueRole(
+          game.leagueId,
+          authGate.session.email,
+          new Set(["admin", "scorekeeper"]),
+        );
+        if (!canManageRoster) {
+          status = forbidden(
+            request,
+            response,
+            "scorekeeper_required",
+            `Admin or scorekeeper role is required for league ${game.leagueId}.`,
+          );
+          return;
+        }
+
+        const search = requestUrl.searchParams.get("search")?.trim().toLowerCase() ?? "";
+        const playerLinks = await repository.listGamePlayers(gameId);
+        const players = (
+          await Promise.all(
+            playerLinks.map(async (link) => ({
+              link,
+              player: await repository.getPlayer(link.playerId),
+            })),
+          )
+        )
+          .flatMap((entry) => (entry.player ? [{ link: entry.link, player: entry.player }] : []))
+          .filter((entry) =>
+            search.length === 0 ? true : entry.player.nickname.toLowerCase().includes(search),
+          )
+          .sort((left, right) => {
+            const updatedSort = right.link.updatedAt.localeCompare(left.link.updatedAt);
+            if (updatedSort !== 0) {
+              return updatedSort;
+            }
+
+            return left.player.nickname.localeCompare(right.player.nickname);
+          })
+          .slice(0, 20)
+          .map((entry) => toPublicPlayer(entry.player));
+        status = 200;
+        sendJsonWithCors(request, response, status, {
+          players,
+        });
+        return;
+      }
+
+      const createGamePlayerMatch = route.match(/^\/v1\/games\/([^/]+)\/players$/);
+      if (method === "POST" && createGamePlayerMatch) {
+        if (!authGate.session) {
+          status = 500;
+          sendJsonWithCors(request, response, status, {
+            error: "internal_error",
+            message: "Session should be available for authenticated route.",
+          });
+          return;
+        }
+
+        const gameId = decodeURIComponent(createGamePlayerMatch[1]);
+        const game = await repository.getGame(gameId);
+        if (!game) {
+          status = notFound(request, response, `Game ${gameId} was not found.`);
+          return;
+        }
+
+        let rawBody: Record<string, unknown>;
+        try {
+          rawBody = await parseJsonBody(request);
+        } catch {
+          status = badRequest(request, response, "Request body must be valid JSON.");
+          return;
+        }
+
+        const parsedBody = quickCreateGamePlayerRequestSchema.safeParse(rawBody);
+        if (!parsedBody.success) {
+          status = badRequest(request, response, formatSchemaValidationError(parsedBody.error));
+          return;
+        }
+
+        const playerId = parsedBody.data.playerId ?? `player-${randomUUID()}`;
+        status = await executeIdempotentMutation({
+          request,
+          response,
+          sessionEmail: authGate.session.email,
+          method,
+          route,
+          requestPayload: parsedBody.data,
+          execute: async () => {
+            const player = await repository.createPlayer({
+              playerId,
+              nickname: parsedBody.data.nickname,
+            });
+            await repository.linkGamePlayer({
+              gameId,
+              playerId: player.playerId,
+            });
+
+            return {
+              statusCode: 201,
+              payload: toPublicPlayer(player),
+            };
+          },
+        });
+        return;
+      }
+
+      const listGameRosterMatch = route.match(/^\/v1\/games\/([^/]+)\/roster$/);
+      if (method === "GET" && listGameRosterMatch) {
+        if (!authGate.session) {
+          status = 500;
+          sendJsonWithCors(request, response, status, {
+            error: "internal_error",
+            message: "Session should be available for authenticated route.",
+          });
+          return;
+        }
+
+        const gameId = decodeURIComponent(listGameRosterMatch[1]);
+        const game = await repository.getGame(gameId);
+        if (!game) {
+          status = notFound(request, response, `Game ${gameId} was not found.`);
+          return;
+        }
+
+        const access = await ensureLeagueAccess(game.leagueId, authGate.session.email);
+        if (!access.allowed) {
+          status = forbidden(
+            request,
+            response,
+            "league_access_required",
+            `Access to league ${game.leagueId} is required.`,
+          );
+          return;
+        }
+
+        const rosterResponse = await buildRosterResponse(game);
+        status = 200;
+        sendJsonWithCors(request, response, status, rosterResponse);
+        return;
+      }
+
+      const assignRosterPlayerMatch = route.match(/^\/v1\/games\/([^/]+)\/roster\/([^/]+)$/);
+      if (method === "PUT" && assignRosterPlayerMatch) {
+        const gameId = decodeURIComponent(assignRosterPlayerMatch[1]);
+        const playerId = decodeURIComponent(assignRosterPlayerMatch[2]);
+        const game = await repository.getGame(gameId);
+        if (!game) {
+          status = notFound(request, response, `Game ${gameId} was not found.`);
+          return;
+        }
+
+        let rawBody: Record<string, unknown>;
+        try {
+          rawBody = await parseJsonBody(request);
+        } catch {
+          status = badRequest(request, response, "Request body must be valid JSON.");
+          return;
+        }
+
+        const parsedBody = assignRosterPlayerRequestSchema.safeParse(rawBody);
+        if (!parsedBody.success) {
+          status = badRequest(request, response, formatSchemaValidationError(parsedBody.error));
+          return;
+        }
+
+        const teams = await ensureGameTeamsForGame(game);
+        if (!teams.some((team) => team.teamId === parsedBody.data.teamId)) {
+          status = badRequest(request, response, "Team ID must be active for this game.");
+          return;
+        }
+
+        const player = await repository.getPlayer(playerId);
+        if (!player) {
+          status = notFound(request, response, `Player ${playerId} was not found.`);
+          return;
+        }
+
+        const assignment = await repository.assignRosterPlayer({
+          gameId,
+          teamId: parsedBody.data.teamId,
+          playerId,
+        });
+        status = 200;
+        sendJsonWithCors(request, response, status, {
+          ...assignment,
+          player: toPublicPlayer(player),
+        });
         return;
       }
 

--- a/api/src/tests/acl.test.ts
+++ b/api/src/tests/acl.test.ts
@@ -6,12 +6,13 @@ import {
   resolveProtectedMutationRoute,
   type AclLookup,
 } from "../auth/acl.js";
-import type { LeagueAclRecord, SeasonRecord, SessionRecord } from "../data/types.js";
+import type { GameRecord, LeagueAclRecord, SeasonRecord, SessionRecord } from "../data/types.js";
 
 interface AclHarnessInput {
   leagueAccess?: Record<string, LeagueAclRecord>;
   seasons?: Record<string, SeasonRecord>;
   sessions?: Record<string, SessionRecord>;
+  games?: Record<string, GameRecord>;
 }
 
 class InMemoryAclLookup implements AclLookup {
@@ -27,6 +28,10 @@ class InMemoryAclLookup implements AclLookup {
 
   async getSession(sessionId: string): Promise<SessionRecord | null> {
     return this.input.sessions?.[sessionId] ?? null;
+  }
+
+  async getGame(gameId: string): Promise<GameRecord | null> {
+    return this.input.games?.[gameId] ?? null;
   }
 }
 
@@ -45,6 +50,18 @@ test("resolveProtectedMutationRoute maps supported mutation endpoints", () => {
   assert.deepEqual(resolveProtectedMutationRoute("POST", "/v1/sessions/session-1/games"), {
     operation: "createGame",
     sessionId: "session-1",
+  });
+  assert.deepEqual(resolveProtectedMutationRoute("POST", "/v1/games/game-1/players"), {
+    operation: "createGamePlayer",
+    gameId: "game-1",
+  });
+  assert.deepEqual(resolveProtectedMutationRoute("PUT", "/v1/games/game-1/teams/red"), {
+    operation: "updateGameTeam",
+    gameId: "game-1",
+  });
+  assert.deepEqual(resolveProtectedMutationRoute("PUT", "/v1/games/game-1/roster/player-1"), {
+    operation: "assignRosterPlayer",
+    gameId: "game-1",
   });
   assert.equal(resolveProtectedMutationRoute("GET", "/v1/leagues"), null);
 });
@@ -136,4 +153,152 @@ test("session-scoped mutation returns not_found when acl scope cannot be resolve
   assert.equal(result.allowed, false);
   assert.equal(result.statusCode, 404);
   assert.equal(result.error?.code, "acl_scope_not_found");
+});
+
+test("game-scoped roster mutation allows scorekeepers", async () => {
+  const result = await authorizeProtectedMutation(
+    "PUT",
+    "/v1/games/game-1/roster/player-1",
+    "scorekeeper-user",
+    new InMemoryAclLookup({
+      games: {
+        "game-1": {
+          leagueId: "league-1",
+          seasonId: "season-1",
+          sessionId: "session-1",
+          gameId: "game-1",
+          status: "scheduled",
+          gameStartTs: "2026-02-23T10:00:00.000Z",
+          createdAt: "2026-02-23T00:00:00.000Z",
+          updatedAt: "2026-02-23T00:00:00.000Z",
+        },
+      },
+      seasons: {
+        "season-1": {
+          leagueId: "league-1",
+          seasonId: "season-1",
+          name: "Season 1",
+          slug: null,
+          startsOn: null,
+          endsOn: null,
+          createdAt: "2026-02-23T00:00:00.000Z",
+          updatedAt: "2026-02-23T00:00:00.000Z",
+        },
+      },
+      leagueAccess: {
+        "league-1:scorekeeper-user": {
+          leagueId: "league-1",
+          userId: "scorekeeper-user",
+          role: "scorekeeper",
+          grantedByUserId: "admin-user",
+          createdAt: "2026-02-23T00:00:00.000Z",
+          updatedAt: "2026-02-23T00:00:00.000Z",
+        },
+      },
+    }),
+  );
+
+  assert.equal(result.allowed, true);
+  assert.equal(result.operation, "assignRosterPlayer");
+  assert.deepEqual(result.scope, {
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "session-1",
+  });
+});
+
+test("game team override mutation rejects scorekeepers", async () => {
+  const result = await authorizeProtectedMutation(
+    "PUT",
+    "/v1/games/game-1/teams/red",
+    "scorekeeper-user",
+    new InMemoryAclLookup({
+      games: {
+        "game-1": {
+          leagueId: "league-1",
+          seasonId: "season-1",
+          sessionId: "session-1",
+          gameId: "game-1",
+          status: "scheduled",
+          gameStartTs: "2026-02-23T10:00:00.000Z",
+          createdAt: "2026-02-23T00:00:00.000Z",
+          updatedAt: "2026-02-23T00:00:00.000Z",
+        },
+      },
+      seasons: {
+        "season-1": {
+          leagueId: "league-1",
+          seasonId: "season-1",
+          name: "Season 1",
+          slug: null,
+          startsOn: null,
+          endsOn: null,
+          createdAt: "2026-02-23T00:00:00.000Z",
+          updatedAt: "2026-02-23T00:00:00.000Z",
+        },
+      },
+      leagueAccess: {
+        "league-1:scorekeeper-user": {
+          leagueId: "league-1",
+          userId: "scorekeeper-user",
+          role: "scorekeeper",
+          grantedByUserId: "admin-user",
+          createdAt: "2026-02-23T00:00:00.000Z",
+          updatedAt: "2026-02-23T00:00:00.000Z",
+        },
+      },
+    }),
+  );
+
+  assert.equal(result.allowed, false);
+  assert.equal(result.statusCode, 403);
+  assert.equal(result.error?.code, "admin_required");
+});
+
+test("game player creation mutation rejects viewers", async () => {
+  const result = await authorizeProtectedMutation(
+    "POST",
+    "/v1/games/game-1/players",
+    "viewer-user",
+    new InMemoryAclLookup({
+      games: {
+        "game-1": {
+          leagueId: "league-1",
+          seasonId: "season-1",
+          sessionId: "session-1",
+          gameId: "game-1",
+          status: "scheduled",
+          gameStartTs: "2026-02-23T10:00:00.000Z",
+          createdAt: "2026-02-23T00:00:00.000Z",
+          updatedAt: "2026-02-23T00:00:00.000Z",
+        },
+      },
+      seasons: {
+        "season-1": {
+          leagueId: "league-1",
+          seasonId: "season-1",
+          name: "Season 1",
+          slug: null,
+          startsOn: null,
+          endsOn: null,
+          createdAt: "2026-02-23T00:00:00.000Z",
+          updatedAt: "2026-02-23T00:00:00.000Z",
+        },
+      },
+      leagueAccess: {
+        "league-1:viewer-user": {
+          leagueId: "league-1",
+          userId: "viewer-user",
+          role: "viewer",
+          grantedByUserId: "admin-user",
+          createdAt: "2026-02-23T00:00:00.000Z",
+          updatedAt: "2026-02-23T00:00:00.000Z",
+        },
+      },
+    }),
+  );
+
+  assert.equal(result.allowed, false);
+  assert.equal(result.statusCode, 403);
+  assert.equal(result.error?.code, "scorekeeper_required");
 });

--- a/api/src/tests/http-security.test.ts
+++ b/api/src/tests/http-security.test.ts
@@ -39,6 +39,7 @@ test("CORS headers are returned only for allowed origins", () => {
   const allowed = buildCorsHeaders("https://qa.3fc.football", allowlist);
   assert.equal(allowed["Access-Control-Allow-Origin"], "https://qa.3fc.football");
   assert.equal(allowed["Access-Control-Allow-Credentials"], "true");
+  assert.equal(allowed["Access-Control-Allow-Methods"], "GET,POST,PATCH,PUT,DELETE,OPTIONS");
   assert.equal(
     allowed["Access-Control-Allow-Headers"],
     "content-type,x-csrf-token,idempotency-key",

--- a/api/src/tests/lambda-core.test.ts
+++ b/api/src/tests/lambda-core.test.ts
@@ -6,6 +6,7 @@ import {
   type ApiGatewayHttpEvent,
 } from "../lambda-core.js";
 import type { RateLimitDecision } from "../auth/rate-limit.js";
+import type { TeamId } from "@3fc/contracts";
 
 interface MockSessionRecord {
   sessionId: string;
@@ -58,6 +59,47 @@ interface MockGameRecord {
   sessionId: string;
   status: "scheduled" | "live" | "finished";
   gameStartTs: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface MockSeasonTeamRecord {
+  seasonId: string;
+  teamId: TeamId;
+  name: string;
+  color: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface MockGameTeamRecord {
+  gameId: string;
+  teamId: TeamId;
+  name: string;
+  color: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface MockPlayerRecord {
+  playerId: string;
+  nickname: string;
+  claimedByUserId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface MockRosterAssignmentRecord {
+  gameId: string;
+  teamId: TeamId;
+  playerId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface MockGamePlayerRecord {
+  gameId: string;
+  playerId: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -118,6 +160,11 @@ interface HarnessConfig {
   seasons?: Record<string, MockSeasonRecord>;
   seasonSessions?: Record<string, MockSessionEntity>;
   games?: Record<string, MockGameRecord>;
+  seasonTeams?: Record<string, MockSeasonTeamRecord>;
+  gameTeams?: Record<string, MockGameTeamRecord>;
+  players?: Record<string, MockPlayerRecord>;
+  rosterAssignments?: Record<string, MockRosterAssignmentRecord>;
+  gamePlayers?: Record<string, MockGamePlayerRecord>;
   rateLimitDecision?:
     | RateLimitDecision
     | ((input: { email: string; clientIp: string }) => RateLimitDecision);
@@ -153,6 +200,11 @@ function createHarness(config: HarnessConfig = {}) {
   const createdSessions: CreatedSessionInput[] = [];
   const createdGames: CreatedGameInput[] = [];
   const createdSessionGames: CreatedSessionGameInput[] = [];
+  const createdSeasonTeams: Array<{ seasonId: string; teamId: TeamId; name: string; color?: string | null }> = [];
+  const createdGameTeams: Array<{ gameId: string; teamId: TeamId; name: string; color?: string | null }> = [];
+  const createdPlayers: Array<{ playerId: string; nickname: string; claimedByUserId?: string | null }> = [];
+  const assignedRosterPlayers: Array<{ gameId: string; teamId: TeamId; playerId: string }> = [];
+  const linkedGamePlayers: Array<{ gameId: string; playerId: string }> = [];
   const magicLinkStarts: string[] = [];
   const magicLinkCompletes: string[] = [];
   const magicLinkRateLimitChecks: Array<{ email: string; clientIp: string }> = [];
@@ -163,6 +215,17 @@ function createHarness(config: HarnessConfig = {}) {
     Object.entries(config.seasonSessions ?? {}),
   );
   const games = new Map<string, MockGameRecord>(Object.entries(config.games ?? {}));
+  const seasonTeams = new Map<string, MockSeasonTeamRecord>(
+    Object.entries(config.seasonTeams ?? {}),
+  );
+  const gameTeams = new Map<string, MockGameTeamRecord>(Object.entries(config.gameTeams ?? {}));
+  const players = new Map<string, MockPlayerRecord>(Object.entries(config.players ?? {}));
+  const rosterAssignments = new Map<string, MockRosterAssignmentRecord>(
+    Object.entries(config.rosterAssignments ?? {}),
+  );
+  const gamePlayers = new Map<string, MockGamePlayerRecord>(
+    Object.entries(config.gamePlayers ?? {}),
+  );
 
   const handler = createLambdaCoreHandler({
     sessionCookieName: "threefc_session",
@@ -245,6 +308,40 @@ function createHarness(config: HarnessConfig = {}) {
         seasons.set(input.seasonId, record);
         return record;
       },
+      async createTeam(input) {
+        createdSeasonTeams.push(input);
+        const existing = seasonTeams.get(`${input.seasonId}:${input.teamId}`);
+        const record = {
+          seasonId: input.seasonId,
+          teamId: input.teamId,
+          name: input.name,
+          color: input.color ?? null,
+          createdAt: existing?.createdAt ?? "2026-02-23T00:00:00.000Z",
+          updatedAt: "2026-02-23T00:00:00.000Z",
+        };
+        seasonTeams.set(`${input.seasonId}:${input.teamId}`, record);
+        return record;
+      },
+      async listTeamsForSeason(seasonId: string) {
+        return [...seasonTeams.values()].filter((team) => team.seasonId === seasonId);
+      },
+      async createGameTeamOverride(input) {
+        createdGameTeams.push(input);
+        const existing = gameTeams.get(`${input.gameId}:${input.teamId}`);
+        const record = {
+          gameId: input.gameId,
+          teamId: input.teamId,
+          name: input.name,
+          color: input.color ?? null,
+          createdAt: existing?.createdAt ?? "2026-02-23T00:00:00.000Z",
+          updatedAt: "2026-02-23T00:00:00.000Z",
+        };
+        gameTeams.set(`${input.gameId}:${input.teamId}`, record);
+        return record;
+      },
+      async listTeamsForGame(gameId: string) {
+        return [...gameTeams.values()].filter((team) => team.gameId === gameId);
+      },
       async createSession(input) {
         createdSessions.push(input);
         const record = {
@@ -304,6 +401,74 @@ function createHarness(config: HarnessConfig = {}) {
       async deleteLeague(leagueId: string) {
         return leagues.delete(leagueId);
       },
+      async createPlayer(input) {
+        createdPlayers.push(input);
+        const record = {
+          playerId: input.playerId,
+          nickname: input.nickname,
+          claimedByUserId: input.claimedByUserId ?? null,
+          createdAt: "2026-02-23T00:00:00.000Z",
+          updatedAt: "2026-02-23T00:00:00.000Z",
+        };
+        players.set(input.playerId, record);
+        return record;
+      },
+      async getPlayer(playerId: string) {
+        return players.get(playerId) ?? null;
+      },
+      async listPlayers(input = {}) {
+        const search = input.search?.toLowerCase() ?? "";
+        return [...players.values()]
+          .filter((player) => search.length === 0 || player.nickname.toLowerCase().includes(search))
+          .slice(0, input.limit ?? 20);
+      },
+      async linkGamePlayer(input) {
+        linkedGamePlayers.push(input);
+        const existing = gamePlayers.get(`${input.gameId}:${input.playerId}`);
+        const record = {
+          gameId: input.gameId,
+          playerId: input.playerId,
+          createdAt: existing?.createdAt ?? "2026-02-23T00:00:00.000Z",
+          updatedAt: "2026-02-23T00:00:00.000Z",
+        };
+        gamePlayers.set(`${input.gameId}:${input.playerId}`, record);
+        return record;
+      },
+      async listGamePlayers(gameId: string) {
+        return [...gamePlayers.values()].filter((player) => player.gameId === gameId);
+      },
+      async assignRosterPlayer(input) {
+        assignedRosterPlayers.push(input);
+        for (const [key, assignment] of rosterAssignments.entries()) {
+          if (assignment.gameId === input.gameId && assignment.playerId === input.playerId) {
+            rosterAssignments.delete(key);
+          }
+        }
+
+        linkedGamePlayers.push({
+          gameId: input.gameId,
+          playerId: input.playerId,
+        });
+        const existingGamePlayer = gamePlayers.get(`${input.gameId}:${input.playerId}`);
+        gamePlayers.set(`${input.gameId}:${input.playerId}`, {
+          gameId: input.gameId,
+          playerId: input.playerId,
+          createdAt: existingGamePlayer?.createdAt ?? "2026-02-23T00:00:00.000Z",
+          updatedAt: "2026-02-23T00:00:00.000Z",
+        });
+        const record = {
+          gameId: input.gameId,
+          teamId: input.teamId,
+          playerId: input.playerId,
+          createdAt: "2026-02-23T00:00:00.000Z",
+          updatedAt: "2026-02-23T00:00:00.000Z",
+        };
+        rosterAssignments.set(`${input.gameId}:${input.playerId}`, record);
+        return record;
+      },
+      async listGameRoster(gameId: string) {
+        return [...rosterAssignments.values()].filter((assignment) => assignment.gameId === gameId);
+      },
       async getLeagueAccess(leagueId: string, userId: string) {
         return config.leagueAccess?.[`${leagueId}:${userId}`] ?? null;
       },
@@ -340,6 +505,11 @@ function createHarness(config: HarnessConfig = {}) {
     createdSessions,
     createdGames,
     createdSessionGames,
+    createdSeasonTeams,
+    createdGameTeams,
+    createdPlayers,
+    assignedRosterPlayers,
+    linkedGamePlayers,
     magicLinkStarts,
     magicLinkCompletes,
     magicLinkRateLimitChecks,
@@ -716,6 +886,357 @@ test("core lambda creates game for admin with resolved ACL scope", async () => {
   assert.equal(harness.createdGames[0].leagueId, "league-1");
   assert.equal(harness.createdGames[0].seasonId, "season-1");
   assert.equal(harness.createdGames[0].sessionId, "session-abc");
+  assert.deepEqual(
+    harness.createdSeasonTeams.map((team) => team.teamId),
+    ["red", "blue", "yellow"],
+  );
+  assert.deepEqual(
+    harness.createdGameTeams.map((team) => team.teamId),
+    ["red", "blue", "yellow"],
+  );
+});
+
+test("core lambda lets scorekeepers quick-create and assign roster players", async () => {
+  const harness = createHarness({
+    sessions: {
+      "session-1": {
+        sessionId: "session-1",
+        email: "scorekeeper@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    games: {
+      "game-1": {
+        gameId: "game-1",
+        leagueId: "league-1",
+        seasonId: "season-1",
+        sessionId: "session-1",
+        status: "scheduled",
+        gameStartTs: "2026-02-23T10:00:00.000Z",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    seasons: {
+      "season-1": {
+        leagueId: "league-1",
+        seasonId: "season-1",
+        name: "Season 1",
+        slug: null,
+        startsOn: null,
+        endsOn: null,
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueAccess: {
+      "league-1:scorekeeper@example.com": {
+        leagueId: "league-1",
+        userId: "scorekeeper@example.com",
+        role: "scorekeeper",
+        grantedByUserId: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  const createPlayerResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/games/game-1/players",
+      headers: {
+        Cookie: "threefc_session=session-1",
+        "Idempotency-Key": "player-create-1",
+      },
+      body: {
+        playerId: "player-ari",
+        nickname: "Ari",
+      },
+    }),
+  );
+
+  assert.equal(createPlayerResponse.statusCode, 201);
+  assert.equal(harness.createdPlayers.length, 1);
+  assert.deepEqual(JSON.parse(createPlayerResponse.body), {
+    playerId: "player-ari",
+    nickname: "Ari",
+    createdAt: "2026-02-23T00:00:00.000Z",
+    updatedAt: "2026-02-23T00:00:00.000Z",
+  });
+  assert.deepEqual(harness.linkedGamePlayers[0], {
+    gameId: "game-1",
+    playerId: "player-ari",
+  });
+
+  const assignResponse = await harness.handler(
+    createEvent({
+      method: "PUT",
+      path: "/v1/games/game-1/roster/player-ari",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+      body: {
+        teamId: "red",
+      },
+    }),
+  );
+
+  assert.equal(assignResponse.statusCode, 200);
+  assert.equal(harness.assignedRosterPlayers.length, 1);
+  assert.equal(harness.assignedRosterPlayers[0].teamId, "red");
+
+  const rosterResponse = await harness.handler(
+    createEvent({
+      method: "GET",
+      path: "/v1/games/game-1/roster",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+    }),
+  );
+
+  assert.equal(rosterResponse.statusCode, 200);
+  const rosterBody = JSON.parse(rosterResponse.body) as {
+    teams: Array<{ teamId: string }>;
+    roster: Array<{ playerId: string; teamId: string; player: { nickname: string } | null }>;
+  };
+  assert.deepEqual(rosterBody.teams.map((team) => team.teamId), ["red", "blue", "yellow"]);
+  assert.deepEqual(rosterBody.roster, [
+    {
+      gameId: "game-1",
+      teamId: "red",
+      playerId: "player-ari",
+      createdAt: "2026-02-23T00:00:00.000Z",
+      updatedAt: "2026-02-23T00:00:00.000Z",
+      player: {
+        playerId: "player-ari",
+        nickname: "Ari",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  ]);
+});
+
+test("core lambda team and roster read routes do not create team records", async () => {
+  const harness = createHarness({
+    sessions: {
+      "session-1": {
+        sessionId: "session-1",
+        email: "viewer@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    games: {
+      "game-1": {
+        gameId: "game-1",
+        leagueId: "league-1",
+        seasonId: "season-1",
+        sessionId: "session-1",
+        status: "scheduled",
+        gameStartTs: "2026-02-23T10:00:00.000Z",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    seasons: {
+      "season-1": {
+        leagueId: "league-1",
+        seasonId: "season-1",
+        name: "Season 1",
+        slug: null,
+        startsOn: null,
+        endsOn: null,
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueAccess: {
+      "league-1:viewer@example.com": {
+        leagueId: "league-1",
+        userId: "viewer@example.com",
+        role: "viewer",
+        grantedByUserId: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  for (const path of [
+    "/v1/seasons/season-1/teams",
+    "/v1/games/game-1/teams",
+    "/v1/games/game-1/roster",
+  ]) {
+    const response = await harness.handler(
+      createEvent({
+        method: "GET",
+        path,
+        headers: {
+          Cookie: "threefc_session=session-1",
+        },
+      }),
+    );
+
+    assert.equal(response.statusCode, 200);
+    const body = JSON.parse(response.body) as { teams?: Array<{ teamId: string }> };
+    assert.deepEqual(body.teams?.map((team) => team.teamId), ["red", "blue", "yellow"]);
+  }
+
+  assert.equal(harness.createdSeasonTeams.length, 0);
+  assert.equal(harness.createdGameTeams.length, 0);
+});
+
+test("core lambda game player list is game-scoped and public", async () => {
+  const harness = createHarness({
+    sessions: {
+      "session-1": {
+        sessionId: "session-1",
+        email: "scorekeeper@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    games: {
+      "game-1": {
+        gameId: "game-1",
+        leagueId: "league-1",
+        seasonId: "season-1",
+        sessionId: "session-1",
+        status: "scheduled",
+        gameStartTs: "2026-02-23T10:00:00.000Z",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+      "game-2": {
+        gameId: "game-2",
+        leagueId: "league-2",
+        seasonId: "season-2",
+        sessionId: "session-2",
+        status: "scheduled",
+        gameStartTs: "2026-02-24T10:00:00.000Z",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    seasons: {
+      "season-1": {
+        leagueId: "league-1",
+        seasonId: "season-1",
+        name: "Season 1",
+        slug: null,
+        startsOn: null,
+        endsOn: null,
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+      "season-2": {
+        leagueId: "league-2",
+        seasonId: "season-2",
+        name: "Season 2",
+        slug: null,
+        startsOn: null,
+        endsOn: null,
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueAccess: {
+      "league-1:scorekeeper@example.com": {
+        leagueId: "league-1",
+        userId: "scorekeeper@example.com",
+        role: "scorekeeper",
+        grantedByUserId: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    players: {
+      "player-game-1": {
+        playerId: "player-game-1",
+        nickname: "Ari",
+        claimedByUserId: "ari@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+      "player-game-2": {
+        playerId: "player-game-2",
+        nickname: "Bao",
+        claimedByUserId: "bao@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+      "player-unlinked": {
+        playerId: "player-unlinked",
+        nickname: "Cy",
+        claimedByUserId: "cy@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    gamePlayers: {
+      "game-1:player-game-1": {
+        gameId: "game-1",
+        playerId: "player-game-1",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+      "game-2:player-game-2": {
+        gameId: "game-2",
+        playerId: "player-game-2",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    rosterAssignments: {
+      "game-1:player-game-1": {
+        gameId: "game-1",
+        playerId: "player-game-1",
+        teamId: "red",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  const playersResponse = await harness.handler(
+    createEvent({
+      method: "GET",
+      path: "/v1/games/game-1/players",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+    }),
+  );
+
+  assert.equal(playersResponse.statusCode, 200);
+  assert.deepEqual(JSON.parse(playersResponse.body), {
+    players: [
+      {
+        playerId: "player-game-1",
+        nickname: "Ari",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    ],
+  });
+  assert.equal(playersResponse.body.includes("claimedByUserId"), false);
+
+  const rosterResponse = await harness.handler(
+    createEvent({
+      method: "GET",
+      path: "/v1/games/game-1/roster",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+    }),
+  );
+
+  assert.equal(rosterResponse.statusCode, 200);
+  assert.equal(rosterResponse.body.includes("claimedByUserId"), false);
 });
 
 test("core lambda deduplicates repeated create league request by idempotency key", async () => {

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -168,11 +168,26 @@ test("repository supports round-trip create/read for core entities", async () =>
   });
   assert.deepEqual(await repository.getGame("game-1"), game);
 
+  const gameTeam = await repository.createGameTeamOverride({
+    gameId: "game-1",
+    teamId: "red",
+    name: "Game Red",
+    color: "#d83b36",
+  });
+  assert.deepEqual(await repository.listTeamsForGame("game-1"), [gameTeam]);
+
   const player = await repository.createPlayer({
     playerId: "player-1",
     nickname: "AJ",
   });
   assert.deepEqual(await repository.getPlayer("player-1"), player);
+  assert.deepEqual(await repository.listPlayers({ search: "aj" }), [player]);
+
+  const gamePlayer = await repository.linkGamePlayer({
+    gameId: "game-1",
+    playerId: "player-1",
+  });
+  assert.deepEqual(await repository.listGamePlayers("game-1"), [gamePlayer]);
 
   const accessGrant = await repository.grantLeagueAccess({
     leagueId: "league-1",
@@ -194,6 +209,15 @@ test("repository supports round-trip create/read for core entities", async () =>
     playerId: "player-1",
   });
   assert.deepEqual(await repository.listGameRoster("game-1"), [rosterAssignment]);
+  assert.equal((await repository.listGamePlayers("game-1")).length, 1);
+
+  const reassignedRoster = await repository.assignRosterPlayer({
+    gameId: "game-1",
+    teamId: "blue",
+    playerId: "player-1",
+  });
+  assert.deepEqual(await repository.listGameRoster("game-1"), [reassignedRoster]);
+  assert.equal(reassignedRoster.teamId, "blue");
 });
 
 test("repository query supports deterministic session->games ordering", async () => {

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -5,6 +5,7 @@ import { resolve } from "node:path";
 import test from "node:test";
 
 import { JSDOM } from "jsdom";
+import type { TeamId } from "@3fc/contracts";
 
 import {
   renderGamePage,
@@ -61,6 +62,39 @@ interface MockGame {
   updatedAt: string;
 }
 
+interface MockTeam {
+  gameId?: string;
+  seasonId?: string;
+  teamId: TeamId;
+  name: string;
+  color: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface MockPlayer {
+  playerId: string;
+  nickname: string;
+  claimedByUserId: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface MockRosterAssignment {
+  gameId: string;
+  teamId: TeamId;
+  playerId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface MockGamePlayer {
+  gameId: string;
+  playerId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 interface MockApiState {
   cookieJar: string;
   storage: Map<string, string>;
@@ -71,6 +105,11 @@ interface MockApiState {
   seasons: Map<string, MockSeason>;
   sessions: Map<string, MockSessionEntity>;
   games: Map<string, MockGame>;
+  seasonTeams: Map<string, MockTeam>;
+  gameTeams: Map<string, MockTeam>;
+  players: Map<string, MockPlayer>;
+  gamePlayers: Map<string, MockGamePlayer>;
+  roster: Map<string, MockRosterAssignment>;
 }
 
 function readUiScript(fileName: string): string {
@@ -88,6 +127,11 @@ function createMockApiState(): MockApiState {
     seasons: new Map<string, MockSeason>(),
     sessions: new Map<string, MockSessionEntity>(),
     games: new Map<string, MockGame>(),
+    seasonTeams: new Map<string, MockTeam>(),
+    gameTeams: new Map<string, MockTeam>(),
+    players: new Map<string, MockPlayer>(),
+    gamePlayers: new Map<string, MockGamePlayer>(),
+    roster: new Map<string, MockRosterAssignment>(),
   };
 }
 
@@ -111,6 +155,62 @@ function isValidEmail(value: unknown): value is string {
 
 function isAuthenticated(state: MockApiState): boolean {
   return Boolean(state.session && state.cookieJar.includes(`threefc_session=${state.session.sessionId}`));
+}
+
+const DEFAULT_MOCK_TEAMS: Array<{ teamId: TeamId; name: string; color: string }> = [
+  { teamId: "red", name: "Red", color: "#d83b36" },
+  { teamId: "blue", name: "Blue", color: "#2364d2" },
+  { teamId: "yellow", name: "Yellow", color: "#e0a612" },
+];
+
+function ensureSeasonTeams(state: MockApiState, seasonId: string): MockTeam[] {
+  for (const team of DEFAULT_MOCK_TEAMS) {
+    const key = `${seasonId}:${team.teamId}`;
+    if (state.seasonTeams.has(key)) {
+      continue;
+    }
+
+    state.seasonTeams.set(key, {
+      seasonId,
+      teamId: team.teamId,
+      name: team.name,
+      color: team.color,
+      createdAt: "2026-03-28T11:00:05.000Z",
+      updatedAt: "2026-03-28T11:00:05.000Z",
+    });
+  }
+
+  return [...state.seasonTeams.values()].filter((team) => team.seasonId === seasonId);
+}
+
+function ensureGameTeams(state: MockApiState, game: MockGame): MockTeam[] {
+  const seasonTeams = ensureSeasonTeams(state, game.seasonId);
+  for (const team of seasonTeams) {
+    const key = `${game.gameId}:${team.teamId}`;
+    if (state.gameTeams.has(key)) {
+      continue;
+    }
+
+    state.gameTeams.set(key, {
+      gameId: game.gameId,
+      teamId: team.teamId,
+      name: team.name,
+      color: team.color,
+      createdAt: "2026-03-28T11:00:06.000Z",
+      updatedAt: "2026-03-28T11:00:06.000Z",
+    });
+  }
+
+  return [...state.gameTeams.values()].filter((team) => team.gameId === game.gameId);
+}
+
+function publicPlayer(player: MockPlayer): Omit<MockPlayer, "claimedByUserId"> {
+  return {
+    playerId: player.playerId,
+    nickname: player.nickname,
+    createdAt: player.createdAt,
+    updatedAt: player.updatedAt,
+  };
 }
 
 function createMockFetch(state: MockApiState) {
@@ -319,6 +419,7 @@ function createMockFetch(state: MockApiState) {
         updatedAt: now,
       };
       state.games.set(gameId, game);
+      ensureGameTeams(state, game);
       return createJsonResponse(201, game);
     }
 
@@ -330,6 +431,111 @@ function createMockFetch(state: MockApiState) {
       }
 
       return createJsonResponse(200, game);
+    }
+
+    const gameRosterMatch = path.match(/^\/v1\/games\/([^/]+)\/roster$/);
+    if (method === "GET" && gameRosterMatch) {
+      const game = state.games.get(decodeURIComponent(gameRosterMatch[1]));
+      if (!game) {
+        return createJsonResponse(404, { error: "not_found", message: "Game not found." });
+      }
+
+      const teams = ensureGameTeams(state, game);
+      const roster = [...state.roster.values()]
+        .filter((assignment) => assignment.gameId === game.gameId)
+        .map((assignment) => ({
+          ...assignment,
+          player: state.players.get(assignment.playerId)
+            ? publicPlayer(state.players.get(assignment.playerId) as MockPlayer)
+            : null,
+        }));
+
+      return createJsonResponse(200, {
+        teams,
+        roster,
+      });
+    }
+
+    const gamePlayersMatch = path.match(/^\/v1\/games\/([^/]+)\/players$/);
+    if (method === "GET" && gamePlayersMatch) {
+      const game = state.games.get(decodeURIComponent(gamePlayersMatch[1]));
+      if (!game) {
+        return createJsonResponse(404, { error: "not_found", message: "Game not found." });
+      }
+
+      const search = target.searchParams.get("search")?.toLowerCase() ?? "";
+      const linkedPlayerIds = new Set(
+        [...state.gamePlayers.values()]
+          .filter((link) => link.gameId === game.gameId)
+          .map((link) => link.playerId),
+      );
+      const players = [...state.players.values()]
+        .filter((player) => linkedPlayerIds.has(player.playerId))
+        .filter((player) => search.length === 0 || player.nickname.toLowerCase().includes(search))
+        .map((player) => publicPlayer(player));
+      return createJsonResponse(200, {
+        players,
+      });
+    }
+
+    if (method === "POST" && gamePlayersMatch) {
+      const game = state.games.get(decodeURIComponent(gamePlayersMatch[1]));
+      if (!game) {
+        return createJsonResponse(404, { error: "not_found", message: "Game not found." });
+      }
+
+      const playerId = String(body.playerId ?? "");
+      const now = "2026-03-28T11:00:07.000Z";
+      const player: MockPlayer = {
+        playerId,
+        nickname: String(body.nickname ?? ""),
+        claimedByUserId: null,
+        createdAt: now,
+        updatedAt: now,
+      };
+      state.players.set(playerId, player);
+      state.gamePlayers.set(`${game.gameId}:${playerId}`, {
+        gameId: game.gameId,
+        playerId,
+        createdAt: now,
+        updatedAt: now,
+      });
+      return createJsonResponse(201, publicPlayer(player));
+    }
+
+    const rosterAssignMatch = path.match(/^\/v1\/games\/([^/]+)\/roster\/([^/]+)$/);
+    if (method === "PUT" && rosterAssignMatch) {
+      const gameId = decodeURIComponent(rosterAssignMatch[1]);
+      const playerId = decodeURIComponent(rosterAssignMatch[2]);
+      const game = state.games.get(gameId);
+      if (!game) {
+        return createJsonResponse(404, { error: "not_found", message: "Game not found." });
+      }
+
+      const player = state.players.get(playerId);
+      if (!player) {
+        return createJsonResponse(404, { error: "not_found", message: "Player not found." });
+      }
+
+      const now = "2026-03-28T11:00:08.000Z";
+      const assignment: MockRosterAssignment = {
+        gameId,
+        playerId,
+        teamId: body.teamId as TeamId,
+        createdAt: now,
+        updatedAt: now,
+      };
+      state.roster.set(`${gameId}:${playerId}`, assignment);
+      state.gamePlayers.set(`${gameId}:${playerId}`, {
+        gameId,
+        playerId,
+        createdAt: now,
+        updatedAt: now,
+      });
+      return createJsonResponse(200, {
+        ...assignment,
+        player: publicPlayer(player),
+      });
     }
 
     return createJsonResponse(404, {
@@ -655,6 +861,72 @@ test("setup happy path runs from sign-in to created game context", async () => {
   assert.equal(leagueId?.textContent, "three-sided-football-club");
   assert.equal(seasonId?.textContent, "autumn-cup");
   assert.equal(createAnotherLink?.getAttribute("href"), "/seasons/autumn-cup");
+});
+
+test("game page quick-creates and assigns roster players", async () => {
+  const apiState = createMockApiState();
+  apiState.session = {
+    sessionId: "session-1",
+    email: "scorekeeper@3fc.football",
+    createdAt: "2026-03-28T11:00:00.000Z",
+    expiresAt: "2026-03-29T11:00:00.000Z",
+  };
+  apiState.cookieJar = "threefc_session=session-1";
+  apiState.seasons.set("autumn-cup", {
+    leagueId: "three-sided-football-club",
+    seasonId: "autumn-cup",
+    name: "Autumn Cup",
+    slug: "autumn-cup",
+    startsOn: null,
+    endsOn: null,
+    createdAt: "2026-03-28T11:00:02.000Z",
+    updatedAt: "2026-03-28T11:00:02.000Z",
+  });
+  apiState.games.set("game-1", {
+    gameId: "game-1",
+    leagueId: "three-sided-football-club",
+    seasonId: "autumn-cup",
+    sessionId: "20260328",
+    status: "scheduled",
+    gameStartTs: "2026-03-28T10:00:00.000Z",
+    createdAt: "2026-03-28T11:00:03.000Z",
+    updatedAt: "2026-03-28T11:00:03.000Z",
+  });
+
+  const gamePage = await bootPage({
+    html: renderGamePage("http://localhost:3001", { gameId: "game-1" }),
+    url: "http://localhost:3000/games/game-1",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+
+  const nicknameInput = gamePage.document.getElementById("player-nickname");
+  const quickCreateButton = gamePage.document.querySelector('[data-action="quick-create-player"]');
+  const rosterTeams = gamePage.document.getElementById("roster-teams");
+  assert(nicknameInput instanceof gamePage.window.HTMLInputElement);
+  assert(quickCreateButton instanceof gamePage.window.HTMLButtonElement);
+  assert(rosterTeams instanceof gamePage.window.HTMLElement);
+  assert.match(rosterTeams.textContent ?? "", /Red/);
+
+  nicknameInput.value = "Ari";
+  nicknameInput.dispatchEvent(new gamePage.window.Event("input", { bubbles: true }));
+  dispatchClick(quickCreateButton);
+  await flushAsync();
+
+  const createdPlayer = [...apiState.players.values()][0];
+  assert(createdPlayer);
+  assert.equal(createdPlayer.nickname, "Ari");
+
+  const assignRedButton = gamePage.document.querySelector(
+    `[data-action="assign-player"][data-player-id="${createdPlayer.playerId}"][data-team-id="red"]`,
+  );
+  assert(assignRedButton instanceof gamePage.window.HTMLButtonElement);
+  dispatchClick(assignRedButton);
+  await flushAsync();
+
+  const assignment = apiState.roster.get(`game-1:${createdPlayer.playerId}`);
+  assert.equal(assignment?.teamId, "red");
+  assert.match(rosterTeams.textContent ?? "", /Ari/);
 });
 
 test("setup flow resolves route ids from static shells", async () => {

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -328,6 +328,23 @@ function createMockFetch(state: MockApiState) {
       return createJsonResponse(200, league);
     }
 
+    if (method === "DELETE" && leagueMatch) {
+      const leagueId = decodeURIComponent(leagueMatch[1]);
+      if (![...state.leagues.keys()].includes(leagueId)) {
+        return createJsonResponse(404, { error: "not_found", message: "League not found." });
+      }
+
+      if ([...state.seasons.values()].some((season) => season.leagueId === leagueId)) {
+        return createJsonResponse(409, {
+          error: "conflict",
+          message: "Cannot delete league with existing seasons.",
+        });
+      }
+
+      state.leagues.delete(leagueId);
+      return new Response(null, { status: 204 });
+    }
+
     const leagueSeasonsMatch = path.match(/^\/v1\/leagues\/([^/]+)\/seasons$/);
     if (method === "GET" && leagueSeasonsMatch) {
       const leagueId = decodeURIComponent(leagueSeasonsMatch[1]);
@@ -366,6 +383,23 @@ function createMockFetch(state: MockApiState) {
       }
 
       return createJsonResponse(200, season);
+    }
+
+    if (method === "DELETE" && seasonMatch) {
+      const seasonId = decodeURIComponent(seasonMatch[1]);
+      if (![...state.seasons.keys()].includes(seasonId)) {
+        return createJsonResponse(404, { error: "not_found", message: "Season not found." });
+      }
+
+      if ([...state.games.values()].some((game) => game.seasonId === seasonId)) {
+        return createJsonResponse(409, {
+          error: "conflict",
+          message: "Cannot delete season with existing games.",
+        });
+      }
+
+      state.seasons.delete(seasonId);
+      return new Response(null, { status: 204 });
     }
 
     const seasonGamesMatch = path.match(/^\/v1\/seasons\/([^/]+)\/games$/);
@@ -861,6 +895,92 @@ test("setup happy path runs from sign-in to created game context", async () => {
   assert.equal(leagueId?.textContent, "three-sided-football-club");
   assert.equal(seasonId?.textContent, "autumn-cup");
   assert.equal(createAnotherLink?.getAttribute("href"), "/seasons/autumn-cup");
+});
+
+test("league page header delete button deletes an empty league", async () => {
+  const apiState = createMockApiState();
+  apiState.session = {
+    sessionId: "session-1",
+    email: "organizer@3fc.football",
+    createdAt: "2026-03-28T11:00:00.000Z",
+    expiresAt: "2026-03-29T11:00:00.000Z",
+  };
+  apiState.cookieJar = "threefc_session=session-1";
+  apiState.leagues.set("empty-league", {
+    leagueId: "empty-league",
+    name: "Empty League",
+    slug: "empty-league",
+    createdByUserId: apiState.session.email,
+    createdAt: "2026-03-28T11:00:01.000Z",
+    updatedAt: "2026-03-28T11:00:01.000Z",
+  });
+
+  const page = await bootPage({
+    html: renderLeaguePage("http://localhost:3001", "empty-league"),
+    url: "http://localhost:3000/leagues/empty-league",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+  Object.defineProperty(page.window, "confirm", {
+    value: () => true,
+    configurable: true,
+  });
+
+  const deleteLeagueButton = page.document.querySelector('[data-testid="delete-league"]');
+  assert(deleteLeagueButton instanceof page.window.HTMLButtonElement);
+  dispatchClick(deleteLeagueButton);
+  await flushAsync();
+
+  assert.equal(apiState.leagues.has("empty-league"), false);
+  assert.equal(page.navigations.at(-1)?.url, "/setup");
+});
+
+test("season page header delete button deletes an empty season", async () => {
+  const apiState = createMockApiState();
+  apiState.session = {
+    sessionId: "session-1",
+    email: "organizer@3fc.football",
+    createdAt: "2026-03-28T11:00:00.000Z",
+    expiresAt: "2026-03-29T11:00:00.000Z",
+  };
+  apiState.cookieJar = "threefc_session=session-1";
+  apiState.leagues.set("three-sided-football-club", {
+    leagueId: "three-sided-football-club",
+    name: "Three Sided Football Club",
+    slug: "three-sided-football-club",
+    createdByUserId: apiState.session.email,
+    createdAt: "2026-03-28T11:00:01.000Z",
+    updatedAt: "2026-03-28T11:00:01.000Z",
+  });
+  apiState.seasons.set("autumn-cup", {
+    leagueId: "three-sided-football-club",
+    seasonId: "autumn-cup",
+    name: "Autumn Cup",
+    slug: "autumn-cup",
+    startsOn: null,
+    endsOn: null,
+    createdAt: "2026-03-28T11:00:02.000Z",
+    updatedAt: "2026-03-28T11:00:02.000Z",
+  });
+
+  const page = await bootPage({
+    html: renderSeasonPage("http://localhost:3001", "autumn-cup"),
+    url: "http://localhost:3000/seasons/autumn-cup",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+  Object.defineProperty(page.window, "confirm", {
+    value: () => true,
+    configurable: true,
+  });
+
+  const deleteSeasonButton = page.document.querySelector('[data-testid="delete-season"]');
+  assert(deleteSeasonButton instanceof page.window.HTMLButtonElement);
+  dispatchClick(deleteSeasonButton);
+  await flushAsync();
+
+  assert.equal(apiState.seasons.has("autumn-cup"), false);
+  assert.equal(page.navigations.at(-1)?.url, "/leagues/three-sided-football-club");
 });
 
 test("game page quick-creates and assigns roster players", async () => {

--- a/app/src/tests/ui-layout.test.ts
+++ b/app/src/tests/ui-layout.test.ts
@@ -98,6 +98,28 @@ test("setup home page includes stepwise setup panels and setup-flow script", () 
   assert.match(html, /https:\/\/qa-api\.3fc\.football/);
 });
 
+test("setup pages can version UI asset URLs for deployments", () => {
+  const previousVersion = process.env.THREEFC_ASSET_VERSION;
+  process.env.THREEFC_ASSET_VERSION = "abc1234";
+
+  try {
+    const setupHtml = renderSetupHomePage("https://qa-api.3fc.football");
+    const signInHtml = renderSignInPage("https://qa-api.3fc.football", "/setup");
+    const componentHtml = renderComponentShowcasePage("https://qa-api.3fc.football");
+
+    assert.match(setupHtml, /href="\/ui\/styles\.css\?v=abc1234"/);
+    assert.match(setupHtml, /<script src="\/ui\/setup-flow\.js\?v=abc1234" defer><\/script>/);
+    assert.match(signInHtml, /<script src="\/ui\/auth-flow\.js\?v=abc1234" defer><\/script>/);
+    assert.match(componentHtml, /<script src="\/ui\/modal\.js\?v=abc1234" defer><\/script>/);
+  } finally {
+    if (previousVersion === undefined) {
+      delete process.env.THREEFC_ASSET_VERSION;
+    } else {
+      process.env.THREEFC_ASSET_VERSION = previousVersion;
+    }
+  }
+});
+
 test("league page includes season create form and seasons table", () => {
   const html = renderLeaguePage("https://qa-api.3fc.football", "league-1");
 

--- a/app/src/tests/ui-layout.test.ts
+++ b/app/src/tests/ui-layout.test.ts
@@ -173,4 +173,7 @@ test("game page renders editable game metadata view", () => {
   assert.match(html, /data-testid="save-game"/);
   assert.match(html, /data-testid="delete-game"/);
   assert.match(html, /data-testid="create-another-game"/);
+  assert.match(html, /data-testid="panel-game-roster"/);
+  assert.match(html, /data-testid="quick-create-player"/);
+  assert.match(html, /data-testid="roster-teams"/);
 });

--- a/app/src/ui/layout.ts
+++ b/app/src/ui/layout.ts
@@ -19,20 +19,29 @@ function escapeHtml(value: string): string {
     .replaceAll("'", "&#39;");
 }
 
+function renderAssetPath(path: string): string {
+  const version = process.env.THREEFC_ASSET_VERSION?.trim();
+  if (!version) {
+    return path;
+  }
+
+  return `${path}?v=${encodeURIComponent(version)}`;
+}
+
 function renderStylesheetLink(): string {
-  return '<link rel="stylesheet" href="/ui/styles.css" />';
+  return `<link rel="stylesheet" href="${escapeHtml(renderAssetPath("/ui/styles.css"))}" />`;
 }
 
 function renderModalScriptTag(): string {
-  return '<script src="/ui/modal.js" defer></script>';
+  return `<script src="${escapeHtml(renderAssetPath("/ui/modal.js"))}" defer></script>`;
 }
 
 function renderSetupScriptTag(): string {
-  return '<script src="/ui/setup-flow.js" defer></script>';
+  return `<script src="${escapeHtml(renderAssetPath("/ui/setup-flow.js"))}" defer></script>`;
 }
 
 function renderAuthScriptTag(): string {
-  return '<script src="/ui/auth-flow.js" defer></script>';
+  return `<script src="${escapeHtml(renderAssetPath("/ui/auth-flow.js"))}" defer></script>`;
 }
 
 function renderSetupFoundationPanels(): string {

--- a/app/src/ui/layout.ts
+++ b/app/src/ui/layout.ts
@@ -692,6 +692,38 @@ export function renderGamePage(apiBaseUrl: string, input: GameContextPageInput):
             </div>`,
             "panel-game-details",
           )}
+          ${renderPanel(
+            "Roster setup",
+            "Create players and assign them to game teams.",
+            `${renderValidatedField({
+              id: "player-nickname",
+              label: "Player nickname",
+              placeholder: "Ari",
+            })}
+            <div data-ui="button-row">
+              ${renderButton("Create player", "primary", {
+                type: "button",
+                "data-action": "quick-create-player",
+                "data-testid": "quick-create-player",
+              })}
+            </div>
+            <div data-ui="field">
+              <label for="player-search">Search players</label>
+              <input data-ui="input" id="player-search" name="player-search" type="search" placeholder="Nickname" autocomplete="off" />
+            </div>
+            <div data-ui="roster-workspace" data-testid="roster-workspace">
+              <section data-ui="player-pool" aria-labelledby="player-pool-title">
+                <h3 id="player-pool-title">Players</h3>
+                <div id="player-pool" data-ui="player-list" data-testid="player-pool"></div>
+              </section>
+              <section data-ui="roster-board" aria-labelledby="roster-board-title">
+                <h3 id="roster-board-title">Teams</h3>
+                <div id="roster-teams" data-ui="roster-grid" data-testid="roster-teams"></div>
+              </section>
+            </div>`,
+            "",
+            "panel-game-roster",
+          )}
         </section>
       </section>
     </main>

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -468,7 +468,7 @@
 
     const title = document.getElementById("league-title");
     const subtitle = document.getElementById("league-subtitle");
-    const deleteLeagueButton = root.querySelector('[data-action="delete-league"]');
+    const deleteLeagueButton = document.querySelector('[data-testid="delete-league"]');
 
     const seasonNameInput = document.getElementById("season-name");
     const seasonFriendlyUrlInput = document.getElementById("season-friendly-url");
@@ -682,7 +682,7 @@
     const gameIdDisplay = document.getElementById("game-id-display");
     const createGameButton = root.querySelector('[data-action="create-game"]');
 
-    const deleteSeasonButton = root.querySelector('[data-action="delete-season"]');
+    const deleteSeasonButton = document.querySelector('[data-testid="delete-season"]');
 
     const gamesBody = document.getElementById("season-games-body");
     const gamesTableWrap = document.querySelector('[data-testid="season-games-table"]');

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -51,6 +51,18 @@
       .slice(0, 48);
   }
 
+  function initialsForName(value) {
+    const initials = value
+      .trim()
+      .split(/\s+/)
+      .filter((segment) => segment.length > 0)
+      .slice(0, 2)
+      .map((segment) => segment[0]?.toUpperCase() ?? "")
+      .join("");
+
+    return initials || "P";
+  }
+
   function setStatus(text, state = "default") {
     if (!statusElement) {
       return;
@@ -932,6 +944,11 @@
     const saveButton = root.querySelector('[data-action="save-game"]');
     const deleteButton = root.querySelector('[data-action="delete-game"]');
     const createAnotherLink = document.getElementById("create-another-game-link");
+    const playerNicknameInput = document.getElementById("player-nickname");
+    const quickCreatePlayerButton = root.querySelector('[data-action="quick-create-player"]');
+    const playerSearchInput = document.getElementById("player-search");
+    const playerPoolElement = document.getElementById("player-pool");
+    const rosterTeamsElement = document.getElementById("roster-teams");
 
     if (
       !(kickoffInput instanceof HTMLInputElement) ||
@@ -944,10 +961,159 @@
 
     let currentLeagueId = "";
     let currentSeasonId = "";
+    let rosterTeams = [];
+    let rosterPlayers = [];
+    let rosterAssignments = [];
+    let rosterSearchTimer = 0;
 
     kickoffInput.addEventListener("input", () => {
       setFieldMessage("game-edit-kickoff");
     });
+
+    function rosterControlsAvailable() {
+      return (
+        playerNicknameInput instanceof HTMLInputElement &&
+        quickCreatePlayerButton instanceof HTMLButtonElement &&
+        playerSearchInput instanceof HTMLInputElement &&
+        playerPoolElement instanceof HTMLElement &&
+        rosterTeamsElement instanceof HTMLElement
+      );
+    }
+
+    function teamById(teamId) {
+      return rosterTeams.find((team) => team.teamId === teamId) ?? null;
+    }
+
+    function playerById(playerId) {
+      const rosterPlayer = rosterAssignments.find((assignment) => assignment.playerId === playerId)?.player;
+      if (rosterPlayer) {
+        return rosterPlayer;
+      }
+
+      return rosterPlayers.find((player) => player.playerId === playerId) ?? null;
+    }
+
+    function assignmentByPlayerId(playerId) {
+      return rosterAssignments.find((assignment) => assignment.playerId === playerId) ?? null;
+    }
+
+    function teamSwatchStyle(team) {
+      const color = typeof team.color === "string" && team.color.length > 0 ? team.color : "#d9f0e8";
+      if (!/^#[0-9a-fA-F]{3,8}$/.test(color)) {
+        return "";
+      }
+
+      return ` style="--team-color: ${escapeHtml(color)}"`;
+    }
+
+    function assignmentButtons(playerId, currentTeamId = null) {
+      return rosterTeams
+        .map((team) => {
+          const active = currentTeamId === team.teamId ? ' data-state="active" aria-pressed="true"' : "";
+          return `<button data-ui="row-action" type="button" data-action="assign-player" data-player-id="${escapeHtml(
+            playerId,
+          )}" data-team-id="${escapeHtml(team.teamId)}"${active}>${escapeHtml(team.name)}</button>`;
+        })
+        .join("");
+    }
+
+    function renderPlayerPool() {
+      if (!(playerPoolElement instanceof HTMLElement)) {
+        return;
+      }
+
+      if (rosterPlayers.length === 0) {
+        playerPoolElement.innerHTML = `<p data-ui="empty-note">No players found.</p>`;
+        return;
+      }
+
+      playerPoolElement.innerHTML = rosterPlayers
+        .map((player) => {
+          const assignment = assignmentByPlayerId(player.playerId);
+          const assignedTeam = assignment ? teamById(assignment.teamId) : null;
+          const statusText = assignedTeam ? `Assigned to ${assignedTeam.name}` : "Unassigned";
+          return `<article data-ui="roster-player" data-player-id="${escapeHtml(player.playerId)}">
+            <figure data-ui="avatar"><span>${escapeHtml(initialsForName(player.nickname))}</span></figure>
+            <div data-ui="roster-player-main">
+              <strong>${escapeHtml(player.nickname)}</strong>
+              <span>${escapeHtml(statusText)}</span>
+            </div>
+            <div data-ui="row-action-buttons">
+              ${assignmentButtons(player.playerId, assignment?.teamId ?? null)}
+            </div>
+          </article>`;
+        })
+        .join("");
+    }
+
+    function renderRosterTeams() {
+      if (!(rosterTeamsElement instanceof HTMLElement)) {
+        return;
+      }
+
+      if (rosterTeams.length === 0) {
+        rosterTeamsElement.innerHTML = `<p data-ui="empty-note">No teams found.</p>`;
+        return;
+      }
+
+      rosterTeamsElement.innerHTML = rosterTeams
+        .map((team) => {
+          const assignments = rosterAssignments.filter((assignment) => assignment.teamId === team.teamId);
+          const players = assignments
+            .map((assignment) => {
+              const player = assignment.player ?? playerById(assignment.playerId);
+              const nickname = player?.nickname ?? assignment.playerId;
+              return `<li data-ui="roster-member">
+                <span>${escapeHtml(nickname)}</span>
+                <div data-ui="row-action-buttons">
+                  ${assignmentButtons(assignment.playerId, team.teamId)}
+                </div>
+              </li>`;
+            })
+            .join("");
+
+          return `<article data-ui="roster-team" data-team-id="${escapeHtml(team.teamId)}"${teamSwatchStyle(team)}>
+            <header>
+              <span data-ui="team-swatch"></span>
+              <h4>${escapeHtml(team.name)}</h4>
+              <span data-ui="roster-count">${assignments.length}</span>
+            </header>
+            <ul>
+              ${players || `<li data-ui="empty-note">No players assigned.</li>`}
+            </ul>
+          </article>`;
+        })
+        .join("");
+    }
+
+    function renderRosterSetup() {
+      renderPlayerPool();
+      renderRosterTeams();
+    }
+
+    async function loadRosterSetup(options = {}) {
+      if (!rosterControlsAvailable()) {
+        return;
+      }
+
+      const search = playerSearchInput.value.trim();
+      const searchQuery = search ? `?search=${encodeURIComponent(search)}` : "";
+      const [rosterPayload, playersPayload] = await Promise.all([
+        requestJsonOrThrow(`/v1/games/${encodeURIComponent(gameId)}/roster`, { method: "GET" }),
+        requestJsonOrThrow(`/v1/games/${encodeURIComponent(gameId)}/players${searchQuery}`, {
+          method: "GET",
+        }),
+      ]);
+
+      rosterTeams = Array.isArray(rosterPayload?.teams) ? rosterPayload.teams : [];
+      rosterAssignments = Array.isArray(rosterPayload?.roster) ? rosterPayload.roster : [];
+      rosterPlayers = Array.isArray(playersPayload?.players) ? playersPayload.players : [];
+      renderRosterSetup();
+
+      if (options.updateStatus !== false) {
+        setStatus("Game roster ready.", "success");
+      }
+    }
 
     async function loadGame() {
       const game = await requestJsonOrThrow(`/v1/games/${encodeURIComponent(gameId)}`, {
@@ -1049,7 +1215,117 @@
       }
     });
 
+    if (rosterControlsAvailable()) {
+      playerNicknameInput.addEventListener("input", () => {
+        setFieldMessage("player-nickname");
+      });
+
+      playerSearchInput.addEventListener("input", () => {
+        window.clearTimeout(rosterSearchTimer);
+        rosterSearchTimer = window.setTimeout(() => {
+          void loadRosterSetup({ updateStatus: false }).catch((error) => {
+            const message = error instanceof Error ? error.message : "Could not search players.";
+            showError(message);
+            setStatus("Player search failed.", "error");
+          });
+        }, 160);
+      });
+
+      quickCreatePlayerButton.addEventListener("click", async () => {
+        clearError();
+
+        const nickname = playerNicknameInput.value.trim();
+        if (!nickname) {
+          setFieldMessage("player-nickname", "invalid", "Player nickname is required.");
+          playerNicknameInput.focus();
+          return;
+        }
+
+        const nicknameSlug = slugify(nickname) || "player";
+        const playerId = `player-${nicknameSlug}-${randomSuffix(6)}`;
+        quickCreatePlayerButton.disabled = true;
+        setStatus("Creating player…", "default");
+
+        try {
+          await requestJsonOrThrow(`/v1/games/${encodeURIComponent(gameId)}/players`, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "Idempotency-Key": createIdempotencyKey("create-player", `${gameId}-${playerId}`),
+            },
+            body: JSON.stringify({
+              playerId,
+              nickname,
+            }),
+          });
+
+          playerNicknameInput.value = "";
+          playerSearchInput.value = "";
+          setFieldMessage("player-nickname", "valid", "Player created.");
+          await loadRosterSetup({ updateStatus: false });
+          setStatus("Player created.", "success");
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "Could not create player.";
+          showError(message);
+          setStatus("Player creation failed.", "error");
+        } finally {
+          quickCreatePlayerButton.disabled = false;
+        }
+      });
+
+      root.addEventListener("click", async (event) => {
+        const target = event.target;
+        if (!(target instanceof HTMLButtonElement)) {
+          return;
+        }
+
+        if (target.getAttribute("data-action") !== "assign-player") {
+          return;
+        }
+
+        const playerId = target.getAttribute("data-player-id");
+        const teamId = target.getAttribute("data-team-id");
+        if (!playerId || !teamId) {
+          return;
+        }
+
+        target.disabled = true;
+        clearError();
+        setStatus("Assigning player…", "default");
+
+        try {
+          await requestJsonOrThrow(
+            `/v1/games/${encodeURIComponent(gameId)}/roster/${encodeURIComponent(playerId)}`,
+            {
+              method: "PUT",
+              headers: {
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                teamId,
+              }),
+            },
+          );
+
+          await loadRosterSetup({ updateStatus: false });
+          const player = playerById(playerId);
+          const team = teamById(teamId);
+          setStatus(
+            `${player?.nickname ?? "Player"} assigned to ${team?.name ?? teamId}.`,
+            "success",
+          );
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "Could not assign player.";
+          showError(message);
+          setStatus("Roster assignment failed.", "error");
+        } finally {
+          target.disabled = false;
+        }
+      });
+    }
+
     await loadGame();
+    await loadRosterSetup({ updateStatus: false });
 
     try {
       const season = await requestJsonOrThrow(`/v1/seasons/${encodeURIComponent(currentSeasonId)}`, {

--- a/app/src/ui/styles.css
+++ b/app/src/ui/styles.css
@@ -453,6 +453,150 @@ body {
   }
 }
 
+[data-ui="roster-workspace"] {
+  display: grid;
+  gap: 0.85rem;
+}
+
+[data-ui="player-pool"],
+[data-ui="roster-board"] {
+  display: grid;
+  gap: 0.55rem;
+
+  h3 {
+    margin: 0;
+    font-size: 0.92rem;
+    color: #294f49;
+  }
+}
+
+[data-ui="player-list"] {
+  display: grid;
+  gap: 0.5rem;
+}
+
+[data-ui="roster-player"] {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.55rem;
+  align-items: center;
+  border: 1px solid #cce0d8;
+  border-radius: 10px;
+  background: #fbfefc;
+  padding: 0.55rem;
+
+  [data-ui="avatar"] {
+    grid-row: span 2;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 999px;
+    border: 1px solid #8db8a9;
+    background: #d9f0e8;
+    color: #0b534a;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 800;
+    margin: 0;
+  }
+
+  [data-ui="roster-player-main"] {
+    display: grid;
+    gap: 0.1rem;
+    min-width: 0;
+
+    strong,
+    span {
+      overflow-wrap: anywhere;
+    }
+
+    span {
+      color: var(--ink-soft);
+      font-size: 0.8rem;
+    }
+  }
+
+  [data-ui="row-action-buttons"] {
+    grid-column: 1 / -1;
+  }
+}
+
+[data-ui="roster-grid"] {
+  display: grid;
+  gap: 0.55rem;
+}
+
+[data-ui="roster-team"] {
+  --team-color: #8db8a9;
+  border: 1px solid #ccdeda;
+  border-radius: 10px;
+  background: #fbfdfc;
+  overflow: hidden;
+
+  > header {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 0.45rem;
+    border-bottom: 1px solid #e0ece8;
+    padding: 0.55rem 0.65rem;
+    background: #f4faf7;
+
+    h4 {
+      margin: 0;
+      font-size: 0.92rem;
+      overflow-wrap: anywhere;
+    }
+  }
+
+  [data-ui="team-swatch"] {
+    width: 0.85rem;
+    height: 0.85rem;
+    border-radius: 999px;
+    background: var(--team-color);
+    box-shadow: inset 0 0 0 1px rgba(29, 42, 47, 0.18);
+  }
+
+  [data-ui="roster-count"] {
+    min-width: 1.5rem;
+    border-radius: 999px;
+    padding: 0.1rem 0.42rem;
+    text-align: center;
+    background: #e7f2ee;
+    color: #294f49;
+    font-weight: 800;
+    font-size: 0.78rem;
+  }
+
+  ul {
+    display: grid;
+    gap: 0.4rem;
+    margin: 0;
+    padding: 0.55rem;
+    list-style: none;
+  }
+}
+
+[data-ui="roster-member"] {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.45rem;
+  border: 1px solid #d7e7e2;
+  border-radius: 8px;
+  background: #ffffff;
+
+  > span {
+    font-weight: 700;
+    overflow-wrap: anywhere;
+  }
+}
+
+[data-ui="empty-note"] {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 0.84rem;
+}
+
 [data-ui="table-wrap"] {
   overflow-x: auto;
   border: 1px solid #cadcd6;
@@ -544,6 +688,12 @@ body {
       border-color: #c46d62;
       background: #ffd9d2;
     }
+  }
+
+  &[data-state="active"] {
+    border-color: var(--accent);
+    background: var(--accent-soft);
+    color: var(--accent-strong);
   }
 }
 
@@ -692,6 +842,15 @@ code {
   }
 
   [data-ui="player-grid"] {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  [data-ui="roster-workspace"] {
+    grid-template-columns: minmax(16rem, 0.9fr) minmax(0, 1.1fr);
+    align-items: start;
+  }
+
+  [data-ui="roster-grid"] {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }

--- a/docs/openapi/v1-core-write.yaml
+++ b/docs/openapi/v1-core-write.yaml
@@ -3,7 +3,7 @@ info:
   title: 3FC Core Write API
   version: 0.1.0
   description: |
-    Authenticated core write routes for league/season/session/game creation.
+    Authenticated core write routes for league/season/session/game creation and M2 roster setup.
 servers:
   - url: https://qa-api.3fc.football
     description: QA
@@ -139,6 +139,257 @@ paths:
           $ref: "#/components/responses/NotFound"
         "409":
           $ref: "#/components/responses/IdempotencyConflict"
+  /v1/seasons/{seasonId}/teams:
+    get:
+      summary: List season default teams
+      operationId: listSeasonTeams
+      parameters:
+        - name: seasonId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Season teams
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - teams
+                properties:
+                  teams:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/SeasonTeam"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /v1/seasons/{seasonId}/teams/{teamId}:
+    put:
+      summary: Upsert season default team
+      operationId: upsertSeasonTeam
+      parameters:
+        - name: seasonId
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/TeamId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpsertTeamRequest"
+      responses:
+        "200":
+          description: Season team upserted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SeasonTeam"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /v1/games/{gameId}/teams:
+    get:
+      summary: List game teams
+      operationId: listGameTeams
+      parameters:
+        - name: gameId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Game teams
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - teams
+                properties:
+                  teams:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/GameTeam"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /v1/games/{gameId}/teams/{teamId}:
+    put:
+      summary: Upsert game team override
+      operationId: upsertGameTeam
+      parameters:
+        - name: gameId
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/TeamId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpsertTeamRequest"
+      responses:
+        "200":
+          description: Game team upserted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GameTeam"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /v1/games/{gameId}/players:
+    get:
+      summary: List recent/searchable players for a game roster
+      operationId: listGamePlayers
+      parameters:
+        - name: gameId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: search
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Player list
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - players
+                properties:
+                  players:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Player"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    post:
+      summary: Quick-create a nickname player in game setup
+      operationId: quickCreateGamePlayer
+      parameters:
+        - name: gameId
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/QuickCreateGamePlayerRequest"
+      responses:
+        "201":
+          description: Player created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Player"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/IdempotencyConflict"
+  /v1/games/{gameId}/roster:
+    get:
+      summary: Read game roster
+      operationId: listGameRoster
+      parameters:
+        - name: gameId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Game roster with teams and player nicknames
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GameRosterResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /v1/games/{gameId}/roster/{playerId}:
+    put:
+      summary: Assign or reassign a player to a game team
+      operationId: assignRosterPlayer
+      parameters:
+        - name: gameId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: playerId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AssignRosterPlayerRequest"
+      responses:
+        "200":
+          description: Roster assignment
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RosterAssignment"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
 components:
   parameters:
     IdempotencyKey:
@@ -150,6 +401,16 @@ components:
         minLength: 1
         maxLength: 128
       description: Optional idempotency key for replay-safe writes.
+    TeamId:
+      name: teamId
+      in: path
+      required: true
+      schema:
+        type: string
+        enum:
+          - red
+          - blue
+          - yellow
   responses:
     BadRequest:
       description: Request body or headers failed validation
@@ -256,6 +517,43 @@ components:
             - scheduled
             - live
             - finished
+    UpsertTeamRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          minLength: 1
+        color:
+          type:
+            - string
+            - "null"
+    QuickCreateGamePlayerRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - nickname
+      properties:
+        playerId:
+          type: string
+          minLength: 1
+        nickname:
+          type: string
+          minLength: 1
+    AssignRosterPlayerRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - teamId
+      properties:
+        teamId:
+          type: string
+          enum:
+            - red
+            - blue
+            - yellow
     League:
       type: object
       required:
@@ -373,6 +671,127 @@ components:
         updatedAt:
           type: string
           format: date-time
+    SeasonTeam:
+      type: object
+      required:
+        - seasonId
+        - teamId
+        - name
+        - color
+        - createdAt
+        - updatedAt
+      properties:
+        seasonId:
+          type: string
+        teamId:
+          type: string
+          enum:
+            - red
+            - blue
+            - yellow
+        name:
+          type: string
+        color:
+          type:
+            - string
+            - "null"
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    GameTeam:
+      type: object
+      required:
+        - gameId
+        - teamId
+        - name
+        - color
+        - createdAt
+        - updatedAt
+      properties:
+        gameId:
+          type: string
+        teamId:
+          type: string
+          enum:
+            - red
+            - blue
+            - yellow
+        name:
+          type: string
+        color:
+          type:
+            - string
+            - "null"
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    Player:
+      type: object
+      required:
+        - playerId
+        - nickname
+        - createdAt
+        - updatedAt
+      properties:
+        playerId:
+          type: string
+        nickname:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    RosterAssignment:
+      type: object
+      required:
+        - gameId
+        - teamId
+        - playerId
+        - createdAt
+        - updatedAt
+      properties:
+        gameId:
+          type: string
+        teamId:
+          type: string
+          enum:
+            - red
+            - blue
+            - yellow
+        playerId:
+          type: string
+        player:
+          anyOf:
+            - $ref: "#/components/schemas/Player"
+            - type: "null"
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    GameRosterResponse:
+      type: object
+      required:
+        - teams
+        - roster
+      properties:
+        teams:
+          type: array
+          items:
+            $ref: "#/components/schemas/GameTeam"
+        roster:
+          type: array
+          items:
+            $ref: "#/components/schemas/RosterAssignment"
     ErrorResponse:
       type: object
       additionalProperties: true

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,5 +1,31 @@
 export type TeamId = "red" | "blue" | "yellow";
 
+export const TEAM_IDS = ["red", "blue", "yellow"] as const satisfies readonly TeamId[];
+
+export interface DefaultTeamDefinition {
+  teamId: TeamId;
+  name: string;
+  color: string;
+}
+
+export const DEFAULT_TEAMS = [
+  {
+    teamId: "red",
+    name: "Red",
+    color: "#d83b36",
+  },
+  {
+    teamId: "blue",
+    name: "Blue",
+    color: "#2364d2",
+  },
+  {
+    teamId: "yellow",
+    name: "Yellow",
+    color: "#e0a612",
+  },
+] as const satisfies readonly DefaultTeamDefinition[];
+
 export interface GoalEventInput {
   gameId: string;
   third: 1 | 2 | 3;

--- a/scripts/deploy/deploy-site.sh
+++ b/scripts/deploy/deploy-site.sh
@@ -29,6 +29,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT_DIR"
 
 PROJECT_NAME="${PROJECT_NAME:-3fc}"
+COMMIT_SHA="$(git rev-parse --short HEAD)"
 
 case "$ENV" in
   qa)
@@ -54,7 +55,7 @@ echo "[deploy] Building workspaces"
 make build >/dev/null
 
 echo "[deploy] Exporting static site for ${ENV}"
-API_BASE_URL="$API_BASE_URL" STATIC_SITE_OUTPUT_DIR="$STATIC_SITE_OUTPUT_DIR" npm run export:static -w @3fc/app >/dev/null
+API_BASE_URL="$API_BASE_URL" THREEFC_ASSET_VERSION="$COMMIT_SHA" STATIC_SITE_OUTPUT_DIR="$STATIC_SITE_OUTPUT_DIR" npm run export:static -w @3fc/app >/dev/null
 
 if [[ ! -f "${STATIC_SITE_OUTPUT_DIR}/index.html" ]]; then
   echo "Static site export did not produce ${STATIC_SITE_OUTPUT_DIR}/index.html" >&2
@@ -103,7 +104,6 @@ aws cloudfront wait invalidation-completed \
   --distribution-id "$SITE_DISTRIBUTION_ID" \
   --id "$INVALIDATION_ID"
 
-COMMIT_SHA="$(git rev-parse --short HEAD)"
 TIMESTAMP="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 SITE_URL="https://${SITE_DOMAIN}"
 

--- a/serverless.api-core.yml
+++ b/serverless.api-core.yml
@@ -131,6 +131,18 @@ functions:
           method: OPTIONS
           path: /v1/seasons/{seasonId}/games
       - httpApi:
+          method: GET
+          path: /v1/seasons/{seasonId}/teams
+      - httpApi:
+          method: PUT
+          path: /v1/seasons/{seasonId}/teams/{teamId}
+      - httpApi:
+          method: OPTIONS
+          path: /v1/seasons/{seasonId}/teams/{teamId}
+      - httpApi:
+          method: OPTIONS
+          path: /v1/seasons/{seasonId}/teams
+      - httpApi:
           method: POST
           path: /v1/seasons/{seasonId}/sessions
       - httpApi:
@@ -148,6 +160,39 @@ functions:
       - httpApi:
           method: OPTIONS
           path: /v1/games/{gameId}
+      - httpApi:
+          method: GET
+          path: /v1/games/{gameId}/teams
+      - httpApi:
+          method: PUT
+          path: /v1/games/{gameId}/teams/{teamId}
+      - httpApi:
+          method: OPTIONS
+          path: /v1/games/{gameId}/teams
+      - httpApi:
+          method: OPTIONS
+          path: /v1/games/{gameId}/teams/{teamId}
+      - httpApi:
+          method: GET
+          path: /v1/games/{gameId}/players
+      - httpApi:
+          method: POST
+          path: /v1/games/{gameId}/players
+      - httpApi:
+          method: OPTIONS
+          path: /v1/games/{gameId}/players
+      - httpApi:
+          method: GET
+          path: /v1/games/{gameId}/roster
+      - httpApi:
+          method: PUT
+          path: /v1/games/{gameId}/roster/{playerId}
+      - httpApi:
+          method: OPTIONS
+          path: /v1/games/{gameId}/roster
+      - httpApi:
+          method: OPTIONS
+          path: /v1/games/{gameId}/roster/{playerId}
       - httpApi:
           method: POST
           path: /v1/sessions/{sessionId}/games


### PR DESCRIPTION
## Summary
- Add Red/Blue/Yellow default team contracts plus season and game team APIs.
- Add game-linked player quick-create/search and roster assignment APIs.
- Add the first mobile roster setup UI on the game page.
- Fix QA browser roster assignment by allowing `PUT` in CORS preflight responses.
- Fix league/season header delete buttons by binding the rendered hero buttons correctly.
- Version deployed static UI asset URLs with the commit SHA so QA deploys do not keep serving stale `setup-flow.js`.
- Wire new routes through Serverless and document them in OpenAPI.

## Validation
- `npm run test -w @3fc/api`
- `npm run test -w @3fc/app`
- `npm test`
- `git diff --check`
- `make backlog-validate`
- QA deploy succeeded: https://github.com/ajfisher/3fc/actions/runs/27894831469
- Manual QA retest passed on `https://qa.3fc.football`: create league -> season -> game -> player, assign player to Red, delete empty league from header, delete empty season from header after deleting its test game.
- implementation sub-agent pass completed
- review sub-agent pass completed, then rebrief/fix pass completed
- second review sub-agent pass accepted the fixes

## Stack Position
Base PR for the M2 stack. #88 should be rebased onto `main` after this lands.

## Known Follow-ups
- QR/self-registration join path remains for a later M2 slice.
- Timer, goal logging, timeline correction, finish game, and M2 E2E quality pack remain for subsequent stacked PRs.

Fixes #23
Part of #24
Part of #25