### PR TITLE
[codex] Add M2 third timer state

### DIFF
--- a/api/src/auth/acl.ts
+++ b/api/src/auth/acl.ts
@@ -9,6 +9,8 @@ const ROUTES = {
   updateGameTeam: /^\/v1\/games\/([^/]+)\/teams\/([^/]+)$/,
   createGamePlayer: /^\/v1\/games\/([^/]+)\/players$/,
   assignRosterPlayer: /^\/v1\/games\/([^/]+)\/roster\/([^/]+)$/,
+  startGameThird: /^\/v1\/games\/([^/]+)\/thirds\/([^/]*)\/start$/,
+  finishGameThird: /^\/v1\/games\/([^/]+)\/thirds\/([^/]*)\/finish$/,
 } as const;
 
 export type ProtectedMutationOperation =
@@ -19,7 +21,9 @@ export type ProtectedMutationOperation =
   | "updateSeasonTeam"
   | "updateGameTeam"
   | "createGamePlayer"
-  | "assignRosterPlayer";
+  | "assignRosterPlayer"
+  | "startGameThird"
+  | "finishGameThird";
 
 export interface ProtectedMutationRoute {
   operation: ProtectedMutationOperation;
@@ -116,6 +120,22 @@ export function resolveProtectedMutationRoute(
     return {
       operation: "assignRosterPlayer",
       gameId: decodeRouteParam(assignRosterPlayerMatch[1]),
+    };
+  }
+
+  const startGameThirdMatch = upperMethod === "POST" ? route.match(ROUTES.startGameThird) : null;
+  if (startGameThirdMatch) {
+    return {
+      operation: "startGameThird",
+      gameId: decodeRouteParam(startGameThirdMatch[1]),
+    };
+  }
+
+  const finishGameThirdMatch = upperMethod === "POST" ? route.match(ROUTES.finishGameThird) : null;
+  if (finishGameThirdMatch) {
+    return {
+      operation: "finishGameThird",
+      gameId: decodeRouteParam(finishGameThirdMatch[1]),
     };
   }
 

--- a/api/src/auth/session.ts
+++ b/api/src/auth/session.ts
@@ -103,6 +103,14 @@ export function isAuthenticatedApiRoute(method: string, route: string): boolean 
     return true;
   }
 
+  if (method === "POST" && /^\/v1\/games\/[^/]+\/thirds\/[^/]*\/start$/.test(route)) {
+    return true;
+  }
+
+  if (method === "POST" && /^\/v1\/games\/[^/]+\/thirds\/[^/]*\/finish$/.test(route)) {
+    return true;
+  }
+
   if (method === "GET" && route === "/v1/auth/session") {
     return true;
   }

--- a/api/src/contracts/core-write.ts
+++ b/api/src/contracts/core-write.ts
@@ -1,9 +1,14 @@
 import { z } from "zod";
-import { TEAM_IDS } from "@3fc/contracts";
+import { TEAM_IDS, THIRD_LENGTH_MINUTES } from "@3fc/contracts";
 
 const nonEmptyTrimmedString = z.string().trim().min(1, "must be a non-empty string");
 const optionalNullableString = z.string().nullable().optional();
 const teamIdSchema = z.enum(TEAM_IDS);
+const thirdLengthMinutesSchema = z.union([
+  z.literal(THIRD_LENGTH_MINUTES[0]),
+  z.literal(THIRD_LENGTH_MINUTES[1]),
+  z.literal(THIRD_LENGTH_MINUTES[2]),
+]);
 
 export const idempotencyKeyHeaderSchema = z
   .string()
@@ -41,6 +46,7 @@ export const createGameRequestSchema = z
     gameId: nonEmptyTrimmedString,
     gameStartTs: nonEmptyTrimmedString,
     status: z.enum(["scheduled", "live", "finished"]).optional(),
+    thirdLengthMinutes: thirdLengthMinutesSchema.optional(),
   })
   .strict();
 

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -661,6 +661,13 @@ export class ThreeFcRepository {
       );
     }
 
+    if (input.status === "scheduled" && isThirdStarted(existing)) {
+      throw new GameTimerTransitionError(
+        "timer_status_locked",
+        "Game status cannot be set back to scheduled after a third has started.",
+      );
+    }
+
     const updatedPayload = {
       ...existing,
       gameStartTs: nextGameStartTs,

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -9,7 +9,16 @@ import {
   type ScanCommandOutput,
   type AttributeValue,
 } from "@aws-sdk/client-dynamodb";
-import { validateAssistPlayerIds } from "@3fc/contracts";
+import {
+  createDefaultThirdTimerSegments,
+  DEFAULT_THIRD_LENGTH_MINUTES,
+  isThirdLengthMinutes,
+  THIRD_NUMBERS,
+  validateAssistPlayerIds,
+  type ThirdLengthMinutes,
+  type ThirdNumber,
+  type ThirdTimerSegment,
+} from "@3fc/contracts";
 
 import {
   aclSk,
@@ -58,6 +67,7 @@ import type {
   SessionRecord,
   TeamRecord,
   GrantLeagueAccessInput,
+  ThirdTransitionInput,
 } from "./types.js";
 
 const ENTITY_TYPE = {
@@ -94,12 +104,23 @@ interface StoredEntity<T> {
   entityType: EntityType;
   createdAt: string;
   updatedAt: string;
+  rawData: string;
   data: T;
 }
 
 class DefaultClock implements Clock {
   now(): string {
     return new Date().toISOString();
+  }
+}
+
+export class GameTimerTransitionError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "GameTimerTransitionError";
   }
 }
 
@@ -113,6 +134,56 @@ function requireGameMinute(gameMinute: number): void {
   if (!Number.isInteger(gameMinute) || gameMinute < 0) {
     throw new Error("gameMinute must be an integer greater than or equal to zero.");
   }
+}
+
+function requireThirdNumber(third: number): asserts third is ThirdNumber {
+  if (!THIRD_NUMBERS.includes(third as ThirdNumber)) {
+    throw new Error("third must be 1, 2, or 3.");
+  }
+}
+
+function normalizeThirdLengthMinutes(value: unknown): ThirdLengthMinutes {
+  return typeof value === "number" && isThirdLengthMinutes(value)
+    ? value
+    : DEFAULT_THIRD_LENGTH_MINUTES;
+}
+
+function normalizeThirdTimerSegments(value: unknown): ThirdTimerSegment[] {
+  const source = Array.isArray(value) ? value : [];
+
+  return THIRD_NUMBERS.map((third) => {
+    const matchingSegment = source.find(
+      (segment): segment is Partial<ThirdTimerSegment> =>
+        typeof segment === "object" &&
+        segment !== null &&
+        (segment as { third?: unknown }).third === third,
+    );
+
+    return {
+      third,
+      startedAt: typeof matchingSegment?.startedAt === "string" ? matchingSegment.startedAt : null,
+      finishedAt: typeof matchingSegment?.finishedAt === "string" ? matchingSegment.finishedAt : null,
+    };
+  });
+}
+
+function normalizeGamePayload(data: unknown): Omit<GameRecord, "createdAt" | "updatedAt"> {
+  const raw = data as Partial<Omit<GameRecord, "createdAt" | "updatedAt">>;
+
+  return {
+    gameId: raw.gameId ?? "",
+    leagueId: raw.leagueId ?? "",
+    seasonId: raw.seasonId ?? "",
+    sessionId: raw.sessionId ?? "",
+    status: raw.status ?? "scheduled",
+    gameStartTs: raw.gameStartTs ?? "",
+    thirdLengthMinutes: normalizeThirdLengthMinutes(raw.thirdLengthMinutes),
+    thirds: normalizeThirdTimerSegments(raw.thirds),
+  };
+}
+
+function isThirdStarted(game: Pick<GameRecord, "thirds">): boolean {
+  return game.thirds.some((third) => third.startedAt !== null);
 }
 
 function readString(value: AttributeValue | undefined, field: string): string {
@@ -159,6 +230,7 @@ function parseStoredEntity<T>(item: Item): StoredEntity<T> {
     entityType: readString(item.entityType, "entityType") as EntityType,
     createdAt: readString(item.createdAt, "createdAt"),
     updatedAt: readString(item.updatedAt, "updatedAt"),
+    rawData,
     data: JSON.parse(rawData) as T,
   };
 }
@@ -454,6 +526,8 @@ export class ThreeFcRepository {
       sessionId: input.sessionId,
       status: input.status ?? "scheduled",
       gameStartTs: input.gameStartTs,
+      thirdLengthMinutes: input.thirdLengthMinutes ?? DEFAULT_THIRD_LENGTH_MINUTES,
+      thirds: createDefaultThirdTimerSegments(),
     };
 
     await this.putEntity(gamePk(input.gameId), metadataSk(), ENTITY_TYPE.game, payload, now);
@@ -468,7 +542,7 @@ export class ThreeFcRepository {
       return null;
     }
 
-    return withTimestamps(item.data as Omit<GameRecord, "createdAt" | "updatedAt">, item.createdAt, item.updatedAt);
+    return withTimestamps(normalizeGamePayload(item.data), item.createdAt, item.updatedAt);
   }
 
   async createSessionGame(input: CreateSessionGameInput): Promise<SessionGameRecord> {
@@ -543,10 +617,15 @@ export class ThreeFcRepository {
     gameId: string;
     status?: GameRecord["status"];
     gameStartTs?: string;
+    thirdLengthMinutes?: ThirdLengthMinutes;
   }): Promise<GameRecord | null> {
     requireNonEmpty("gameId", input.gameId);
 
-    if (input.status === undefined && input.gameStartTs === undefined) {
+    if (
+      input.status === undefined &&
+      input.gameStartTs === undefined &&
+      input.thirdLengthMinutes === undefined
+    ) {
       throw new Error("At least one game field must be updated.");
     }
 
@@ -555,26 +634,60 @@ export class ThreeFcRepository {
       return null;
     }
 
-    const existing = gameItem.data as Omit<GameRecord, "createdAt" | "updatedAt">;
+    const existing = normalizeGamePayload(gameItem.data);
     const nextGameStartTs = input.gameStartTs ?? existing.gameStartTs;
     const nextStatus = input.status ?? existing.status;
+    const nextThirdLengthMinutes = input.thirdLengthMinutes ?? existing.thirdLengthMinutes;
+
+    if (
+      input.thirdLengthMinutes !== undefined &&
+      input.thirdLengthMinutes !== existing.thirdLengthMinutes &&
+      existing.status === "finished"
+    ) {
+      throw new GameTimerTransitionError(
+        "game_finished",
+        "Third length cannot be changed after the game is finished.",
+      );
+    }
+
+    if (
+      input.thirdLengthMinutes !== undefined &&
+      input.thirdLengthMinutes !== existing.thirdLengthMinutes &&
+      isThirdStarted(existing)
+    ) {
+      throw new GameTimerTransitionError(
+        "third_length_locked",
+        "Third length cannot be changed after a third has started.",
+      );
+    }
 
     const updatedPayload = {
       ...existing,
       gameStartTs: nextGameStartTs,
       status: nextStatus,
+      thirdLengthMinutes: nextThirdLengthMinutes,
     };
 
     const now = this.clock.now();
 
-    await this.putEntityWithTimestamps(
+    const gameUpdated = await this.putEntityWithTimestampsIfUnchanged(
       gamePk(existing.gameId),
       metadataSk(),
       ENTITY_TYPE.game,
       updatedPayload,
       gameItem.createdAt,
       now,
+      {
+        updatedAt: gameItem.updatedAt,
+        rawData: gameItem.rawData,
+      },
     );
+    if (!gameUpdated) {
+      throw new GameTimerTransitionError(
+        "game_state_changed",
+        "Game state changed while applying this update. Reload and try again.",
+      );
+    }
 
     const oldSessionGameSk = gameSessionIndexSk(existing.gameStartTs, existing.gameId);
     const oldSessionGameItem = await this.getEntity(
@@ -605,6 +718,150 @@ export class ThreeFcRepository {
     return withTimestamps(updatedPayload, gameItem.createdAt, now);
   }
 
+  async startGameThird(input: ThirdTransitionInput): Promise<GameRecord | null> {
+    requireNonEmpty("gameId", input.gameId);
+    requireThirdNumber(input.third);
+
+    const gameItem = await this.getEntity(gamePk(input.gameId), metadataSk());
+    if (!gameItem || gameItem.entityType !== ENTITY_TYPE.game) {
+      return null;
+    }
+
+    const existing = normalizeGamePayload(gameItem.data);
+    if (existing.status === "finished") {
+      throw new GameTimerTransitionError(
+        "game_finished",
+        "Cannot start a third after the game is finished.",
+      );
+    }
+
+    const thirds = existing.thirds.map((third) => ({ ...third }));
+    const target = thirds.find((third) => third.third === input.third);
+    if (!target) {
+      throw new GameTimerTransitionError("invalid_third", "Third must be 1, 2, or 3.");
+    }
+
+    if (target.startedAt) {
+      throw new GameTimerTransitionError(
+        "third_already_started",
+        `Third ${input.third} has already been started.`,
+      );
+    }
+
+    const runningThird = thirds.find((third) => third.startedAt && !third.finishedAt);
+    if (runningThird) {
+      throw new GameTimerTransitionError(
+        "third_already_running",
+        `Third ${runningThird.third} must be finished before another third can start.`,
+      );
+    }
+
+    const previousThirds = thirds.filter((third) => third.third < input.third);
+    const unfinishedPreviousThird = previousThirds.find((third) => !third.finishedAt);
+    if (unfinishedPreviousThird) {
+      throw new GameTimerTransitionError(
+        "previous_third_unfinished",
+        `Third ${unfinishedPreviousThird.third} must be finished before third ${input.third} can start.`,
+      );
+    }
+
+    const now = this.clock.now();
+    target.startedAt = now;
+    const updatedPayload = {
+      ...existing,
+      status: "live" as const,
+      thirds,
+    };
+
+    const transitionApplied = await this.putEntityWithTimestampsIfUnchanged(
+      gamePk(existing.gameId),
+      metadataSk(),
+      ENTITY_TYPE.game,
+      updatedPayload,
+      gameItem.createdAt,
+      now,
+      {
+        updatedAt: gameItem.updatedAt,
+        rawData: gameItem.rawData,
+      },
+    );
+    if (!transitionApplied) {
+      throw new GameTimerTransitionError(
+        "timer_state_changed",
+        "Timer state changed while applying this transition. Reload the game and try again.",
+      );
+    }
+
+    return withTimestamps(updatedPayload, gameItem.createdAt, now);
+  }
+
+  async finishGameThird(input: ThirdTransitionInput): Promise<GameRecord | null> {
+    requireNonEmpty("gameId", input.gameId);
+    requireThirdNumber(input.third);
+
+    const gameItem = await this.getEntity(gamePk(input.gameId), metadataSk());
+    if (!gameItem || gameItem.entityType !== ENTITY_TYPE.game) {
+      return null;
+    }
+
+    const existing = normalizeGamePayload(gameItem.data);
+    if (existing.status === "finished") {
+      throw new GameTimerTransitionError(
+        "game_finished",
+        "Cannot finish a third after the game is finished.",
+      );
+    }
+
+    const thirds = existing.thirds.map((third) => ({ ...third }));
+    const target = thirds.find((third) => third.third === input.third);
+    if (!target) {
+      throw new GameTimerTransitionError("invalid_third", "Third must be 1, 2, or 3.");
+    }
+
+    if (!target.startedAt) {
+      throw new GameTimerTransitionError(
+        "third_not_started",
+        `Third ${input.third} cannot be finished before it is started.`,
+      );
+    }
+
+    if (target.finishedAt) {
+      throw new GameTimerTransitionError(
+        "third_already_finished",
+        `Third ${input.third} has already been finished.`,
+      );
+    }
+
+    const now = this.clock.now();
+    target.finishedAt = now;
+    const updatedPayload = {
+      ...existing,
+      status: existing.status === "scheduled" ? ("live" as const) : existing.status,
+      thirds,
+    };
+
+    const transitionApplied = await this.putEntityWithTimestampsIfUnchanged(
+      gamePk(existing.gameId),
+      metadataSk(),
+      ENTITY_TYPE.game,
+      updatedPayload,
+      gameItem.createdAt,
+      now,
+      {
+        updatedAt: gameItem.updatedAt,
+        rawData: gameItem.rawData,
+      },
+    );
+    if (!transitionApplied) {
+      throw new GameTimerTransitionError(
+        "timer_state_changed",
+        "Timer state changed while applying this transition. Reload the game and try again.",
+      );
+    }
+
+    return withTimestamps(updatedPayload, gameItem.createdAt, now);
+  }
+
   async deleteGame(gameId: string): Promise<boolean> {
     requireNonEmpty("gameId", gameId);
 
@@ -613,7 +870,7 @@ export class ThreeFcRepository {
       return false;
     }
 
-    const game = gameItem.data as Omit<GameRecord, "createdAt" | "updatedAt">;
+    const game = normalizeGamePayload(gameItem.data);
 
     await this.deleteEntity(gamePk(gameId), metadataSk());
     await this.deleteEntity(
@@ -866,6 +1123,7 @@ export class ThreeFcRepository {
     requireNonEmpty("gameId", input.gameId);
     requireNonEmpty("eventId", input.eventId);
     requireNonEmpty("scorerPlayerId", input.scorerPlayerId);
+    requireThirdNumber(input.third);
     requireGameMinute(input.gameMinute);
 
     validateAssistPlayerIds(input.scorerPlayerId, input.assistPlayerIds);
@@ -1004,6 +1262,42 @@ export class ThreeFcRepository {
         Item: buildItemWithTimestamps(pk, sk, entityType, payload, createdAt, updatedAt),
       }),
     );
+  }
+
+  private async putEntityWithTimestampsIfUnchanged<T>(
+    pk: string,
+    sk: string,
+    entityType: EntityType,
+    payload: T,
+    createdAt: string,
+    updatedAt: string,
+    expected: { updatedAt: string; rawData: string },
+  ): Promise<boolean> {
+    try {
+      await this.client.send(
+        new PutItemCommand({
+          TableName: this.tableName,
+          Item: buildItemWithTimestamps(pk, sk, entityType, payload, createdAt, updatedAt),
+          ConditionExpression: "#updatedAt = :expectedUpdatedAt AND #data = :expectedData",
+          ExpressionAttributeNames: {
+            "#updatedAt": "updatedAt",
+            "#data": "data",
+          },
+          ExpressionAttributeValues: {
+            ":expectedUpdatedAt": { S: expected.updatedAt },
+            ":expectedData": { S: expected.rawData },
+          },
+        }),
+      );
+      return true;
+    } catch (error) {
+      const awsError = error as { name?: string };
+      if (awsError.name === "ConditionalCheckFailedException") {
+        return false;
+      }
+
+      throw error;
+    }
   }
 
   private async deleteEntity(pk: string, sk: string): Promise<void> {

--- a/api/src/data/types.ts
+++ b/api/src/data/types.ts
@@ -1,4 +1,4 @@
-import type { TeamId } from "@3fc/contracts";
+import type { TeamId, ThirdLengthMinutes, ThirdNumber, ThirdTimerSegment } from "@3fc/contracts";
 
 export type GameStatus = "scheduled" | "live" | "finished";
 export type LeagueRole = "admin" | "scorekeeper" | "viewer";
@@ -56,6 +56,8 @@ export interface GameRecord {
   sessionId: string;
   status: GameStatus;
   gameStartTs: string;
+  thirdLengthMinutes: ThirdLengthMinutes;
+  thirds: ThirdTimerSegment[];
   createdAt: string;
   updatedAt: string;
 }
@@ -169,6 +171,7 @@ export interface CreateGameInput {
   sessionId: string;
   status?: GameStatus;
   gameStartTs: string;
+  thirdLengthMinutes?: ThirdLengthMinutes;
 }
 
 export interface CreateSessionGameInput {
@@ -211,13 +214,18 @@ export interface AssignRosterInput {
 export interface CreateGoalEventInput {
   gameId: string;
   eventId: string;
-  third: 1 | 2 | 3;
+  third: ThirdNumber;
   gameMinute: number;
   scoringTeamId: TeamId | null;
   concedingTeamId: TeamId;
   scorerPlayerId: string;
   assistPlayerIds: string[];
   ownGoal: boolean;
+}
+
+export interface ThirdTransitionInput {
+  gameId: string;
+  third: ThirdNumber;
 }
 
 export interface CreateIdempotencyRecordInput {

--- a/api/src/lambda-core.ts
+++ b/api/src/lambda-core.ts
@@ -2,7 +2,16 @@ import { createHash, randomUUID } from "node:crypto";
 
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { SESv2Client, SendEmailCommand } from "@aws-sdk/client-sesv2";
-import { DEFAULT_TEAMS, TEAM_IDS, type TeamId } from "@3fc/contracts";
+import {
+  buildGameTimerState,
+  DEFAULT_TEAMS,
+  isThirdLengthMinutes,
+  isThirdNumber,
+  TEAM_IDS,
+  type TeamId,
+  type ThirdLengthMinutes,
+  type ThirdNumber,
+} from "@3fc/contracts";
 
 import { authorizeProtectedMutation } from "./auth/acl.js";
 import {
@@ -39,7 +48,7 @@ import {
   quickCreateGamePlayerRequestSchema,
   upsertTeamRequestSchema,
 } from "./contracts/core-write.js";
-import { ThreeFcRepository } from "./data/repository.js";
+import { GameTimerTransitionError, ThreeFcRepository } from "./data/repository.js";
 import type { GameStatus } from "./data/types.js";
 import { logAuthRateLimit, logRequest, logRequestError } from "./logging.js";
 
@@ -213,12 +222,22 @@ interface RepositoryContract {
     sessionId: string;
     status?: GameStatus;
     gameStartTs: string;
+    thirdLengthMinutes?: ThirdLengthMinutes;
   }): Promise<{
     gameId: string;
     leagueId: string;
     seasonId: string;
     sessionId: string;
     gameStartTs: string;
+    thirdLengthMinutes: ThirdLengthMinutes;
+    thirds: Array<{
+      third: ThirdNumber;
+      startedAt: string | null;
+      finishedAt: string | null;
+    }>;
+    status: "scheduled" | "live" | "finished";
+    createdAt: string;
+    updatedAt: string;
   }>;
   createSessionGame(input: {
     sessionId: string;
@@ -237,6 +256,12 @@ interface RepositoryContract {
       sessionId: string;
       status: "scheduled" | "live" | "finished";
       gameStartTs: string;
+      thirdLengthMinutes: ThirdLengthMinutes;
+      thirds: Array<{
+        third: ThirdNumber;
+        startedAt: string | null;
+        finishedAt: string | null;
+      }>;
       createdAt: string;
       updatedAt: string;
     }>
@@ -251,6 +276,12 @@ interface RepositoryContract {
         sessionId: string;
         status: "scheduled" | "live" | "finished";
         gameStartTs: string;
+        thirdLengthMinutes: ThirdLengthMinutes;
+        thirds: Array<{
+          third: ThirdNumber;
+          startedAt: string | null;
+          finishedAt: string | null;
+        }>;
         createdAt: string;
         updatedAt: string;
       }
@@ -260,6 +291,7 @@ interface RepositoryContract {
     gameId: string;
     status?: "scheduled" | "live" | "finished";
     gameStartTs?: string;
+    thirdLengthMinutes?: ThirdLengthMinutes;
   }): Promise<
     | {
         gameId: string;
@@ -268,6 +300,50 @@ interface RepositoryContract {
         sessionId: string;
         status: "scheduled" | "live" | "finished";
         gameStartTs: string;
+        thirdLengthMinutes: ThirdLengthMinutes;
+        thirds: Array<{
+          third: ThirdNumber;
+          startedAt: string | null;
+          finishedAt: string | null;
+        }>;
+        createdAt: string;
+        updatedAt: string;
+      }
+    | null
+  >;
+  startGameThird(input: { gameId: string; third: ThirdNumber }): Promise<
+    | {
+        gameId: string;
+        leagueId: string;
+        seasonId: string;
+        sessionId: string;
+        status: "scheduled" | "live" | "finished";
+        gameStartTs: string;
+        thirdLengthMinutes: ThirdLengthMinutes;
+        thirds: Array<{
+          third: ThirdNumber;
+          startedAt: string | null;
+          finishedAt: string | null;
+        }>;
+        createdAt: string;
+        updatedAt: string;
+      }
+    | null
+  >;
+  finishGameThird(input: { gameId: string; third: ThirdNumber }): Promise<
+    | {
+        gameId: string;
+        leagueId: string;
+        seasonId: string;
+        sessionId: string;
+        status: "scheduled" | "live" | "finished";
+        gameStartTs: string;
+        thirdLengthMinutes: ThirdLengthMinutes;
+        thirds: Array<{
+          third: ThirdNumber;
+          startedAt: string | null;
+          finishedAt: string | null;
+        }>;
         createdAt: string;
         updatedAt: string;
       }
@@ -676,6 +752,56 @@ function sortTeams<T extends { teamId: TeamId }>(teams: T[]): T[] {
   return [...teams].sort((left, right) => compareTeamIds(left.teamId, right.teamId));
 }
 
+function buildGameResponse(game: {
+  gameId: string;
+  leagueId: string;
+  seasonId: string;
+  sessionId: string;
+  status: "scheduled" | "live" | "finished";
+  gameStartTs: string;
+  thirdLengthMinutes: ThirdLengthMinutes;
+  thirds: Array<{
+    third: ThirdNumber;
+    startedAt: string | null;
+    finishedAt: string | null;
+  }>;
+  createdAt: string;
+  updatedAt: string;
+}) {
+  return {
+    ...game,
+    timer: buildGameTimerState({
+      thirdLengthMinutes: game.thirdLengthMinutes,
+      thirds: game.thirds,
+    }),
+  };
+}
+
+function parseThirdRouteParam(value: string): ThirdNumber | null {
+  if (value === "1" || value === "2" || value === "3") {
+    const parsed = Number.parseInt(value, 10);
+    return isThirdNumber(parsed) ? parsed : null;
+  }
+
+  return null;
+}
+
+function timerTransitionConflictResponse(
+  origin: string | undefined,
+  allowedOrigins: string[],
+  error: GameTimerTransitionError,
+): ApiGatewayHttpResponse {
+  return createJsonResponse(
+    409,
+    {
+      error: "conflict",
+      code: error.code,
+      message: error.message,
+    },
+    buildCorsHeaders(origin, allowedOrigins),
+  );
+}
+
 function toPublicPlayer(player: {
   playerId: string;
   nickname: string;
@@ -870,11 +996,13 @@ async function buildRosterResponse(repository: RepositoryContract, game: {
 function parseGamePatchBody(rawBody: Record<string, unknown>): {
   status?: "scheduled" | "live" | "finished";
   gameStartTs?: string;
+  thirdLengthMinutes?: ThirdLengthMinutes;
 } | null {
   const allowedStatuses = new Set(["scheduled", "live", "finished"]);
   const parsed: {
     status?: "scheduled" | "live" | "finished";
     gameStartTs?: string;
+    thirdLengthMinutes?: ThirdLengthMinutes;
   } = {};
 
   if (rawBody.status !== undefined) {
@@ -893,7 +1021,19 @@ function parseGamePatchBody(rawBody: Record<string, unknown>): {
     parsed.gameStartTs = rawBody.gameStartTs;
   }
 
-  if (parsed.status === undefined && parsed.gameStartTs === undefined) {
+  if (rawBody.thirdLengthMinutes !== undefined) {
+    if (typeof rawBody.thirdLengthMinutes !== "number" || !isThirdLengthMinutes(rawBody.thirdLengthMinutes)) {
+      return null;
+    }
+
+    parsed.thirdLengthMinutes = rawBody.thirdLengthMinutes;
+  }
+
+  if (
+    parsed.status === undefined &&
+    parsed.gameStartTs === undefined &&
+    parsed.thirdLengthMinutes === undefined
+  ) {
     return null;
   }
 
@@ -1615,7 +1755,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
           return createJsonResponse(
             status,
             {
-              games,
+              games: games.map((game) => buildGameResponse(game)),
             },
             buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
           );
@@ -1787,6 +1927,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
                 sessionId,
                 status: parsedBody.data.status as GameStatus | undefined,
                 gameStartTs: parsedBody.data.gameStartTs,
+                thirdLengthMinutes: parsedBody.data.thirdLengthMinutes,
               });
 
               await dependencies.repository.createSessionGame({
@@ -1800,7 +1941,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
 
               return createJsonResponse(
                 201,
-                createdGame,
+                buildGameResponse(createdGame),
                 buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
               );
             },
@@ -1837,7 +1978,83 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
           status = 200;
           return createJsonResponse(
             status,
-            game,
+            buildGameResponse(game),
+            buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
+          );
+        }
+
+        const startThirdMatch = route.match(/^\/v1\/games\/([^/]+)\/thirds\/([^/]*)\/start$/);
+        if (method === "POST" && startThirdMatch) {
+          const gameId = decodeRouteParam(startThirdMatch[1]);
+          const third = parseThirdRouteParam(decodeRouteParam(startThirdMatch[2]));
+          if (!third) {
+            status = 400;
+            return badRequest(origin, dependencies.corsAllowedOrigins, "Third must be 1, 2, or 3.");
+          }
+
+          let updated;
+          try {
+            updated = await dependencies.repository.startGameThird({ gameId, third });
+          } catch (error) {
+            if (error instanceof GameTimerTransitionError) {
+              status = 409;
+              return timerTransitionConflictResponse(
+                origin,
+                dependencies.corsAllowedOrigins,
+                error,
+              );
+            }
+
+            throw error;
+          }
+
+          if (!updated) {
+            status = 404;
+            return notFound(origin, dependencies.corsAllowedOrigins, `Game ${gameId} was not found.`);
+          }
+
+          status = 200;
+          return createJsonResponse(
+            status,
+            buildGameResponse(updated),
+            buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
+          );
+        }
+
+        const finishThirdMatch = route.match(/^\/v1\/games\/([^/]+)\/thirds\/([^/]*)\/finish$/);
+        if (method === "POST" && finishThirdMatch) {
+          const gameId = decodeRouteParam(finishThirdMatch[1]);
+          const third = parseThirdRouteParam(decodeRouteParam(finishThirdMatch[2]));
+          if (!third) {
+            status = 400;
+            return badRequest(origin, dependencies.corsAllowedOrigins, "Third must be 1, 2, or 3.");
+          }
+
+          let updated;
+          try {
+            updated = await dependencies.repository.finishGameThird({ gameId, third });
+          } catch (error) {
+            if (error instanceof GameTimerTransitionError) {
+              status = 409;
+              return timerTransitionConflictResponse(
+                origin,
+                dependencies.corsAllowedOrigins,
+                error,
+              );
+            }
+
+            throw error;
+          }
+
+          if (!updated) {
+            status = 404;
+            return notFound(origin, dependencies.corsAllowedOrigins, `Game ${gameId} was not found.`);
+          }
+
+          status = 200;
+          return createJsonResponse(
+            status,
+            buildGameResponse(updated),
             buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
           );
         }
@@ -2170,15 +2387,30 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
             return badRequest(
               origin,
               dependencies.corsAllowedOrigins,
-              "PATCH /v1/games/{gameId} accepts status and/or gameStartTs.",
+              "PATCH /v1/games/{gameId} accepts status, gameStartTs, and/or thirdLengthMinutes.",
             );
           }
 
-          const updated = await dependencies.repository.updateGame({
-            gameId,
-            status: parsedPatch.status,
-            gameStartTs: parsedPatch.gameStartTs,
-          });
+          let updated;
+          try {
+            updated = await dependencies.repository.updateGame({
+              gameId,
+              status: parsedPatch.status,
+              gameStartTs: parsedPatch.gameStartTs,
+              thirdLengthMinutes: parsedPatch.thirdLengthMinutes,
+            });
+          } catch (error) {
+            if (error instanceof GameTimerTransitionError) {
+              status = 409;
+              return timerTransitionConflictResponse(
+                origin,
+                dependencies.corsAllowedOrigins,
+                error,
+              );
+            }
+
+            throw error;
+          }
 
           if (!updated) {
             status = 404;
@@ -2188,7 +2420,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
           status = 200;
           return createJsonResponse(
             status,
-            updated,
+            buildGameResponse(updated),
             buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
           );
         }

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -9,7 +9,16 @@ import {
   GetItemCommand,
   PutItemCommand,
 } from "@aws-sdk/client-dynamodb";
-import { DEFAULT_TEAMS, TEAM_IDS, type TeamId } from "@3fc/contracts";
+import {
+  buildGameTimerState,
+  DEFAULT_TEAMS,
+  isThirdLengthMinutes,
+  isThirdNumber,
+  TEAM_IDS,
+  type TeamId,
+  type ThirdLengthMinutes,
+  type ThirdNumber,
+} from "@3fc/contracts";
 
 import {
   isMagicLinkEmailLike,
@@ -49,7 +58,7 @@ import {
   quickCreateGamePlayerRequestSchema,
   upsertTeamRequestSchema,
 } from "./contracts/core-write.js";
-import { ThreeFcRepository } from "./data/repository.js";
+import { GameTimerTransitionError, ThreeFcRepository } from "./data/repository.js";
 import { buildHealthResponse } from "./index.js";
 import { logAuthRateLimit, logRequest, logRequestError } from "./logging.js";
 
@@ -320,6 +329,53 @@ function sortTeams<T extends { teamId: TeamId }>(teams: T[]): T[] {
   return [...teams].sort((left, right) => compareTeamIds(left.teamId, right.teamId));
 }
 
+function buildGameResponse(game: {
+  gameId: string;
+  leagueId: string;
+  seasonId: string;
+  sessionId: string;
+  status: "scheduled" | "live" | "finished";
+  gameStartTs: string;
+  thirdLengthMinutes: ThirdLengthMinutes;
+  thirds: Array<{
+    third: ThirdNumber;
+    startedAt: string | null;
+    finishedAt: string | null;
+  }>;
+  createdAt: string;
+  updatedAt: string;
+}) {
+  return {
+    ...game,
+    timer: buildGameTimerState({
+      thirdLengthMinutes: game.thirdLengthMinutes,
+      thirds: game.thirds,
+    }),
+  };
+}
+
+function parseThirdRouteParam(value: string): ThirdNumber | null {
+  if (value === "1" || value === "2" || value === "3") {
+    const parsed = Number.parseInt(value, 10);
+    return isThirdNumber(parsed) ? parsed : null;
+  }
+
+  return null;
+}
+
+function timerTransitionConflict(
+  request: IncomingMessage,
+  response: ServerResponse,
+  error: GameTimerTransitionError,
+): number {
+  sendJsonWithCors(request, response, 409, {
+    error: "conflict",
+    code: error.code,
+    message: error.message,
+  });
+  return 409;
+}
+
 function toPublicPlayer(player: {
   playerId: string;
   nickname: string;
@@ -502,10 +558,12 @@ async function buildRosterResponse(game: {
 function parseGamePatchBody(rawBody: Record<string, unknown>): {
   status?: "scheduled" | "live" | "finished";
   gameStartTs?: string;
+  thirdLengthMinutes?: ThirdLengthMinutes;
 } | null {
   const parsed: {
     status?: "scheduled" | "live" | "finished";
     gameStartTs?: string;
+    thirdLengthMinutes?: ThirdLengthMinutes;
   } = {};
 
   if (rawBody.status !== undefined) {
@@ -527,7 +585,19 @@ function parseGamePatchBody(rawBody: Record<string, unknown>): {
     parsed.gameStartTs = rawBody.gameStartTs;
   }
 
-  if (parsed.status === undefined && parsed.gameStartTs === undefined) {
+  if (rawBody.thirdLengthMinutes !== undefined) {
+    if (typeof rawBody.thirdLengthMinutes !== "number" || !isThirdLengthMinutes(rawBody.thirdLengthMinutes)) {
+      return null;
+    }
+
+    parsed.thirdLengthMinutes = rawBody.thirdLengthMinutes;
+  }
+
+  if (
+    parsed.status === undefined &&
+    parsed.gameStartTs === undefined &&
+    parsed.thirdLengthMinutes === undefined
+  ) {
     return null;
   }
 
@@ -877,6 +947,7 @@ async function handleCreateGame(
         sessionId: scope.sessionId,
         status: parsedBody.data.status,
         gameStartTs: parsedBody.data.gameStartTs,
+        thirdLengthMinutes: parsedBody.data.thirdLengthMinutes,
       });
 
       await repository.createSessionGame({
@@ -890,7 +961,7 @@ async function handleCreateGame(
 
       return {
         statusCode: 201,
-        payload: game,
+        payload: buildGameResponse(game),
       };
     },
   });
@@ -1511,7 +1582,7 @@ async function start(): Promise<void> {
         const games = await repository.listGamesForSeason(seasonId);
         status = 200;
         sendJsonWithCors(request, response, status, {
-          games,
+          games: games.map((game) => buildGameResponse(game)),
         });
         return;
       }
@@ -1690,7 +1761,69 @@ async function start(): Promise<void> {
         }
 
         status = 200;
-        sendJsonWithCors(request, response, status, game);
+        sendJsonWithCors(request, response, status, buildGameResponse(game));
+        return;
+      }
+
+      const startThirdMatch = route.match(/^\/v1\/games\/([^/]+)\/thirds\/([^/]*)\/start$/);
+      if (method === "POST" && startThirdMatch) {
+        const gameId = decodeURIComponent(startThirdMatch[1]);
+        const third = parseThirdRouteParam(decodeURIComponent(startThirdMatch[2]));
+        if (!third) {
+          status = badRequest(request, response, "Third must be 1, 2, or 3.");
+          return;
+        }
+
+        let updated;
+        try {
+          updated = await repository.startGameThird({ gameId, third });
+        } catch (error) {
+          if (error instanceof GameTimerTransitionError) {
+            status = timerTransitionConflict(request, response, error);
+            return;
+          }
+
+          throw error;
+        }
+
+        if (!updated) {
+          status = notFound(request, response, `Game ${gameId} was not found.`);
+          return;
+        }
+
+        status = 200;
+        sendJsonWithCors(request, response, status, buildGameResponse(updated));
+        return;
+      }
+
+      const finishThirdMatch = route.match(/^\/v1\/games\/([^/]+)\/thirds\/([^/]*)\/finish$/);
+      if (method === "POST" && finishThirdMatch) {
+        const gameId = decodeURIComponent(finishThirdMatch[1]);
+        const third = parseThirdRouteParam(decodeURIComponent(finishThirdMatch[2]));
+        if (!third) {
+          status = badRequest(request, response, "Third must be 1, 2, or 3.");
+          return;
+        }
+
+        let updated;
+        try {
+          updated = await repository.finishGameThird({ gameId, third });
+        } catch (error) {
+          if (error instanceof GameTimerTransitionError) {
+            status = timerTransitionConflict(request, response, error);
+            return;
+          }
+
+          throw error;
+        }
+
+        if (!updated) {
+          status = notFound(request, response, `Game ${gameId} was not found.`);
+          return;
+        }
+
+        status = 200;
+        sendJsonWithCors(request, response, status, buildGameResponse(updated));
         return;
       }
 
@@ -2021,16 +2154,27 @@ async function start(): Promise<void> {
           status = badRequest(
             request,
             response,
-            "PATCH /v1/games/{gameId} accepts status and/or gameStartTs.",
+            "PATCH /v1/games/{gameId} accepts status, gameStartTs, and/or thirdLengthMinutes.",
           );
           return;
         }
 
-        const updated = await repository.updateGame({
-          gameId,
-          status: parsedPatch.status,
-          gameStartTs: parsedPatch.gameStartTs,
-        });
+        let updated;
+        try {
+          updated = await repository.updateGame({
+            gameId,
+            status: parsedPatch.status,
+            gameStartTs: parsedPatch.gameStartTs,
+            thirdLengthMinutes: parsedPatch.thirdLengthMinutes,
+          });
+        } catch (error) {
+          if (error instanceof GameTimerTransitionError) {
+            status = timerTransitionConflict(request, response, error);
+            return;
+          }
+
+          throw error;
+        }
 
         if (!updated) {
           status = notFound(request, response, `Game ${gameId} was not found.`);
@@ -2038,7 +2182,7 @@ async function start(): Promise<void> {
         }
 
         status = 200;
-        sendJsonWithCors(request, response, status, updated);
+        sendJsonWithCors(request, response, status, buildGameResponse(updated));
         return;
       }
 

--- a/api/src/tests/acl.test.ts
+++ b/api/src/tests/acl.test.ts
@@ -7,6 +7,7 @@ import {
   type AclLookup,
 } from "../auth/acl.js";
 import type { GameRecord, LeagueAclRecord, SeasonRecord, SessionRecord } from "../data/types.js";
+import { createDefaultThirdTimerSegments, DEFAULT_THIRD_LENGTH_MINUTES } from "@3fc/contracts";
 
 interface AclHarnessInput {
   leagueAccess?: Record<string, LeagueAclRecord>;
@@ -35,6 +36,13 @@ class InMemoryAclLookup implements AclLookup {
   }
 }
 
+function defaultTimerFields(): Pick<GameRecord, "thirdLengthMinutes" | "thirds"> {
+  return {
+    thirdLengthMinutes: DEFAULT_THIRD_LENGTH_MINUTES,
+    thirds: createDefaultThirdTimerSegments(),
+  };
+}
+
 test("resolveProtectedMutationRoute maps supported mutation endpoints", () => {
   assert.deepEqual(resolveProtectedMutationRoute("POST", "/v1/leagues"), {
     operation: "createLeague",
@@ -61,6 +69,14 @@ test("resolveProtectedMutationRoute maps supported mutation endpoints", () => {
   });
   assert.deepEqual(resolveProtectedMutationRoute("PUT", "/v1/games/game-1/roster/player-1"), {
     operation: "assignRosterPlayer",
+    gameId: "game-1",
+  });
+  assert.deepEqual(resolveProtectedMutationRoute("POST", "/v1/games/game-1/thirds/1/start"), {
+    operation: "startGameThird",
+    gameId: "game-1",
+  });
+  assert.deepEqual(resolveProtectedMutationRoute("POST", "/v1/games/game-1/thirds/1/finish"), {
+    operation: "finishGameThird",
     gameId: "game-1",
   });
   assert.equal(resolveProtectedMutationRoute("GET", "/v1/leagues"), null);
@@ -169,6 +185,7 @@ test("game-scoped roster mutation allows scorekeepers", async () => {
           gameId: "game-1",
           status: "scheduled",
           gameStartTs: "2026-02-23T10:00:00.000Z",
+          ...defaultTimerFields(),
           createdAt: "2026-02-23T00:00:00.000Z",
           updatedAt: "2026-02-23T00:00:00.000Z",
         },
@@ -207,6 +224,59 @@ test("game-scoped roster mutation allows scorekeepers", async () => {
   });
 });
 
+test("game-scoped timer mutation allows scorekeepers", async () => {
+  const result = await authorizeProtectedMutation(
+    "POST",
+    "/v1/games/game-1/thirds/1/start",
+    "scorekeeper-user",
+    new InMemoryAclLookup({
+      games: {
+        "game-1": {
+          leagueId: "league-1",
+          seasonId: "season-1",
+          sessionId: "session-1",
+          gameId: "game-1",
+          status: "scheduled",
+          gameStartTs: "2026-02-23T10:00:00.000Z",
+          ...defaultTimerFields(),
+          createdAt: "2026-02-23T00:00:00.000Z",
+          updatedAt: "2026-02-23T00:00:00.000Z",
+        },
+      },
+      seasons: {
+        "season-1": {
+          leagueId: "league-1",
+          seasonId: "season-1",
+          name: "Season 1",
+          slug: null,
+          startsOn: null,
+          endsOn: null,
+          createdAt: "2026-02-23T00:00:00.000Z",
+          updatedAt: "2026-02-23T00:00:00.000Z",
+        },
+      },
+      leagueAccess: {
+        "league-1:scorekeeper-user": {
+          leagueId: "league-1",
+          userId: "scorekeeper-user",
+          role: "scorekeeper",
+          grantedByUserId: "admin-user",
+          createdAt: "2026-02-23T00:00:00.000Z",
+          updatedAt: "2026-02-23T00:00:00.000Z",
+        },
+      },
+    }),
+  );
+
+  assert.equal(result.allowed, true);
+  assert.equal(result.operation, "startGameThird");
+  assert.deepEqual(result.scope, {
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "session-1",
+  });
+});
+
 test("game team override mutation rejects scorekeepers", async () => {
   const result = await authorizeProtectedMutation(
     "PUT",
@@ -221,6 +291,7 @@ test("game team override mutation rejects scorekeepers", async () => {
           gameId: "game-1",
           status: "scheduled",
           gameStartTs: "2026-02-23T10:00:00.000Z",
+          ...defaultTimerFields(),
           createdAt: "2026-02-23T00:00:00.000Z",
           updatedAt: "2026-02-23T00:00:00.000Z",
         },
@@ -269,6 +340,7 @@ test("game player creation mutation rejects viewers", async () => {
           gameId: "game-1",
           status: "scheduled",
           gameStartTs: "2026-02-23T10:00:00.000Z",
+          ...defaultTimerFields(),
           createdAt: "2026-02-23T00:00:00.000Z",
           updatedAt: "2026-02-23T00:00:00.000Z",
         },

--- a/api/src/tests/lambda-core.test.ts
+++ b/api/src/tests/lambda-core.test.ts
@@ -6,7 +6,14 @@ import {
   type ApiGatewayHttpEvent,
 } from "../lambda-core.js";
 import type { RateLimitDecision } from "../auth/rate-limit.js";
-import type { TeamId } from "@3fc/contracts";
+import {
+  createDefaultThirdTimerSegments,
+  DEFAULT_THIRD_LENGTH_MINUTES,
+  type TeamId,
+  type ThirdLengthMinutes,
+  type ThirdTimerSegment,
+} from "@3fc/contracts";
+import { GameTimerTransitionError } from "../data/repository.js";
 
 interface MockSessionRecord {
   sessionId: string;
@@ -59,9 +66,14 @@ interface MockGameRecord {
   sessionId: string;
   status: "scheduled" | "live" | "finished";
   gameStartTs: string;
+  thirdLengthMinutes: ThirdLengthMinutes;
+  thirds: ThirdTimerSegment[];
   createdAt: string;
   updatedAt: string;
 }
+
+type MockGameInput = Omit<MockGameRecord, "thirdLengthMinutes" | "thirds"> &
+  Partial<Pick<MockGameRecord, "thirdLengthMinutes" | "thirds">>;
 
 interface MockSeasonTeamRecord {
   seasonId: string;
@@ -133,6 +145,7 @@ interface CreatedGameInput {
   sessionId: string;
   status?: "scheduled" | "live" | "finished";
   gameStartTs: string;
+  thirdLengthMinutes?: ThirdLengthMinutes;
 }
 
 interface CreatedSessionGameInput {
@@ -159,7 +172,7 @@ interface HarnessConfig {
   leagues?: Record<string, MockLeagueRecord>;
   seasons?: Record<string, MockSeasonRecord>;
   seasonSessions?: Record<string, MockSessionEntity>;
-  games?: Record<string, MockGameRecord>;
+  games?: Record<string, MockGameInput>;
   seasonTeams?: Record<string, MockSeasonTeamRecord>;
   gameTeams?: Record<string, MockGameTeamRecord>;
   players?: Record<string, MockPlayerRecord>;
@@ -214,7 +227,16 @@ function createHarness(config: HarnessConfig = {}) {
   const sessionEntities = new Map<string, MockSessionEntity>(
     Object.entries(config.seasonSessions ?? {}),
   );
-  const games = new Map<string, MockGameRecord>(Object.entries(config.games ?? {}));
+  const games = new Map<string, MockGameRecord>(
+    Object.entries(config.games ?? {}).map(([gameId, game]) => [
+      gameId,
+      {
+        ...game,
+        thirdLengthMinutes: game.thirdLengthMinutes ?? DEFAULT_THIRD_LENGTH_MINUTES,
+        thirds: game.thirds ?? createDefaultThirdTimerSegments(),
+      },
+    ]),
+  );
   const seasonTeams = new Map<string, MockSeasonTeamRecord>(
     Object.entries(config.seasonTeams ?? {}),
   );
@@ -361,6 +383,8 @@ function createHarness(config: HarnessConfig = {}) {
           sessionId: input.sessionId,
           status: input.status ?? "scheduled",
           gameStartTs: input.gameStartTs,
+          thirdLengthMinutes: input.thirdLengthMinutes ?? DEFAULT_THIRD_LENGTH_MINUTES,
+          thirds: createDefaultThirdTimerSegments(),
           createdAt: "2026-02-23T00:00:00.000Z",
           updatedAt: "2026-02-23T00:00:00.000Z",
         };
@@ -383,11 +407,117 @@ function createHarness(config: HarnessConfig = {}) {
           return null;
         }
 
+        if (
+          input.thirdLengthMinutes !== undefined &&
+          input.thirdLengthMinutes !== existing.thirdLengthMinutes &&
+          existing.status === "finished"
+        ) {
+          throw new GameTimerTransitionError(
+            "game_finished",
+            "Third length cannot be changed after the game is finished.",
+          );
+        }
+
+        if (
+          input.thirdLengthMinutes !== undefined &&
+          input.thirdLengthMinutes !== existing.thirdLengthMinutes &&
+          existing.thirds.some((third) => third.startedAt !== null)
+        ) {
+          throw new GameTimerTransitionError(
+            "third_length_locked",
+            "Third length cannot be changed after a third has started.",
+          );
+        }
+
         const updated = {
           ...existing,
           status: input.status ?? existing.status,
           gameStartTs: input.gameStartTs ?? existing.gameStartTs,
+          thirdLengthMinutes: input.thirdLengthMinutes ?? existing.thirdLengthMinutes,
           updatedAt: "2026-02-23T00:00:01.000Z",
+        };
+        games.set(input.gameId, updated);
+        return updated;
+      },
+      async startGameThird(input) {
+        const existing = games.get(input.gameId);
+        if (!existing) {
+          return null;
+        }
+
+        if (existing.status === "finished") {
+          throw new GameTimerTransitionError("game_finished", "Cannot start a third after the game is finished.");
+        }
+
+        const thirds = existing.thirds.map((third) => ({ ...third }));
+        const target = thirds.find((third) => third.third === input.third);
+        if (!target) {
+          throw new GameTimerTransitionError("invalid_third", "Third must be 1, 2, or 3.");
+        }
+        if (target.startedAt) {
+          throw new GameTimerTransitionError("third_already_started", `Third ${input.third} has already been started.`);
+        }
+        const runningThird = thirds.find((third) => third.startedAt && !third.finishedAt);
+        if (runningThird) {
+          throw new GameTimerTransitionError(
+            "third_already_running",
+            `Third ${runningThird.third} must be finished before another third can start.`,
+          );
+        }
+        const unfinishedPreviousThird = thirds
+          .filter((third) => third.third < input.third)
+          .find((third) => !third.finishedAt);
+        if (unfinishedPreviousThird) {
+          throw new GameTimerTransitionError(
+            "previous_third_unfinished",
+            `Third ${unfinishedPreviousThird.third} must be finished before third ${input.third} can start.`,
+          );
+        }
+
+        target.startedAt = "2026-02-23T00:00:01.000Z";
+        const updated = {
+          ...existing,
+          status: "live" as const,
+          thirds,
+          updatedAt: "2026-02-23T00:00:01.000Z",
+        };
+        games.set(input.gameId, updated);
+        return updated;
+      },
+      async finishGameThird(input) {
+        const existing = games.get(input.gameId);
+        if (!existing) {
+          return null;
+        }
+
+        if (existing.status === "finished") {
+          throw new GameTimerTransitionError("game_finished", "Cannot finish a third after the game is finished.");
+        }
+
+        const thirds = existing.thirds.map((third) => ({ ...third }));
+        const target = thirds.find((third) => third.third === input.third);
+        if (!target) {
+          throw new GameTimerTransitionError("invalid_third", "Third must be 1, 2, or 3.");
+        }
+        if (!target.startedAt) {
+          throw new GameTimerTransitionError(
+            "third_not_started",
+            `Third ${input.third} cannot be finished before it is started.`,
+          );
+        }
+        if (target.finishedAt) {
+          throw new GameTimerTransitionError(
+            "third_already_finished",
+            `Third ${input.third} has already been finished.`,
+          );
+        }
+
+        target.finishedAt = "2026-02-23T00:00:02.000Z";
+        const updated = {
+          ...existing,
+          status: existing.status === "scheduled" ? ("live" as const) : existing.status,
+          thirds,
+          updatedAt: "2026-02-23T00:00:02.000Z",
         };
         games.set(input.gameId, updated);
         return updated;
@@ -1018,6 +1148,251 @@ test("core lambda lets scorekeepers quick-create and assign roster players", asy
       },
     },
   ]);
+});
+
+test("core lambda lets scorekeepers start and finish thirds", async () => {
+  const harness = createHarness({
+    sessions: {
+      "session-1": {
+        sessionId: "session-1",
+        email: "scorekeeper@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    games: {
+      "game-1": {
+        gameId: "game-1",
+        leagueId: "league-1",
+        seasonId: "season-1",
+        sessionId: "session-1",
+        status: "scheduled",
+        gameStartTs: "2026-02-23T10:00:00.000Z",
+        thirdLengthMinutes: 30,
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    seasons: {
+      "season-1": {
+        leagueId: "league-1",
+        seasonId: "season-1",
+        name: "Season 1",
+        slug: null,
+        startsOn: null,
+        endsOn: null,
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueAccess: {
+      "league-1:scorekeeper@example.com": {
+        leagueId: "league-1",
+        userId: "scorekeeper@example.com",
+        role: "scorekeeper",
+        grantedByUserId: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  const startResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/games/game-1/thirds/1/start",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+    }),
+  );
+
+  assert.equal(startResponse.statusCode, 200);
+  const startBody = JSON.parse(startResponse.body) as {
+    status: string;
+    thirdLengthMinutes: number;
+    timer: { status: string; activeThird: number | null; thirdLengthMinutes: number };
+    thirds: Array<{ third: number; startedAt: string | null }>;
+  };
+  assert.equal(startBody.status, "live");
+  assert.equal(startBody.thirdLengthMinutes, 30);
+  assert.equal(startBody.timer.thirdLengthMinutes, 30);
+  assert.equal(startBody.timer.activeThird, 1);
+  assert.equal(startBody.timer.status, "running");
+  assert.equal(startBody.thirds[0].startedAt, "2026-02-23T00:00:01.000Z");
+
+  const finishResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/games/game-1/thirds/1/finish",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+    }),
+  );
+
+  assert.equal(finishResponse.statusCode, 200);
+  const finishBody = JSON.parse(finishResponse.body) as {
+    timer: { status: string; activeThird: number | null; thirds: Array<{ status: string }> };
+    thirds: Array<{ finishedAt: string | null }>;
+  };
+  assert.equal(finishBody.timer.status, "between_thirds");
+  assert.equal(finishBody.timer.activeThird, null);
+  assert.equal(finishBody.timer.thirds[0].status, "finished");
+  assert.equal(finishBody.thirds[0].finishedAt, "2026-02-23T00:00:02.000Z");
+
+  const invalidFinishResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/games/game-1/thirds/2/finish",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+    }),
+  );
+
+  assert.equal(invalidFinishResponse.statusCode, 409);
+  assert.deepEqual(JSON.parse(invalidFinishResponse.body), {
+    error: "conflict",
+    code: "third_not_started",
+    message: "Third 2 cannot be finished before it is started.",
+  });
+
+  for (const invalidThird of ["1abc", "1.9", "01", ""]) {
+    const invalidStartResponse = await harness.handler(
+      createEvent({
+        method: "POST",
+        path: `/v1/games/game-1/thirds/${invalidThird}/start`,
+        headers: {
+          Cookie: "threefc_session=session-1",
+        },
+      }),
+    );
+
+    assert.equal(invalidStartResponse.statusCode, 400);
+    assert.deepEqual(JSON.parse(invalidStartResponse.body), {
+      error: "Third must be 1, 2, or 3.",
+    });
+  }
+});
+
+test("core lambda rejects viewer third timer mutations through ACL", async () => {
+  const harness = createHarness({
+    sessions: {
+      "session-1": {
+        sessionId: "session-1",
+        email: "viewer@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    games: {
+      "game-1": {
+        gameId: "game-1",
+        leagueId: "league-1",
+        seasonId: "season-1",
+        sessionId: "session-1",
+        status: "scheduled",
+        gameStartTs: "2026-02-23T10:00:00.000Z",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    seasons: {
+      "season-1": {
+        leagueId: "league-1",
+        seasonId: "season-1",
+        name: "Season 1",
+        slug: null,
+        startsOn: null,
+        endsOn: null,
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueAccess: {
+      "league-1:viewer@example.com": {
+        leagueId: "league-1",
+        userId: "viewer@example.com",
+        role: "viewer",
+        grantedByUserId: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  const response = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/games/game-1/thirds/1/start",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+    }),
+  );
+
+  assert.equal(response.statusCode, 403);
+  assert.deepEqual(JSON.parse(response.body), {
+    error: "forbidden",
+    code: "scorekeeper_required",
+    message: "Admin or scorekeeper role is required for league league-1.",
+  });
+});
+
+test("core lambda rejects third length changes on finished games", async () => {
+  const harness = createHarness({
+    sessions: {
+      "session-1": {
+        sessionId: "session-1",
+        email: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    games: {
+      "game-1": {
+        gameId: "game-1",
+        leagueId: "league-1",
+        seasonId: "season-1",
+        sessionId: "session-1",
+        status: "finished",
+        gameStartTs: "2026-02-23T10:00:00.000Z",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueAccess: {
+      "league-1:admin@example.com": {
+        leagueId: "league-1",
+        userId: "admin@example.com",
+        role: "admin",
+        grantedByUserId: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  const response = await harness.handler(
+    createEvent({
+      method: "PATCH",
+      path: "/v1/games/game-1",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+      body: {
+        thirdLengthMinutes: 30,
+      },
+    }),
+  );
+
+  assert.equal(response.statusCode, 409);
+  assert.deepEqual(JSON.parse(response.body), {
+    error: "conflict",
+    code: "game_finished",
+    message: "Third length cannot be changed after the game is finished.",
+  });
 });
 
 test("core lambda team and roster read routes do not create team records", async () => {

--- a/api/src/tests/lambda-core.test.ts
+++ b/api/src/tests/lambda-core.test.ts
@@ -429,6 +429,13 @@ function createHarness(config: HarnessConfig = {}) {
           );
         }
 
+        if (input.status === "scheduled" && existing.thirds.some((third) => third.startedAt !== null)) {
+          throw new GameTimerTransitionError(
+            "timer_status_locked",
+            "Game status cannot be set back to scheduled after a third has started.",
+          );
+        }
+
         const updated = {
           ...existing,
           status: input.status ?? existing.status,
@@ -1392,6 +1399,68 @@ test("core lambda rejects third length changes on finished games", async () => {
     error: "conflict",
     code: "game_finished",
     message: "Third length cannot be changed after the game is finished.",
+  });
+});
+
+test("core lambda rejects setting scheduled status after a third starts", async () => {
+  const thirds = createDefaultThirdTimerSegments();
+  thirds[0] = {
+    ...thirds[0],
+    startedAt: "2026-02-23T00:00:01.000Z",
+  };
+
+  const harness = createHarness({
+    sessions: {
+      "session-1": {
+        sessionId: "session-1",
+        email: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    games: {
+      "game-1": {
+        gameId: "game-1",
+        leagueId: "league-1",
+        seasonId: "season-1",
+        sessionId: "session-1",
+        status: "live",
+        gameStartTs: "2026-02-23T10:00:00.000Z",
+        thirds,
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueAccess: {
+      "league-1:admin@example.com": {
+        leagueId: "league-1",
+        userId: "admin@example.com",
+        role: "admin",
+        grantedByUserId: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  const response = await harness.handler(
+    createEvent({
+      method: "PATCH",
+      path: "/v1/games/game-1",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+      body: {
+        status: "scheduled",
+      },
+    }),
+  );
+
+  assert.equal(response.statusCode, 409);
+  assert.deepEqual(JSON.parse(response.body), {
+    error: "conflict",
+    code: "timer_status_locked",
+    message: "Game status cannot be set back to scheduled after a third has started.",
   });
 });
 

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -9,6 +9,11 @@ import {
   PutItemCommand,
   QueryCommand,
 } from "@aws-sdk/client-dynamodb";
+import {
+  createDefaultThirdTimerSegments,
+  DEFAULT_THIRD_LENGTH_MINUTES,
+  formatThirdDisplayTime,
+} from "@3fc/contracts";
 
 import { ThreeFcRepository } from "../data/repository.js";
 
@@ -16,11 +21,20 @@ type Item = Record<string, AttributeValue>;
 
 class InMemoryDynamoClient {
   private readonly items = new Map<string, Item>();
+  private beforeNextPut: (() => void) | null = null;
 
   seedItem(item: Item): void {
     const pk = this.readString(item.pk, "pk");
     const sk = this.readString(item.sk, "sk");
     this.items.set(`${pk}|${sk}`, item);
+  }
+
+  readItem(pk: string, sk: string): Item | undefined {
+    return this.items.get(`${pk}|${sk}`);
+  }
+
+  runBeforeNextPut(callback: () => void): void {
+    this.beforeNextPut = callback;
   }
 
   async send(command: unknown): Promise<unknown> {
@@ -34,7 +48,21 @@ class InMemoryDynamoClient {
       const sk = this.readString(item.sk, "sk");
       const id = `${pk}|${sk}`;
 
-      if (command.input.ConditionExpression && this.items.has(id)) {
+      if (this.beforeNextPut) {
+        const callback = this.beforeNextPut;
+        this.beforeNextPut = null;
+        callback();
+      }
+
+      if (
+        command.input.ConditionExpression &&
+        !this.conditionMatches(
+        command.input.ConditionExpression,
+          this.items.get(id),
+          command.input.ExpressionAttributeNames ?? {},
+          command.input.ExpressionAttributeValues ?? {},
+        )
+      ) {
         const error = new Error("Conditional request failed.");
         (error as Error & { name: string }).name = "ConditionalCheckFailedException";
         throw error;
@@ -96,6 +124,44 @@ class InMemoryDynamoClient {
     }
 
     return value.S;
+  }
+
+  private conditionMatches(
+    expression: string,
+    existing: Item | undefined,
+    attributeNames: Record<string, string>,
+    attributeValues: Record<string, AttributeValue>,
+  ): boolean {
+    return expression.split(/\s+AND\s+/).every((clause) => {
+      const attributeNotExists = clause.match(/^attribute_not_exists\(([^)]+)\)$/);
+      if (attributeNotExists) {
+        const attributeName = this.resolveAttributeName(attributeNotExists[1], attributeNames);
+        return !existing || existing[attributeName] === undefined;
+      }
+
+      const equality = clause.match(/^(.+?)\s*=\s*(.+)$/);
+      if (equality) {
+        const attributeName = this.resolveAttributeName(equality[1], attributeNames);
+        const expected = attributeValues[equality[2].trim()];
+        const actual = existing?.[attributeName];
+        return this.attributeValueEquals(actual, expected);
+      }
+
+      throw new Error(`Unsupported condition expression in test client: ${expression}`);
+    });
+  }
+
+  private resolveAttributeName(value: string, attributeNames: Record<string, string>): string {
+    const trimmed = value.trim();
+    return attributeNames[trimmed] ?? trimmed;
+  }
+
+  private attributeValueEquals(left: AttributeValue | undefined, right: AttributeValue | undefined): boolean {
+    if (!left || !right) {
+      return false;
+    }
+
+    return JSON.stringify(left) === JSON.stringify(right);
   }
 }
 
@@ -396,6 +462,208 @@ test("repository supports update and delete of games", async () => {
   assert.equal(deleted, true);
   assert.equal(await repository.getGame("game-1"), null);
   assert.deepEqual(await repository.listSessionsForSeason("season-1"), []);
+});
+
+test("repository gives legacy games default timer state", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  client.seedItem({
+    pk: { S: "GAME#game-legacy" },
+    sk: { S: "METADATA" },
+    entityType: { S: "game" },
+    createdAt: { S: "2026-02-22T00:00:00.000Z" },
+    updatedAt: { S: "2026-02-22T00:00:00.000Z" },
+    data: {
+      S: JSON.stringify({
+        gameId: "game-legacy",
+        leagueId: "league-1",
+        seasonId: "season-1",
+        sessionId: "session-1",
+        status: "scheduled",
+        gameStartTs: "2026-02-22T10:00:00.000Z",
+      }),
+    },
+  });
+
+  const game = await repository.getGame("game-legacy");
+  assert.equal(game?.thirdLengthMinutes, DEFAULT_THIRD_LENGTH_MINUTES);
+  assert.deepEqual(game?.thirds, createDefaultThirdTimerSegments());
+});
+
+test("repository enforces third timer transitions in order", async () => {
+  const repository = createRepository();
+
+  await repository.createGame({
+    gameId: "game-1",
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "session-1",
+    gameStartTs: "2026-02-22T10:00:00Z",
+    thirdLengthMinutes: 25,
+  });
+
+  await assert.rejects(
+    repository.finishGameThird({ gameId: "game-1", third: 1 }),
+    /cannot be finished before it is started/,
+  );
+
+  const startedFirst = await repository.startGameThird({ gameId: "game-1", third: 1 });
+  assert.equal(startedFirst?.status, "live");
+  assert.equal(startedFirst?.thirdLengthMinutes, 25);
+  assert.equal(startedFirst?.thirds[0].startedAt, "2026-02-22T00:00:01.000Z");
+  assert.equal(startedFirst?.thirds[0].finishedAt, null);
+
+  await assert.rejects(
+    repository.startGameThird({ gameId: "game-1", third: 1 }),
+    /already been started/,
+  );
+  await assert.rejects(
+    repository.startGameThird({ gameId: "game-1", third: 2 }),
+    /Third 1 must be finished before another third can start/,
+  );
+
+  const finishedFirst = await repository.finishGameThird({ gameId: "game-1", third: 1 });
+  assert.equal(finishedFirst?.thirds[0].finishedAt, "2026-02-22T00:00:02.000Z");
+
+  const startedSecond = await repository.startGameThird({ gameId: "game-1", third: 2 });
+  assert.equal(startedSecond?.thirds[1].startedAt, "2026-02-22T00:00:03.000Z");
+});
+
+test("repository rejects stale timer transition writes without overwriting newer state", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  await repository.createGame({
+    gameId: "game-1",
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "session-1",
+    gameStartTs: "2026-02-22T10:00:00Z",
+  });
+
+  client.runBeforeNextPut(() => {
+    const item = client.readItem("GAME#game-1", "METADATA");
+    if (!item?.data?.S) {
+      throw new Error("Expected seeded game item.");
+    }
+    const data = JSON.parse(item.data.S) as {
+      status: "scheduled" | "live" | "finished";
+      thirds: Array<{ third: number; startedAt: string | null; finishedAt: string | null }>;
+    };
+    data.status = "live";
+    data.thirds[0].startedAt = "2026-02-22T00:00:99.000Z";
+    item.data.S = JSON.stringify(data);
+    item.updatedAt = { S: "2026-02-22T00:00:99.000Z" };
+    client.seedItem(item);
+  });
+
+  await assert.rejects(
+    repository.startGameThird({ gameId: "game-1", third: 1 }),
+    /Timer state changed while applying this transition/,
+  );
+  const externallyStarted = await repository.getGame("game-1");
+  assert.equal(externallyStarted?.thirds[0].startedAt, "2026-02-22T00:00:99.000Z");
+
+  client.runBeforeNextPut(() => {
+    const item = client.readItem("GAME#game-1", "METADATA");
+    if (!item?.data?.S) {
+      throw new Error("Expected seeded game item.");
+    }
+    const data = JSON.parse(item.data.S) as {
+      thirds: Array<{ third: number; startedAt: string | null; finishedAt: string | null }>;
+    };
+    data.thirds[0].finishedAt = "2026-02-22T00:01:99.000Z";
+    item.data.S = JSON.stringify(data);
+    item.updatedAt = { S: "2026-02-22T00:01:99.000Z" };
+    client.seedItem(item);
+  });
+
+  await assert.rejects(
+    repository.finishGameThird({ gameId: "game-1", third: 1 }),
+    /Timer state changed while applying this transition/,
+  );
+  const externallyFinished = await repository.getGame("game-1");
+  assert.equal(externallyFinished?.thirds[0].finishedAt, "2026-02-22T00:01:99.000Z");
+});
+
+test("timer display formatting switches to stoppage after nominal length", () => {
+  assert.deepEqual(formatThirdDisplayTime(1199, 20), {
+    displayTime: "19:59",
+    phase: "regulation",
+    elapsedSeconds: 1199,
+    stoppageSeconds: 0,
+    stoppageMinute: null,
+  });
+  assert.deepEqual(formatThirdDisplayTime(1200, 20), {
+    displayTime: "20+01",
+    phase: "stoppage",
+    elapsedSeconds: 1200,
+    stoppageSeconds: 0,
+    stoppageMinute: 1,
+  });
+  assert.deepEqual(formatThirdDisplayTime(1260, 20), {
+    displayTime: "20+02",
+    phase: "stoppage",
+    elapsedSeconds: 1260,
+    stoppageSeconds: 60,
+    stoppageMinute: 2,
+  });
+});
+
+test("repository locks third length after timer starts and rejects finished games", async () => {
+  const repository = createRepository();
+
+  await repository.createGame({
+    gameId: "game-1",
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "session-1",
+    gameStartTs: "2026-02-22T10:00:00Z",
+  });
+
+  const rescheduled = await repository.updateGame({
+    gameId: "game-1",
+    thirdLengthMinutes: 30,
+  });
+  assert.equal(rescheduled?.thirdLengthMinutes, 30);
+
+  await repository.startGameThird({ gameId: "game-1", third: 1 });
+  await assert.rejects(
+    repository.updateGame({
+      gameId: "game-1",
+      thirdLengthMinutes: 20,
+    }),
+    /Third length cannot be changed after a third has started/,
+  );
+
+  await repository.updateGame({
+    gameId: "game-1",
+    status: "finished",
+  });
+  await assert.rejects(
+    repository.finishGameThird({ gameId: "game-1", third: 1 }),
+    /Cannot finish a third after the game is finished/,
+  );
+});
+
+test("repository rejects third length changes on finished games even before timer starts", async () => {
+  const repository = createRepository();
+
+  await repository.createGame({
+    gameId: "game-1",
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "session-1",
+    status: "finished",
+    gameStartTs: "2026-02-22T10:00:00Z",
+  });
+
+  await assert.rejects(
+    repository.updateGame({
+      gameId: "game-1",
+      thirdLengthMinutes: 30,
+    }),
+    /Third length cannot be changed after the game is finished/,
+  );
 });
 
 test("repository blocks deleting season or league while descendants exist", async () => {

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -630,6 +630,13 @@ test("repository locks third length after timer starts and rejects finished game
   await assert.rejects(
     repository.updateGame({
       gameId: "game-1",
+      status: "scheduled",
+    }),
+    /Game status cannot be set back to scheduled after a third has started/,
+  );
+  await assert.rejects(
+    repository.updateGame({
+      gameId: "game-1",
       thirdLengthMinutes: 20,
     }),
     /Third length cannot be changed after a third has started/,

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -5,7 +5,13 @@ import { resolve } from "node:path";
 import test from "node:test";
 
 import { JSDOM } from "jsdom";
-import type { TeamId } from "@3fc/contracts";
+import {
+  createDefaultThirdTimerSegments,
+  DEFAULT_THIRD_LENGTH_MINUTES,
+  type TeamId,
+  type ThirdLengthMinutes,
+  type ThirdTimerSegment,
+} from "@3fc/contracts";
 
 import {
   renderGamePage,
@@ -58,6 +64,8 @@ interface MockGame {
   sessionId: string;
   status: "scheduled" | "live" | "finished";
   gameStartTs: string;
+  thirdLengthMinutes: ThirdLengthMinutes;
+  thirds: ThirdTimerSegment[];
   createdAt: string;
   updatedAt: string;
 }
@@ -449,6 +457,11 @@ function createMockFetch(state: MockApiState) {
         sessionId,
         status: body.status === "live" || body.status === "finished" ? body.status : "scheduled",
         gameStartTs: String(body.gameStartTs ?? ""),
+        thirdLengthMinutes:
+          body.thirdLengthMinutes === 25 || body.thirdLengthMinutes === 30
+            ? body.thirdLengthMinutes
+            : DEFAULT_THIRD_LENGTH_MINUTES,
+        thirds: createDefaultThirdTimerSegments(),
         createdAt: now,
         updatedAt: now,
       };
@@ -465,6 +478,90 @@ function createMockFetch(state: MockApiState) {
       }
 
       return createJsonResponse(200, game);
+    }
+
+    if (method === "PATCH" && gameMatch) {
+      const gameId = decodeURIComponent(gameMatch[1]);
+      const game = state.games.get(gameId);
+      if (!game) {
+        return createJsonResponse(404, { error: "not_found", message: "Game not found." });
+      }
+
+      const updated: MockGame = {
+        ...game,
+        status:
+          body.status === "scheduled" || body.status === "live" || body.status === "finished"
+            ? body.status
+            : game.status,
+        gameStartTs: typeof body.gameStartTs === "string" ? body.gameStartTs : game.gameStartTs,
+        thirdLengthMinutes:
+          body.thirdLengthMinutes === 20 || body.thirdLengthMinutes === 25 || body.thirdLengthMinutes === 30
+            ? body.thirdLengthMinutes
+            : game.thirdLengthMinutes,
+        updatedAt: "2026-03-28T11:00:09.000Z",
+      };
+      state.games.set(gameId, updated);
+      return createJsonResponse(200, updated);
+    }
+
+    const startThirdMatch = path.match(/^\/v1\/games\/([^/]+)\/thirds\/([^/]+)\/start$/);
+    if (method === "POST" && startThirdMatch) {
+      const gameId = decodeURIComponent(startThirdMatch[1]);
+      const thirdNumber = Number.parseInt(decodeURIComponent(startThirdMatch[2]), 10);
+      const game = state.games.get(gameId);
+      if (!game) {
+        return createJsonResponse(404, { error: "not_found", message: "Game not found." });
+      }
+
+      const thirds = game.thirds.map((third) => ({ ...third }));
+      const target = thirds.find((third) => third.third === thirdNumber);
+      if (!target) {
+        return createJsonResponse(400, { error: "Third must be 1, 2, or 3." });
+      }
+      if (target.startedAt) {
+        return createJsonResponse(409, {
+          error: "conflict",
+          message: `Third ${thirdNumber} has already been started.`,
+        });
+      }
+
+      target.startedAt = "2026-03-28T11:00:10.000Z";
+      const updated: MockGame = {
+        ...game,
+        status: "live",
+        thirds,
+        updatedAt: "2026-03-28T11:00:10.000Z",
+      };
+      state.games.set(gameId, updated);
+      return createJsonResponse(200, updated);
+    }
+
+    const finishThirdMatch = path.match(/^\/v1\/games\/([^/]+)\/thirds\/([^/]+)\/finish$/);
+    if (method === "POST" && finishThirdMatch) {
+      const gameId = decodeURIComponent(finishThirdMatch[1]);
+      const thirdNumber = Number.parseInt(decodeURIComponent(finishThirdMatch[2]), 10);
+      const game = state.games.get(gameId);
+      if (!game) {
+        return createJsonResponse(404, { error: "not_found", message: "Game not found." });
+      }
+
+      const thirds = game.thirds.map((third) => ({ ...third }));
+      const target = thirds.find((third) => third.third === thirdNumber);
+      if (!target?.startedAt) {
+        return createJsonResponse(409, {
+          error: "conflict",
+          message: `Third ${thirdNumber} cannot be finished before it is started.`,
+        });
+      }
+
+      target.finishedAt = "2026-03-28T11:00:11.000Z";
+      const updated: MockGame = {
+        ...game,
+        thirds,
+        updatedAt: "2026-03-28T11:00:11.000Z",
+      };
+      state.games.set(gameId, updated);
+      return createJsonResponse(200, updated);
     }
 
     const gameRosterMatch = path.match(/^\/v1\/games\/([^/]+)\/roster$/);
@@ -1009,6 +1106,8 @@ test("game page quick-creates and assigns roster players", async () => {
     sessionId: "20260328",
     status: "scheduled",
     gameStartTs: "2026-03-28T10:00:00.000Z",
+    thirdLengthMinutes: DEFAULT_THIRD_LENGTH_MINUTES,
+    thirds: createDefaultThirdTimerSegments(),
     createdAt: "2026-03-28T11:00:03.000Z",
     updatedAt: "2026-03-28T11:00:03.000Z",
   });
@@ -1023,10 +1122,33 @@ test("game page quick-creates and assigns roster players", async () => {
   const nicknameInput = gamePage.document.getElementById("player-nickname");
   const quickCreateButton = gamePage.document.querySelector('[data-action="quick-create-player"]');
   const rosterTeams = gamePage.document.getElementById("roster-teams");
+  const thirdLengthInput = gamePage.document.getElementById("game-edit-third-length");
+  const timerDisplay = gamePage.document.getElementById("timer-display-value");
+  const startThirdButton = gamePage.document.querySelector('[data-action="start-active-third"]');
+  const finishThirdButton = gamePage.document.querySelector('[data-action="finish-active-third"]');
   assert(nicknameInput instanceof gamePage.window.HTMLInputElement);
   assert(quickCreateButton instanceof gamePage.window.HTMLButtonElement);
   assert(rosterTeams instanceof gamePage.window.HTMLElement);
+  assert(thirdLengthInput instanceof gamePage.window.HTMLSelectElement);
+  assert(timerDisplay instanceof gamePage.window.HTMLElement);
+  assert(startThirdButton instanceof gamePage.window.HTMLButtonElement);
+  assert(finishThirdButton instanceof gamePage.window.HTMLButtonElement);
+  assert.equal(thirdLengthInput.value, "20");
+  assert.equal(timerDisplay.textContent, "00:00");
+  assert.equal(startThirdButton.textContent, "Start Third 1");
   assert.match(rosterTeams.textContent ?? "", /Red/);
+
+  dispatchClick(startThirdButton);
+  await flushAsync();
+  assert.equal(apiState.games.get("game-1")?.status, "live");
+  assert.equal(apiState.games.get("game-1")?.thirds[0].startedAt, "2026-03-28T11:00:10.000Z");
+  assert.equal(thirdLengthInput.disabled, true);
+  assert.equal(finishThirdButton.textContent, "Finish Third 1");
+
+  dispatchClick(finishThirdButton);
+  await flushAsync();
+  assert.equal(apiState.games.get("game-1")?.thirds[0].finishedAt, "2026-03-28T11:00:11.000Z");
+  assert.equal(startThirdButton.textContent, "Start Third 2");
 
   nicknameInput.value = "Ari";
   nicknameInput.dispatchEvent(new gamePage.window.Event("input", { bubbles: true }));
@@ -1084,6 +1206,8 @@ test("setup flow resolves route ids from static shells", async () => {
     sessionId: "20260328",
     status: "scheduled",
     gameStartTs: "2026-03-28T10:00:00.000Z",
+    thirdLengthMinutes: DEFAULT_THIRD_LENGTH_MINUTES,
+    thirds: createDefaultThirdTimerSegments(),
     createdAt: "2026-03-28T11:00:03.000Z",
     updatedAt: "2026-03-28T11:00:03.000Z",
   });

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -487,6 +487,14 @@ function createMockFetch(state: MockApiState) {
         return createJsonResponse(404, { error: "not_found", message: "Game not found." });
       }
 
+      if (body.status === "scheduled" && game.thirds.some((third) => third.startedAt !== null)) {
+        return createJsonResponse(409, {
+          error: "conflict",
+          code: "timer_status_locked",
+          message: "Game status cannot be set back to scheduled after a third has started.",
+        });
+      }
+
       const updated: MockGame = {
         ...game,
         status:
@@ -1122,17 +1130,23 @@ test("game page quick-creates and assigns roster players", async () => {
   const nicknameInput = gamePage.document.getElementById("player-nickname");
   const quickCreateButton = gamePage.document.querySelector('[data-action="quick-create-player"]');
   const rosterTeams = gamePage.document.getElementById("roster-teams");
+  const statusInput = gamePage.document.getElementById("game-edit-status");
   const thirdLengthInput = gamePage.document.getElementById("game-edit-third-length");
   const timerDisplay = gamePage.document.getElementById("timer-display-value");
   const startThirdButton = gamePage.document.querySelector('[data-action="start-active-third"]');
   const finishThirdButton = gamePage.document.querySelector('[data-action="finish-active-third"]');
+  const scheduledStatusOption = statusInput?.querySelector('option[value="scheduled"]');
   assert(nicknameInput instanceof gamePage.window.HTMLInputElement);
   assert(quickCreateButton instanceof gamePage.window.HTMLButtonElement);
   assert(rosterTeams instanceof gamePage.window.HTMLElement);
+  assert(statusInput instanceof gamePage.window.HTMLSelectElement);
+  assert(scheduledStatusOption instanceof gamePage.window.HTMLOptionElement);
   assert(thirdLengthInput instanceof gamePage.window.HTMLSelectElement);
   assert(timerDisplay instanceof gamePage.window.HTMLElement);
   assert(startThirdButton instanceof gamePage.window.HTMLButtonElement);
   assert(finishThirdButton instanceof gamePage.window.HTMLButtonElement);
+  assert.equal(statusInput.value, "scheduled");
+  assert.equal(scheduledStatusOption.disabled, false);
   assert.equal(thirdLengthInput.value, "20");
   assert.equal(timerDisplay.textContent, "00:00");
   assert.equal(startThirdButton.textContent, "Start Third 1");
@@ -1142,6 +1156,8 @@ test("game page quick-creates and assigns roster players", async () => {
   await flushAsync();
   assert.equal(apiState.games.get("game-1")?.status, "live");
   assert.equal(apiState.games.get("game-1")?.thirds[0].startedAt, "2026-03-28T11:00:10.000Z");
+  assert.equal(statusInput.value, "live");
+  assert.equal(scheduledStatusOption.disabled, true);
   assert.equal(thirdLengthInput.disabled, true);
   assert.equal(finishThirdButton.textContent, "Finish Third 1");
 

--- a/app/src/tests/ui-layout.test.ts
+++ b/app/src/tests/ui-layout.test.ts
@@ -139,6 +139,7 @@ test("season page includes game create form and games table", () => {
   assert.match(html, /data-page="season"/);
   assert.match(html, /data-season-id="season-1"/);
   assert.match(html, /Game date/);
+  assert.match(html, /data-testid="game-third-length"/);
   assert.match(html, /season-games-body/);
   assert.match(html, /data-testid="create-game"/);
   assert.match(html, /data-testid="delete-season"/);
@@ -195,6 +196,11 @@ test("game page renders editable game metadata view", () => {
   assert.match(html, /data-testid="save-game"/);
   assert.match(html, /data-testid="delete-game"/);
   assert.match(html, /data-testid="create-another-game"/);
+  assert.match(html, /data-testid="panel-game-timer"/);
+  assert.match(html, /data-testid="third-timer"/);
+  assert.match(html, /data-testid="start-third"/);
+  assert.match(html, /data-testid="finish-third"/);
+  assert.match(html, /data-testid="game-edit-third-length"/);
   assert.match(html, /data-testid="panel-game-roster"/);
   assert.match(html, /data-testid="quick-create-player"/);
   assert.match(html, /data-testid="roster-teams"/);

--- a/app/src/ui/layout.ts
+++ b/app/src/ui/layout.ts
@@ -321,7 +321,16 @@ export function renderSeasonPage(apiBaseUrl: string, seasonId: string): string {
       label: "Kickoff time",
       type: "datetime-local",
       required: true,
-    })}<dl data-ui="id-preview"><div><dt>Game ID</dt><dd id="game-id-display">Not generated yet</dd></div></dl>`,
+    })}
+    <div data-ui="field">
+      <label for="game-third-length">Third length</label>
+      <select id="game-third-length" data-ui="input" data-testid="game-third-length">
+        <option value="20" selected>20 minutes</option>
+        <option value="25">25 minutes</option>
+        <option value="30">30 minutes</option>
+      </select>
+    </div>
+    <dl data-ui="id-preview"><div><dt>Game ID</dt><dd id="game-id-display">Not generated yet</dd></div></dl>`,
     `<div data-ui="button-row">${renderButton("Create game", "primary", {
       type: "button",
       "data-action": "create-game",
@@ -685,6 +694,14 @@ export function renderGamePage(apiBaseUrl: string, input: GameContextPageInput):
                 <option value="live">Live</option>
                 <option value="finished">Finished</option>
               </select>
+            </div>
+            <div data-ui="field">
+              <label for="game-edit-third-length">Third length</label>
+              <select id="game-edit-third-length" data-ui="input" data-testid="game-edit-third-length">
+                <option value="20">20 minutes</option>
+                <option value="25">25 minutes</option>
+                <option value="30">30 minutes</option>
+              </select>
             </div>`,
             `<div data-ui="button-row">
               ${renderButton("Save changes", "primary", {
@@ -700,6 +717,36 @@ export function renderGamePage(apiBaseUrl: string, input: GameContextPageInput):
               <a id="create-another-game-link" href="/setup" data-ui="button-link" data-variant="secondary" data-testid="create-another-game">Create another game</a>
             </div>`,
             "panel-game-details",
+          )}
+          ${renderPanel(
+            "Third timer",
+            "Start and finish thirds in order.",
+            `<div data-ui="timer-board" data-testid="third-timer">
+              <div data-ui="timer-display">
+                <span id="timer-third-label">Third 1</span>
+                <strong id="timer-display-value">00:00</strong>
+                <span id="timer-phase-label">Not started</span>
+              </div>
+              <dl data-ui="id-preview" data-testid="timer-context-details">
+                <div><dt>Length</dt><dd id="timer-third-length">20 minutes</dd></div>
+                <div><dt>Status</dt><dd id="timer-status">Not started</dd></div>
+                <div><dt>Active third</dt><dd id="timer-active-third">-</dd></div>
+              </dl>
+              <ol data-ui="third-status-list" id="third-status-list" data-testid="third-status-list"></ol>
+            </div>`,
+            `<div data-ui="button-row">
+              ${renderButton("Start Third 1", "primary", {
+                type: "button",
+                "data-action": "start-active-third",
+                "data-testid": "start-third",
+              })}
+              ${renderButton("Finish Third", "secondary", {
+                type: "button",
+                "data-action": "finish-active-third",
+                "data-testid": "finish-third",
+              })}
+            </div>`,
+            "panel-game-timer",
           )}
           ${renderPanel(
             "Roster setup",

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -1107,6 +1107,17 @@
       return finished ?? timer.thirds[0] ?? null;
     }
 
+    function syncStatusOptions(hasStarted) {
+      const scheduledOption = statusInput.querySelector('option[value="scheduled"]');
+      if (scheduledOption instanceof HTMLOptionElement) {
+        scheduledOption.disabled = hasStarted;
+      }
+
+      if (hasStarted && statusInput.value === "scheduled") {
+        statusInput.value = currentGame.status === "finished" ? "finished" : "live";
+      }
+    }
+
     function renderTimer() {
       if (!currentGame) {
         return;
@@ -1126,6 +1137,7 @@
 
       thirdLengthInput.value = String(timer.thirdLengthMinutes);
       thirdLengthInput.disabled = hasStarted;
+      syncStatusOptions(hasStarted);
 
       if (timerThirdLabel) {
         timerThirdLabel.textContent = segment ? `Third ${segment.third}` : "Third 1";

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -250,6 +250,102 @@
     return localNow.toISOString().slice(0, 10);
   }
 
+  function parseThirdLengthMinutes(value) {
+    const parsed = Number.parseInt(String(value), 10);
+    return [20, 25, 30].includes(parsed) ? parsed : 20;
+  }
+
+  function defaultTimerThirds() {
+    return [1, 2, 3].map((third) => ({
+      third,
+      startedAt: null,
+      finishedAt: null,
+      status: "not_started",
+    }));
+  }
+
+  function buildTimerState(game) {
+    if (game?.timer && Array.isArray(game.timer.thirds)) {
+      return game.timer;
+    }
+
+    const thirdLengthMinutes = parseThirdLengthMinutes(game?.thirdLengthMinutes);
+    const sourceThirds = Array.isArray(game?.thirds) ? game.thirds : defaultTimerThirds();
+    const thirdsByNumber = new Map(sourceThirds.map((third) => [third.third, third]));
+    const thirds = [1, 2, 3].map((third) => {
+      const segment = thirdsByNumber.get(third) ?? {
+        third,
+        startedAt: null,
+        finishedAt: null,
+      };
+      const status = segment.finishedAt ? "finished" : segment.startedAt ? "running" : "not_started";
+      return {
+        third,
+        startedAt: segment.startedAt ?? null,
+        finishedAt: segment.finishedAt ?? null,
+        status,
+      };
+    });
+    const activeThird = thirds.find((third) => third.status === "running")?.third ?? null;
+    const anyStarted = thirds.some((third) => third.startedAt !== null);
+    const allFinished = thirds.every((third) => third.status === "finished");
+    const status = activeThird
+      ? "running"
+      : allFinished
+        ? "complete"
+        : anyStarted
+          ? "between_thirds"
+          : "not_started";
+
+    return {
+      thirdLengthMinutes,
+      activeThird,
+      status,
+      thirds,
+    };
+  }
+
+  function elapsedSeconds(startedAt, finishedAt = null) {
+    const started = new Date(startedAt);
+    const finished = finishedAt ? new Date(finishedAt) : new Date();
+    if (Number.isNaN(started.getTime()) || Number.isNaN(finished.getTime())) {
+      return 0;
+    }
+
+    return Math.max(0, Math.floor((finished.getTime() - started.getTime()) / 1000));
+  }
+
+  function formatTimerDisplay(totalSeconds, thirdLengthMinutes) {
+    const safeSeconds = Math.max(0, Math.floor(totalSeconds));
+    const nominalSeconds = thirdLengthMinutes * 60;
+    if (safeSeconds < nominalSeconds) {
+      const minutes = Math.floor(safeSeconds / 60);
+      const seconds = safeSeconds % 60;
+      return {
+        displayTime: `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`,
+        phase: "regulation",
+      };
+    }
+
+    const stoppageSeconds = safeSeconds - nominalSeconds;
+    const stoppageMinute = Math.floor(stoppageSeconds / 60) + 1;
+    return {
+      displayTime: `${thirdLengthMinutes}+${String(stoppageMinute).padStart(2, "0")}`,
+      phase: "stoppage",
+    };
+  }
+
+  function humanTimerStatus(value) {
+    const labels = {
+      not_started: "Not started",
+      running: "Running",
+      between_thirds: "Between thirds",
+      complete: "All thirds finished",
+      finished: "Finished",
+    };
+    return labels[value] ?? value;
+  }
+
   function syncKickoffFromDate(dateInput, kickoffInput) {
     const gameDate = dateInput.value.trim();
     if (!gameDate) {
@@ -679,6 +775,7 @@
 
     const gameDateInput = document.getElementById("game-date");
     const gameKickoffInput = document.getElementById("game-kickoff");
+    const gameThirdLengthInput = document.getElementById("game-third-length");
     const gameIdDisplay = document.getElementById("game-id-display");
     const createGameButton = root.querySelector('[data-action="create-game"]');
 
@@ -691,6 +788,7 @@
     if (
       !(gameDateInput instanceof HTMLInputElement) ||
       !(gameKickoffInput instanceof HTMLInputElement) ||
+      !(gameThirdLengthInput instanceof HTMLSelectElement) ||
       !(createGameButton instanceof HTMLButtonElement) ||
       !(gamesBody instanceof HTMLElement)
     ) {
@@ -843,6 +941,7 @@
             gameId,
             gameStartTs: kickoffIso,
             status: "scheduled",
+            thirdLengthMinutes: parseThirdLengthMinutes(gameThirdLengthInput.value),
           }),
         });
 
@@ -941,9 +1040,19 @@
 
     const kickoffInput = document.getElementById("game-edit-kickoff");
     const statusInput = document.getElementById("game-edit-status");
+    const thirdLengthInput = document.getElementById("game-edit-third-length");
     const saveButton = root.querySelector('[data-action="save-game"]');
     const deleteButton = root.querySelector('[data-action="delete-game"]');
     const createAnotherLink = document.getElementById("create-another-game-link");
+    const timerThirdLabel = document.getElementById("timer-third-label");
+    const timerDisplayValue = document.getElementById("timer-display-value");
+    const timerPhaseLabel = document.getElementById("timer-phase-label");
+    const timerThirdLength = document.getElementById("timer-third-length");
+    const timerStatus = document.getElementById("timer-status");
+    const timerActiveThird = document.getElementById("timer-active-third");
+    const thirdStatusList = document.getElementById("third-status-list");
+    const startThirdButton = root.querySelector('[data-action="start-active-third"]');
+    const finishThirdButton = root.querySelector('[data-action="finish-active-third"]');
     const playerNicknameInput = document.getElementById("player-nickname");
     const quickCreatePlayerButton = root.querySelector('[data-action="quick-create-player"]');
     const playerSearchInput = document.getElementById("player-search");
@@ -953,14 +1062,19 @@
     if (
       !(kickoffInput instanceof HTMLInputElement) ||
       !(statusInput instanceof HTMLSelectElement) ||
+      !(thirdLengthInput instanceof HTMLSelectElement) ||
       !(saveButton instanceof HTMLButtonElement) ||
-      !(deleteButton instanceof HTMLButtonElement)
+      !(deleteButton instanceof HTMLButtonElement) ||
+      !(startThirdButton instanceof HTMLButtonElement) ||
+      !(finishThirdButton instanceof HTMLButtonElement)
     ) {
       return;
     }
 
     let currentLeagueId = "";
     let currentSeasonId = "";
+    let currentGame = null;
+    let timerTickInterval = 0;
     let rosterTeams = [];
     let rosterPlayers = [];
     let rosterAssignments = [];
@@ -969,6 +1083,111 @@
     kickoffInput.addEventListener("input", () => {
       setFieldMessage("game-edit-kickoff");
     });
+
+    function nextStartableThird(timer) {
+      if (timer.status === "running" || timer.status === "complete") {
+        return null;
+      }
+
+      const next = timer.thirds.find((third) => third.status === "not_started");
+      if (!next) {
+        return null;
+      }
+
+      return next.third;
+    }
+
+    function displaySegmentForTimer(timer) {
+      const running = timer.thirds.find((third) => third.status === "running");
+      if (running) {
+        return running;
+      }
+
+      const finished = [...timer.thirds].reverse().find((third) => third.status === "finished");
+      return finished ?? timer.thirds[0] ?? null;
+    }
+
+    function renderTimer() {
+      if (!currentGame) {
+        return;
+      }
+
+      const timer = buildTimerState(currentGame);
+      const segment = displaySegmentForTimer(timer);
+      const hasStarted = timer.thirds.some((third) => third.startedAt !== null);
+      const activeSegment = timer.thirds.find((third) => third.status === "running") ?? null;
+      const display = segment?.startedAt
+        ? formatTimerDisplay(
+            elapsedSeconds(segment.startedAt, segment.finishedAt),
+            timer.thirdLengthMinutes,
+          )
+        : { displayTime: "00:00", phase: "regulation" };
+      const nextThird = nextStartableThird(timer);
+
+      thirdLengthInput.value = String(timer.thirdLengthMinutes);
+      thirdLengthInput.disabled = hasStarted;
+
+      if (timerThirdLabel) {
+        timerThirdLabel.textContent = segment ? `Third ${segment.third}` : "Third 1";
+      }
+      if (timerDisplayValue) {
+        timerDisplayValue.textContent = display.displayTime;
+      }
+      if (timerPhaseLabel) {
+        timerPhaseLabel.textContent =
+          timer.status === "running" && display.phase === "stoppage"
+            ? "Stoppage"
+            : humanTimerStatus(timer.status);
+      }
+      if (timerThirdLength) {
+        timerThirdLength.textContent = `${timer.thirdLengthMinutes} minutes`;
+      }
+      if (timerStatus) {
+        timerStatus.textContent = humanTimerStatus(timer.status);
+      }
+      if (timerActiveThird) {
+        timerActiveThird.textContent = timer.activeThird ? `Third ${timer.activeThird}` : "-";
+      }
+      if (thirdStatusList) {
+        thirdStatusList.innerHTML = timer.thirds
+          .map((third) => {
+            const status = humanTimerStatus(third.status);
+            const detail = third.finishedAt
+              ? `Finished ${third.finishedAt}`
+              : third.startedAt
+                ? `Started ${third.startedAt}`
+                : "Waiting";
+            return `<li data-ui="third-status-item" data-state="${escapeHtml(third.status)}">
+              <strong>Third ${third.third}</strong>
+              <span>${escapeHtml(status)}</span>
+              <small>${escapeHtml(detail)}</small>
+            </li>`;
+          })
+          .join("");
+      }
+
+      const gameFinished = currentGame.status === "finished";
+      startThirdButton.disabled = gameFinished || nextThird === null;
+      finishThirdButton.disabled = gameFinished || !activeSegment;
+      startThirdButton.textContent = nextThird ? `Start Third ${nextThird}` : "Start Third";
+      finishThirdButton.textContent = activeSegment ? `Finish Third ${activeSegment.third}` : "Finish Third";
+      if (nextThird) {
+        startThirdButton.setAttribute("data-third", String(nextThird));
+      } else {
+        startThirdButton.removeAttribute("data-third");
+      }
+      if (activeSegment) {
+        finishThirdButton.setAttribute("data-third", String(activeSegment.third));
+      } else {
+        finishThirdButton.removeAttribute("data-third");
+      }
+
+      window.clearInterval(timerTickInterval);
+      timerTickInterval = 0;
+      if (activeSegment) {
+        timerTickInterval = window.setInterval(renderTimer, 1000);
+      }
+    }
 
     function rosterControlsAvailable() {
       return (
@@ -1120,6 +1339,7 @@
         method: "GET",
       });
 
+      currentGame = game;
       currentLeagueId = game.leagueId;
       currentSeasonId = game.seasonId;
 
@@ -1143,6 +1363,8 @@
 
       kickoffInput.value = toLocalDateTimeInput(game.gameStartTs);
       statusInput.value = game.status;
+      thirdLengthInput.value = String(parseThirdLengthMinutes(game.thirdLengthMinutes ?? game.timer?.thirdLengthMinutes));
+      renderTimer();
 
       if (gameLeagueLink instanceof HTMLAnchorElement) {
         gameLeagueLink.href = `/leagues/${encodeURIComponent(game.leagueId)}`;
@@ -1178,6 +1400,7 @@
           body: JSON.stringify({
             gameStartTs: kickoffIso,
             status: statusInput.value,
+            thirdLengthMinutes: parseThirdLengthMinutes(thirdLengthInput.value),
           }),
         });
 
@@ -1212,6 +1435,62 @@
         setStatus("Game deletion failed.", "error");
       } finally {
         deleteButton.disabled = false;
+      }
+    });
+
+    startThirdButton.addEventListener("click", async () => {
+      const third = startThirdButton.getAttribute("data-third");
+      if (!third) {
+        return;
+      }
+
+      startThirdButton.disabled = true;
+      clearError();
+      setStatus(`Starting third ${third}…`, "default");
+
+      try {
+        currentGame = await requestJsonOrThrow(
+          `/v1/games/${encodeURIComponent(gameId)}/thirds/${encodeURIComponent(third)}/start`,
+          { method: "POST" },
+        );
+        renderTimer();
+        statusInput.value = currentGame.status;
+        setStatus(`Third ${third} started.`, "success");
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Could not start third.";
+        showError(message);
+        setStatus("Third start failed.", "error");
+      } finally {
+        startThirdButton.disabled = false;
+        renderTimer();
+      }
+    });
+
+    finishThirdButton.addEventListener("click", async () => {
+      const third = finishThirdButton.getAttribute("data-third");
+      if (!third) {
+        return;
+      }
+
+      finishThirdButton.disabled = true;
+      clearError();
+      setStatus(`Finishing third ${third}…`, "default");
+
+      try {
+        currentGame = await requestJsonOrThrow(
+          `/v1/games/${encodeURIComponent(gameId)}/thirds/${encodeURIComponent(third)}/finish`,
+          { method: "POST" },
+        );
+        renderTimer();
+        statusInput.value = currentGame.status;
+        setStatus(`Third ${third} finished.`, "success");
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Could not finish third.";
+        showError(message);
+        setStatus("Third finish failed.", "error");
+      } finally {
+        finishThirdButton.disabled = false;
+        renderTimer();
       }
     });
 

--- a/app/src/ui/styles.css
+++ b/app/src/ui/styles.css
@@ -330,6 +330,12 @@ body {
       border-color: #862e25;
     }
   }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.55;
+    transform: none;
+  }
 }
 
 [data-ui="button-link"] {
@@ -456,6 +462,76 @@ body {
 [data-ui="roster-workspace"] {
   display: grid;
   gap: 0.85rem;
+}
+
+[data-ui="timer-board"] {
+  display: grid;
+  gap: 0.75rem;
+}
+
+[data-ui="timer-display"] {
+  display: grid;
+  gap: 0.2rem;
+  border: 1px solid #c6ddd5;
+  border-radius: 10px;
+  padding: 0.75rem;
+  background: #f7fcfa;
+
+  span {
+    color: var(--ink-soft);
+    font-weight: 700;
+    font-size: 0.82rem;
+  }
+
+  strong {
+    font-family: var(--font-display);
+    font-size: 2.4rem;
+    line-height: 1;
+  }
+}
+
+[data-ui="third-status-list"] {
+  display: grid;
+  gap: 0.45rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+[data-ui="third-status-item"] {
+  display: grid;
+  gap: 0.12rem;
+  border: 1px solid #d3e5df;
+  border-radius: 8px;
+  padding: 0.5rem;
+  background: #ffffff;
+
+  strong,
+  span,
+  small {
+    overflow-wrap: anywhere;
+  }
+
+  span {
+    color: #31534f;
+    font-weight: 700;
+    font-size: 0.84rem;
+  }
+
+  small {
+    color: var(--ink-soft);
+    font-size: 0.76rem;
+  }
+
+  &[data-state="running"] {
+    border-color: var(--accent);
+    background: var(--accent-soft);
+  }
+
+  &[data-state="finished"] {
+    border-color: #abcfc1;
+    background: #f3faf7;
+  }
 }
 
 [data-ui="player-pool"],

--- a/docs/openapi/v1-core-write.yaml
+++ b/docs/openapi/v1-core-write.yaml
@@ -3,7 +3,7 @@ info:
   title: 3FC Core Write API
   version: 0.1.0
   description: |
-    Authenticated core write routes for league/season/session/game creation and M2 roster setup.
+    Authenticated core write routes for league/season/session/game creation, M2 roster setup, and third timer control.
 servers:
   - url: https://qa-api.3fc.football
     description: QA
@@ -139,6 +139,62 @@ paths:
           $ref: "#/components/responses/NotFound"
         "409":
           $ref: "#/components/responses/IdempotencyConflict"
+  /v1/games/{gameId}/thirds/{third}/start:
+    post:
+      summary: Start a game third timer
+      operationId: startGameThird
+      parameters:
+        - name: gameId
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/ThirdNumber"
+      responses:
+        "200":
+          description: Third started
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Game"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+  /v1/games/{gameId}/thirds/{third}/finish:
+    post:
+      summary: Finish a game third timer
+      operationId: finishGameThird
+      parameters:
+        - name: gameId
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/ThirdNumber"
+      responses:
+        "200":
+          description: Third finished
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Game"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
   /v1/seasons/{seasonId}/teams:
     get:
       summary: List season default teams
@@ -411,6 +467,16 @@ components:
           - red
           - blue
           - yellow
+    ThirdNumber:
+      name: third
+      in: path
+      required: true
+      schema:
+        type: integer
+        enum:
+          - 1
+          - 2
+          - 3
   responses:
     BadRequest:
       description: Request body or headers failed validation
@@ -432,6 +498,12 @@ components:
             $ref: "#/components/schemas/ErrorResponse"
     NotFound:
       description: Referenced parent entity not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    Conflict:
+      description: State transition rejected
       content:
         application/json:
           schema:
@@ -517,6 +589,13 @@ components:
             - scheduled
             - live
             - finished
+        thirdLengthMinutes:
+          type: integer
+          enum:
+            - 20
+            - 25
+            - 30
+          default: 20
     UpsertTeamRequest:
       type: object
       additionalProperties: false
@@ -646,6 +725,9 @@ components:
         - sessionId
         - status
         - gameStartTs
+        - thirdLengthMinutes
+        - thirds
+        - timer
         - createdAt
         - updatedAt
       properties:
@@ -665,12 +747,98 @@ components:
             - finished
         gameStartTs:
           type: string
+        thirdLengthMinutes:
+          type: integer
+          enum:
+            - 20
+            - 25
+            - 30
+        thirds:
+          type: array
+          minItems: 3
+          maxItems: 3
+          items:
+            $ref: "#/components/schemas/ThirdTimerSegment"
+        timer:
+          $ref: "#/components/schemas/GameTimerState"
         createdAt:
           type: string
           format: date-time
         updatedAt:
           type: string
           format: date-time
+    ThirdTimerSegment:
+      type: object
+      required:
+        - third
+        - startedAt
+        - finishedAt
+      properties:
+        third:
+          type: integer
+          enum:
+            - 1
+            - 2
+            - 3
+        startedAt:
+          type:
+            - string
+            - "null"
+          format: date-time
+        finishedAt:
+          type:
+            - string
+            - "null"
+          format: date-time
+    ThirdTimerState:
+      allOf:
+        - $ref: "#/components/schemas/ThirdTimerSegment"
+        - type: object
+          required:
+            - status
+          properties:
+            status:
+              type: string
+              enum:
+                - not_started
+                - running
+                - finished
+    GameTimerState:
+      type: object
+      required:
+        - thirdLengthMinutes
+        - activeThird
+        - status
+        - thirds
+      properties:
+        thirdLengthMinutes:
+          type: integer
+          enum:
+            - 20
+            - 25
+            - 30
+        activeThird:
+          type:
+            - integer
+            - "null"
+          enum:
+            - 1
+            - 2
+            - 3
+            - null
+        status:
+          type: string
+          enum:
+            - not_started
+            - running
+            - between_thirds
+            - complete
+        thirds:
+          type: array
+          minItems: 3
+          maxItems: 3
+          items:
+            $ref: "#/components/schemas/ThirdTimerState"
     SeasonTeam:
       type: object
       required:

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,6 +1,13 @@
 export type TeamId = "red" | "blue" | "yellow";
+export type ThirdNumber = 1 | 2 | 3;
+export type ThirdLengthMinutes = 20 | 25 | 30;
+export type ThirdTimerStatus = "not_started" | "running" | "finished";
+export type GameTimerStatus = "not_started" | "running" | "between_thirds" | "complete";
 
 export const TEAM_IDS = ["red", "blue", "yellow"] as const satisfies readonly TeamId[];
+export const THIRD_NUMBERS = [1, 2, 3] as const satisfies readonly ThirdNumber[];
+export const THIRD_LENGTH_MINUTES = [20, 25, 30] as const satisfies readonly ThirdLengthMinutes[];
+export const DEFAULT_THIRD_LENGTH_MINUTES = 20 satisfies ThirdLengthMinutes;
 
 export interface DefaultTeamDefinition {
   teamId: TeamId;
@@ -36,6 +43,31 @@ export interface GoalEventInput {
   ownGoal: boolean;
 }
 
+export interface ThirdTimerSegment {
+  third: ThirdNumber;
+  startedAt: string | null;
+  finishedAt: string | null;
+}
+
+export interface ThirdTimerState extends ThirdTimerSegment {
+  status: ThirdTimerStatus;
+}
+
+export interface GameTimerState {
+  thirdLengthMinutes: ThirdLengthMinutes;
+  activeThird: ThirdNumber | null;
+  status: GameTimerStatus;
+  thirds: ThirdTimerState[];
+}
+
+export interface ThirdDisplayTime {
+  displayTime: string;
+  phase: "regulation" | "stoppage";
+  elapsedSeconds: number;
+  stoppageSeconds: number;
+  stoppageMinute: number | null;
+}
+
 export interface GameHealth {
   status: "ok";
   service: "api";
@@ -44,6 +76,99 @@ export interface GameHealth {
 }
 
 export const MAX_ASSISTS = 3;
+
+export function isThirdNumber(value: number): value is ThirdNumber {
+  return THIRD_NUMBERS.includes(value as ThirdNumber);
+}
+
+export function isThirdLengthMinutes(value: number): value is ThirdLengthMinutes {
+  return THIRD_LENGTH_MINUTES.includes(value as ThirdLengthMinutes);
+}
+
+export function createDefaultThirdTimerSegments(): ThirdTimerSegment[] {
+  return THIRD_NUMBERS.map((third) => ({
+    third,
+    startedAt: null,
+    finishedAt: null,
+  }));
+}
+
+export function buildGameTimerState(input: {
+  thirdLengthMinutes: ThirdLengthMinutes;
+  thirds: readonly ThirdTimerSegment[];
+}): GameTimerState {
+  const thirdsByNumber = new Map(input.thirds.map((third) => [third.third, third]));
+  const thirds = THIRD_NUMBERS.map((third) => {
+    const segment = thirdsByNumber.get(third) ?? {
+      third,
+      startedAt: null,
+      finishedAt: null,
+    };
+    const status: ThirdTimerStatus = segment.finishedAt
+      ? "finished"
+      : segment.startedAt
+        ? "running"
+        : "not_started";
+
+    return {
+      third,
+      startedAt: segment.startedAt,
+      finishedAt: segment.finishedAt,
+      status,
+    };
+  });
+  const activeThird = thirds.find((third) => third.status === "running")?.third ?? null;
+  const anyStarted = thirds.some((third) => third.startedAt !== null);
+  const allFinished = thirds.every((third) => third.status === "finished");
+  const status: GameTimerStatus = activeThird
+    ? "running"
+    : allFinished
+      ? "complete"
+      : anyStarted
+        ? "between_thirds"
+        : "not_started";
+
+  return {
+    thirdLengthMinutes: input.thirdLengthMinutes,
+    activeThird,
+    status,
+    thirds,
+  };
+}
+
+function padTwoDigits(value: number): string {
+  return String(value).padStart(2, "0");
+}
+
+export function formatThirdDisplayTime(
+  elapsedSeconds: number,
+  thirdLengthMinutes: ThirdLengthMinutes,
+): ThirdDisplayTime {
+  const safeElapsedSeconds = Math.max(0, Math.floor(elapsedSeconds));
+  const nominalSeconds = thirdLengthMinutes * 60;
+
+  if (safeElapsedSeconds < nominalSeconds) {
+    const minutes = Math.floor(safeElapsedSeconds / 60);
+    const seconds = safeElapsedSeconds % 60;
+    return {
+      displayTime: `${padTwoDigits(minutes)}:${padTwoDigits(seconds)}`,
+      phase: "regulation",
+      elapsedSeconds: safeElapsedSeconds,
+      stoppageSeconds: 0,
+      stoppageMinute: null,
+    };
+  }
+
+  const stoppageSeconds = safeElapsedSeconds - nominalSeconds;
+  const stoppageMinute = Math.floor(stoppageSeconds / 60) + 1;
+  return {
+    displayTime: `${thirdLengthMinutes}+${padTwoDigits(stoppageMinute)}`,
+    phase: "stoppage",
+    elapsedSeconds: safeElapsedSeconds,
+    stoppageSeconds,
+    stoppageMinute,
+  };
+}
 
 export function validateAssistPlayerIds(
   scorerPlayerId: string,

--- a/serverless.api-core.yml
+++ b/serverless.api-core.yml
@@ -161,6 +161,18 @@ functions:
           method: OPTIONS
           path: /v1/games/{gameId}
       - httpApi:
+          method: POST
+          path: /v1/games/{gameId}/thirds/{third}/start
+      - httpApi:
+          method: OPTIONS
+          path: /v1/games/{gameId}/thirds/{third}/start
+      - httpApi:
+          method: POST
+          path: /v1/games/{gameId}/thirds/{third}/finish
+      - httpApi:
+          method: OPTIONS
+          path: /v1/games/{gameId}/thirds/{third}/finish
+      - httpApi:
           method: GET
           path: /v1/games/{gameId}/teams
       - httpApi:


### PR DESCRIPTION
## Summary
- add three-third timer state to game records and responses, with default timer metadata for legacy game reads
- add start/finish third APIs with strict third parsing, ACL protection, server-side transition validation, and conditional state writes
- surface third length and timer controls in the phone-first game UI, with OpenAPI and Serverless route coverage
- lock started games out of the invalid `live`/timer-started -> `scheduled` transition; the API now returns `409 timer_status_locked` and the UI disables `Scheduled` once a third has started

## Stack
- Base: `main` after #87 merged
- Ready to review as the next M2 slice

Fixes #26
Part of #7

## Validation
- `npm run test -w @3fc/api`
- `npm run test -w @3fc/app`
- `npm test`
- `git diff --check`
- rebased locally onto merged `main` and force-pushed to `codex/m2-02-third-timer`
- latest PR checks passed: https://github.com/ajfisher/3fc/actions/runs/27896416937
- latest QA deploy passed, including deployed smoke tests: https://github.com/ajfisher/3fc/actions/runs/27896416929
- implementation subagent pass, review subagent pass, rebriefed implementation for review findings, second review found no issues

## Known Risks / Follow-ups
- Scoring, event timeline, finish-game/results, and full browser E2E remain in later M2 stacked slices.
- Timer completion currently marks timer state complete after all thirds finish; explicit game finalization remains a separate M2 slice.