### PR TITLE
[codex] Add M2 goal scoring API

### DIFF
--- a/api/src/auth/acl.ts
+++ b/api/src/auth/acl.ts
@@ -11,6 +11,7 @@ const ROUTES = {
   assignRosterPlayer: /^\/v1\/games\/([^/]+)\/roster\/([^/]+)$/,
   startGameThird: /^\/v1\/games\/([^/]+)\/thirds\/([^/]*)\/start$/,
   finishGameThird: /^\/v1\/games\/([^/]+)\/thirds\/([^/]*)\/finish$/,
+  createGoal: /^\/v1\/games\/([^/]+)\/goals$/,
 } as const;
 
 export type ProtectedMutationOperation =
@@ -23,7 +24,8 @@ export type ProtectedMutationOperation =
   | "createGamePlayer"
   | "assignRosterPlayer"
   | "startGameThird"
-  | "finishGameThird";
+  | "finishGameThird"
+  | "createGoal";
 
 export interface ProtectedMutationRoute {
   operation: ProtectedMutationOperation;
@@ -136,6 +138,14 @@ export function resolveProtectedMutationRoute(
     return {
       operation: "finishGameThird",
       gameId: decodeRouteParam(finishGameThirdMatch[1]),
+    };
+  }
+
+  const createGoalMatch = upperMethod === "POST" ? route.match(ROUTES.createGoal) : null;
+  if (createGoalMatch) {
+    return {
+      operation: "createGoal",
+      gameId: decodeRouteParam(createGoalMatch[1]),
     };
   }
 

--- a/api/src/auth/session.ts
+++ b/api/src/auth/session.ts
@@ -111,6 +111,10 @@ export function isAuthenticatedApiRoute(method: string, route: string): boolean 
     return true;
   }
 
+  if (method === "POST" && /^\/v1\/games\/[^/]+\/goals$/.test(route)) {
+    return true;
+  }
+
   if (method === "GET" && route === "/v1/auth/session") {
     return true;
   }

--- a/api/src/contracts/core-write.ts
+++ b/api/src/contracts/core-write.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { TEAM_IDS, THIRD_LENGTH_MINUTES } from "@3fc/contracts";
+import { MAX_ASSISTS, TEAM_IDS, THIRD_LENGTH_MINUTES } from "@3fc/contracts";
 
 const nonEmptyTrimmedString = z.string().trim().min(1, "must be a non-empty string");
 const optionalNullableString = z.string().nullable().optional();
@@ -70,6 +70,64 @@ export const assignRosterPlayerRequestSchema = z
   })
   .strict();
 
+export const createGoalRequestSchema = z
+  .object({
+    scoringTeamId: teamIdSchema.nullable(),
+    concedingTeamId: teamIdSchema,
+    scorerPlayerId: nonEmptyTrimmedString,
+    assistPlayerIds: z
+      .array(nonEmptyTrimmedString)
+      .max(MAX_ASSISTS, `must contain no more than ${MAX_ASSISTS} player IDs`)
+      .optional()
+      .default([]),
+    ownGoal: z.boolean(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    const assistPlayerIds = value.assistPlayerIds;
+    const uniqueAssistPlayerIds = new Set(assistPlayerIds);
+
+    if (uniqueAssistPlayerIds.size !== assistPlayerIds.length) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["assistPlayerIds"],
+        message: "must be unique",
+      });
+    }
+
+    if (uniqueAssistPlayerIds.has(value.scorerPlayerId)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["assistPlayerIds"],
+        message: "must not include the scorer",
+      });
+    }
+
+    if (value.ownGoal && value.scoringTeamId !== null) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["scoringTeamId"],
+        message: "must be null for own goals",
+      });
+    }
+
+    if (!value.ownGoal && value.scoringTeamId === null) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["scoringTeamId"],
+        message: "is required for standard goals",
+      });
+    }
+
+    if (!value.ownGoal && value.scoringTeamId === value.concedingTeamId) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["concedingTeamId"],
+        message: "must differ from scoringTeamId for standard goals",
+      });
+    }
+  });
+
 export type CreateLeagueRequest = z.infer<typeof createLeagueRequestSchema>;
 export type CreateSeasonRequest = z.infer<typeof createSeasonRequestSchema>;
 export type CreateSessionRequest = z.infer<typeof createSessionRequestSchema>;
@@ -77,6 +135,7 @@ export type CreateGameRequest = z.infer<typeof createGameRequestSchema>;
 export type UpsertTeamRequest = z.infer<typeof upsertTeamRequestSchema>;
 export type QuickCreateGamePlayerRequest = z.infer<typeof quickCreateGamePlayerRequestSchema>;
 export type AssignRosterPlayerRequest = z.infer<typeof assignRosterPlayerRequestSchema>;
+export type CreateGoalRequest = z.infer<typeof createGoalRequestSchema>;
 
 export function formatSchemaValidationError(error: z.ZodError): string {
   if (error.issues.length === 0) {

--- a/api/src/data/keys.ts
+++ b/api/src/data/keys.ts
@@ -71,7 +71,17 @@ export function gameSessionIndexSk(gameStartTs: string, gameId: string): string 
   return `GAME#${gameStartTs}#${gameId}`;
 }
 
-export function goalSk(third: 1 | 2 | 3, gameMinute: number, eventId: string): string {
+export function goalEventIdSk(eventId: string): string {
+  return `GOAL_EVENT#${eventId}`;
+}
+
+export function goalSk(
+  third: 1 | 2 | 3,
+  gameMinute: number,
+  elapsedSeconds: number,
+  eventId: string,
+): string {
   const minuteSortable = String(gameMinute).padStart(4, "0");
-  return `GOAL#${third}#${minuteSortable}#${eventId}`;
+  const elapsedSortable = String(elapsedSeconds).padStart(6, "0");
+  return `GOAL#${third}#${minuteSortable}#${elapsedSortable}#${eventId}`;
 }

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -244,8 +244,8 @@ function normalizeGoalEventPayload(data: unknown): Omit<GoalEventRecord, "create
     gameMinute,
     elapsedSeconds,
     stoppageMinute:
-      raw.stoppageMinute === null || Number.isInteger(raw.stoppageMinute)
-        ? (raw.stoppageMinute ?? null)
+      Number.isInteger(raw.stoppageMinute) && (raw.stoppageMinute as number) >= 1
+        ? (raw.stoppageMinute as number)
         : null,
     displayTime: raw.displayTime ?? String(gameMinute),
     scoringTeamId: raw.scoringTeamId ?? null,

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -208,6 +208,10 @@ function normalizeNonNegativeInteger(value: unknown): number {
   return Number.isInteger(value) && (value as number) >= 0 ? (value as number) : 0;
 }
 
+function normalizePositiveInteger(value: unknown): number {
+  return Number.isInteger(value) && (value as number) >= 1 ? (value as number) : 1;
+}
+
 function normalizeGameTeamPayload(data: unknown): Omit<GameTeamRecord, "createdAt" | "updatedAt"> {
   const raw = data as Partial<Omit<GameTeamRecord, "createdAt" | "updatedAt">>;
 
@@ -224,8 +228,8 @@ function normalizeGameTeamPayload(data: unknown): Omit<GameTeamRecord, "createdA
 function normalizeGoalEventPayload(data: unknown): Omit<GoalEventRecord, "createdAt" | "updatedAt"> {
   const raw = data as Partial<Omit<GoalEventRecord, "createdAt" | "updatedAt">>;
   const third = raw.third ?? 1;
-  const thirdMinute = normalizeNonNegativeInteger(raw.thirdMinute);
-  const gameMinute = normalizeNonNegativeInteger(raw.gameMinute);
+  const thirdMinute = normalizePositiveInteger(raw.thirdMinute);
+  const gameMinute = normalizePositiveInteger(raw.gameMinute);
   const elapsedSeconds = normalizeNonNegativeInteger(raw.elapsedSeconds);
 
   return {
@@ -263,10 +267,25 @@ function sortGameTeams<T extends { teamId: TeamId }>(teams: T[]): T[] {
 }
 
 function isConditionalWriteFailure(error: unknown): boolean {
-  const awsError = error as { name?: string };
-  return (
-    awsError.name === "ConditionalCheckFailedException" ||
-    awsError.name === "TransactionCanceledException"
+  const awsError = error as {
+    name?: string;
+    CancellationReasons?: Array<{ Code?: string }>;
+    cancellationReasons?: Array<{ Code?: string }>;
+  };
+
+  if (awsError.name === "ConditionalCheckFailedException") {
+    return true;
+  }
+
+  if (awsError.name !== "TransactionCanceledException") {
+    return false;
+  }
+
+  const cancellationReasons = awsError.CancellationReasons ?? awsError.cancellationReasons ?? [];
+  return cancellationReasons.some(
+    (reason) =>
+      reason.Code === "ConditionalCheckFailed" ||
+      reason.Code === "ConditionalCheckFailedException",
   );
 }
 

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -232,8 +232,8 @@ function normalizeGameTeamPayload(data: unknown): Omit<GameTeamRecord, "createdA
   return {
     gameId: raw.gameId ?? "",
     teamId: isTeamId(raw.teamId) ? raw.teamId : "red",
-    name: raw.name ?? "",
-    color: raw.color ?? null,
+    name: typeof raw.name === "string" ? raw.name : "",
+    color: typeof raw.color === "string" ? raw.color : null,
     scored: normalizeNonNegativeInteger(raw.scored),
     conceded: normalizeNonNegativeInteger(raw.conceded),
   };
@@ -1386,10 +1386,10 @@ export class ThreeFcRepository {
         ? Math.max(0, Math.floor((nowMs - startedAtMs) / 1000))
         : 0;
     const display = formatThirdDisplayTime(elapsedSeconds, game.thirdLengthMinutes);
-    const thirdMinute =
-      display.phase === "stoppage"
-        ? game.thirdLengthMinutes
-        : Math.floor(display.elapsedSeconds / 60) + 1;
+    const thirdMinute = Math.min(
+      game.thirdLengthMinutes,
+      Math.floor(display.elapsedSeconds / 60) + 1,
+    );
     const gameMinute = (activeThird.third - 1) * game.thirdLengthMinutes + thirdMinute;
     const payload = {
       gameId: input.gameId,

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -231,7 +231,7 @@ function normalizeGameTeamPayload(data: unknown): Omit<GameTeamRecord, "createdA
 
   return {
     gameId: raw.gameId ?? "",
-    teamId: raw.teamId ?? "red",
+    teamId: isTeamId(raw.teamId) ? raw.teamId : "red",
     name: raw.name ?? "",
     color: raw.color ?? null,
     scored: normalizeNonNegativeInteger(raw.scored),

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -168,6 +168,16 @@ function requireTeamId(teamId: string | null, fieldName: string): asserts teamId
   }
 }
 
+function isTeamId(value: unknown): value is TeamId {
+  return typeof value === "string" && TEAM_IDS.includes(value as TeamId);
+}
+
+function normalizeThirdNumber(value: unknown): ThirdNumber {
+  return typeof value === "number" && THIRD_NUMBERS.includes(value as ThirdNumber)
+    ? (value as ThirdNumber)
+    : 1;
+}
+
 function normalizeThirdLengthMinutes(value: unknown): ThirdLengthMinutes {
   return typeof value === "number" && isThirdLengthMinutes(value)
     ? value
@@ -231,7 +241,7 @@ function normalizeGameTeamPayload(data: unknown): Omit<GameTeamRecord, "createdA
 
 function normalizeGoalEventPayload(data: unknown): Omit<GoalEventRecord, "createdAt" | "updatedAt"> {
   const raw = data as Partial<Omit<GoalEventRecord, "createdAt" | "updatedAt">>;
-  const third = raw.third ?? 1;
+  const third = normalizeThirdNumber(raw.third);
   const thirdMinute = normalizePositiveInteger(raw.thirdMinute);
   const gameMinute = normalizePositiveInteger(raw.gameMinute);
   const elapsedSeconds = normalizeNonNegativeInteger(raw.elapsedSeconds);
@@ -248,8 +258,8 @@ function normalizeGoalEventPayload(data: unknown): Omit<GoalEventRecord, "create
         ? (raw.stoppageMinute as number)
         : null,
     displayTime: raw.displayTime ?? String(gameMinute),
-    scoringTeamId: raw.scoringTeamId ?? null,
-    concedingTeamId: raw.concedingTeamId ?? "red",
+    scoringTeamId: isTeamId(raw.scoringTeamId) ? raw.scoringTeamId : null,
+    concedingTeamId: isTeamId(raw.concedingTeamId) ? raw.concedingTeamId : "red",
     scorerPlayerId: raw.scorerPlayerId ?? "",
     assistPlayerIds: Array.isArray(raw.assistPlayerIds)
       ? raw.assistPlayerIds.filter((playerId): playerId is string => typeof playerId === "string")

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -1297,7 +1297,9 @@ export class ThreeFcRepository {
       );
     }
 
-    const teamItems = await this.queryByPrefix(gamePk(input.gameId), "TEAM#");
+    const teamItems = await this.queryByPrefix(gamePk(input.gameId), "TEAM#", {
+      consistentRead: true,
+    });
     const teamStates = teamItems
       .filter((item) => item.entityType === ENTITY_TYPE.gameTeam)
       .map((item) => ({

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -105,6 +105,10 @@ interface DynamoCommandClient {
   send(command: unknown): Promise<unknown>;
 }
 
+interface QueryByPrefixOptions {
+  consistentRead?: boolean;
+}
+
 interface StoredEntity<T> {
   pk: string;
   sk: string;
@@ -1534,7 +1538,7 @@ export class ThreeFcRepository {
 
   async listGoalEvents(gameId: string): Promise<GoalEventRecord[]> {
     requireNonEmpty("gameId", gameId);
-    const items = await this.queryByPrefix(gamePk(gameId), "GOAL#");
+    const items = await this.queryByPrefix(gamePk(gameId), "GOAL#", { consistentRead: true });
 
     return items
       .filter((item) => item.entityType === ENTITY_TYPE.goal)
@@ -1703,11 +1707,16 @@ export class ThreeFcRepository {
     return parseStoredEntity(result.Item);
   }
 
-  private async queryByPrefix(pk: string, skPrefix: string): Promise<Array<StoredEntity<unknown>>> {
+  private async queryByPrefix(
+    pk: string,
+    skPrefix: string,
+    options: QueryByPrefixOptions = {},
+  ): Promise<Array<StoredEntity<unknown>>> {
     const result = (await this.client.send(
       new QueryCommand({
         TableName: this.tableName,
         KeyConditionExpression: "pk = :pk and begins_with(sk, :skPrefix)",
+        ConsistentRead: options.consistentRead,
         ExpressionAttributeValues: {
           ":pk": { S: pk },
           ":skPrefix": { S: skPrefix },

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -7,14 +7,18 @@ import {
   type QueryCommandOutput,
   ScanCommand,
   type ScanCommandOutput,
+  TransactWriteItemsCommand,
   type AttributeValue,
 } from "@aws-sdk/client-dynamodb";
 import {
   createDefaultThirdTimerSegments,
   DEFAULT_THIRD_LENGTH_MINUTES,
+  formatThirdDisplayTime,
   isThirdLengthMinutes,
   THIRD_NUMBERS,
   validateAssistPlayerIds,
+  TEAM_IDS,
+  type TeamId,
   type ThirdLengthMinutes,
   type ThirdNumber,
   type ThirdTimerSegment,
@@ -26,6 +30,7 @@ import {
   gamePlayerSk,
   gameSessionIndexPk,
   gameSessionIndexSk,
+  goalEventIdSk,
   goalSk,
   idempotencyPk,
   leaguePk,
@@ -43,7 +48,8 @@ import type {
   AssignRosterInput,
   CreateGameTeamInput,
   CreateGameInput,
-  CreateGoalEventInput,
+  CreateGoalInput,
+  CreateGoalResult,
   CreateIdempotencyRecordInput,
   CreateLeagueInput,
   CreatePlayerInput,
@@ -83,6 +89,7 @@ const ENTITY_TYPE = {
   acl: "acl",
   roster: "roster",
   goal: "goal",
+  goalEventId: "goalEventId",
   idempotency: "idempotency",
 } as const;
 
@@ -124,21 +131,36 @@ export class GameTimerTransitionError extends Error {
   }
 }
 
+export class GoalCreationError extends Error {
+  constructor(
+    readonly code: string,
+    readonly statusCode: 400 | 409,
+    message: string,
+  ) {
+    super(message);
+    this.name = "GoalCreationError";
+  }
+}
+
 function requireNonEmpty(name: string, value: string): void {
   if (value.trim().length === 0) {
     throw new Error(`${name} must be a non-empty string.`);
   }
 }
 
-function requireGameMinute(gameMinute: number): void {
-  if (!Number.isInteger(gameMinute) || gameMinute < 0) {
-    throw new Error("gameMinute must be an integer greater than or equal to zero.");
-  }
-}
-
 function requireThirdNumber(third: number): asserts third is ThirdNumber {
   if (!THIRD_NUMBERS.includes(third as ThirdNumber)) {
     throw new Error("third must be 1, 2, or 3.");
+  }
+}
+
+function requireTeamId(teamId: string | null, fieldName: string): asserts teamId is TeamId {
+  if (teamId === null || !TEAM_IDS.includes(teamId as TeamId)) {
+    throw new GoalCreationError(
+      "invalid_team",
+      400,
+      `${fieldName} must be red, blue, or yellow.`,
+    );
   }
 }
 
@@ -182,8 +204,70 @@ function normalizeGamePayload(data: unknown): Omit<GameRecord, "createdAt" | "up
   };
 }
 
+function normalizeNonNegativeInteger(value: unknown): number {
+  return Number.isInteger(value) && (value as number) >= 0 ? (value as number) : 0;
+}
+
+function normalizeGameTeamPayload(data: unknown): Omit<GameTeamRecord, "createdAt" | "updatedAt"> {
+  const raw = data as Partial<Omit<GameTeamRecord, "createdAt" | "updatedAt">>;
+
+  return {
+    gameId: raw.gameId ?? "",
+    teamId: raw.teamId ?? "red",
+    name: raw.name ?? "",
+    color: raw.color ?? null,
+    scored: normalizeNonNegativeInteger(raw.scored),
+    conceded: normalizeNonNegativeInteger(raw.conceded),
+  };
+}
+
+function normalizeGoalEventPayload(data: unknown): Omit<GoalEventRecord, "createdAt" | "updatedAt"> {
+  const raw = data as Partial<Omit<GoalEventRecord, "createdAt" | "updatedAt">>;
+  const third = raw.third ?? 1;
+  const thirdMinute = normalizeNonNegativeInteger(raw.thirdMinute);
+  const gameMinute = normalizeNonNegativeInteger(raw.gameMinute);
+  const elapsedSeconds = normalizeNonNegativeInteger(raw.elapsedSeconds);
+
+  return {
+    gameId: raw.gameId ?? "",
+    eventId: raw.eventId ?? "",
+    third,
+    thirdMinute,
+    gameMinute,
+    elapsedSeconds,
+    stoppageMinute:
+      raw.stoppageMinute === null || Number.isInteger(raw.stoppageMinute)
+        ? (raw.stoppageMinute ?? null)
+        : null,
+    displayTime: raw.displayTime ?? String(gameMinute),
+    scoringTeamId: raw.scoringTeamId ?? null,
+    concedingTeamId: raw.concedingTeamId ?? "red",
+    scorerPlayerId: raw.scorerPlayerId ?? "",
+    assistPlayerIds: Array.isArray(raw.assistPlayerIds)
+      ? raw.assistPlayerIds.filter((playerId): playerId is string => typeof playerId === "string")
+      : [],
+    ownGoal: raw.ownGoal ?? false,
+  };
+}
+
 function isThirdStarted(game: Pick<GameRecord, "thirds">): boolean {
   return game.thirds.some((third) => third.startedAt !== null);
+}
+
+function compareTeamIds(left: TeamId, right: TeamId): number {
+  return TEAM_IDS.indexOf(left) - TEAM_IDS.indexOf(right);
+}
+
+function sortGameTeams<T extends { teamId: TeamId }>(teams: T[]): T[] {
+  return [...teams].sort((left, right) => compareTeamIds(left.teamId, right.teamId));
+}
+
+function isConditionalWriteFailure(error: unknown): boolean {
+  const awsError = error as { name?: string };
+  return (
+    awsError.name === "ConditionalCheckFailedException" ||
+    awsError.name === "TransactionCanceledException"
+  );
 }
 
 function readString(value: AttributeValue | undefined, field: string): string {
@@ -425,11 +509,14 @@ export class ThreeFcRepository {
 
     const now = this.clock.now();
     const existing = await this.getEntity(gamePk(input.gameId), teamSk(input.teamId));
+    const existingPayload = existing ? normalizeGameTeamPayload(existing.data) : null;
     const payload = {
       gameId: input.gameId,
       teamId: input.teamId,
       name: input.name,
       color: input.color ?? null,
+      scored: existingPayload?.scored ?? 0,
+      conceded: existingPayload?.conceded ?? 0,
     };
 
     await this.putEntityWithTimestamps(
@@ -447,15 +534,17 @@ export class ThreeFcRepository {
     requireNonEmpty("gameId", gameId);
     const items = await this.queryByPrefix(gamePk(gameId), "TEAM#");
 
-    return items
+    const teams = items
       .filter((item) => item.entityType === ENTITY_TYPE.gameTeam)
       .map((item) =>
         withTimestamps(
-          item.data as Omit<GameTeamRecord, "createdAt" | "updatedAt">,
+          normalizeGameTeamPayload(item.data),
           item.createdAt,
           item.updatedAt,
         ),
       );
+
+    return sortGameTeams(teams);
   }
 
   async createSession(input: CreateSessionInput): Promise<SessionRecord> {
@@ -1126,29 +1215,156 @@ export class ThreeFcRepository {
       );
   }
 
-  async createGoalEvent(input: CreateGoalEventInput): Promise<GoalEventRecord> {
+  async createGoal(input: CreateGoalInput): Promise<CreateGoalResult | null> {
     requireNonEmpty("gameId", input.gameId);
     requireNonEmpty("eventId", input.eventId);
+    requireNonEmpty("concedingTeamId", input.concedingTeamId);
     requireNonEmpty("scorerPlayerId", input.scorerPlayerId);
-    requireThirdNumber(input.third);
-    requireGameMinute(input.gameMinute);
+    requireTeamId(input.concedingTeamId, "concedingTeamId");
+    if (input.scoringTeamId !== null) {
+      requireTeamId(input.scoringTeamId, "scoringTeamId");
+    }
 
-    validateAssistPlayerIds(input.scorerPlayerId, input.assistPlayerIds);
+    try {
+      validateAssistPlayerIds(input.scorerPlayerId, input.assistPlayerIds);
+    } catch (error) {
+      throw new GoalCreationError(
+        "invalid_assists",
+        400,
+        error instanceof Error ? error.message : "Assist player IDs are invalid.",
+      );
+    }
 
     if (input.ownGoal && input.scoringTeamId !== null) {
-      throw new Error("ownGoal=true requires scoringTeamId to be null.");
+      throw new GoalCreationError(
+        "own_goal_scoring_team",
+        400,
+        "ownGoal=true requires scoringTeamId to be null.",
+      );
     }
 
     if (!input.ownGoal && input.scoringTeamId === null) {
-      throw new Error("scoringTeamId is required when ownGoal=false.");
+      throw new GoalCreationError(
+        "scoring_team_required",
+        400,
+        "scoringTeamId is required when ownGoal=false.",
+      );
+    }
+
+    if (!input.ownGoal && input.scoringTeamId === input.concedingTeamId) {
+      throw new GoalCreationError(
+        "same_team_goal",
+        400,
+        "scoringTeamId and concedingTeamId must be different for a standard goal.",
+      );
+    }
+
+    const gameItem = await this.getEntity(gamePk(input.gameId), metadataSk());
+    if (!gameItem || gameItem.entityType !== ENTITY_TYPE.game) {
+      return null;
+    }
+
+    const game = normalizeGamePayload(gameItem.data);
+    const activeThird = game.thirds.find((third) => third.startedAt && !third.finishedAt);
+    if (!activeThird?.startedAt) {
+      throw new GoalCreationError(
+        "no_active_third",
+        409,
+        "A goal can only be created while a third is running.",
+      );
+    }
+
+    const teamItems = await this.queryByPrefix(gamePk(input.gameId), "TEAM#");
+    const teamStates = teamItems
+      .filter((item) => item.entityType === ENTITY_TYPE.gameTeam)
+      .map((item) => ({
+        record: withTimestamps(
+          normalizeGameTeamPayload(item.data),
+          item.createdAt,
+          item.updatedAt,
+        ),
+        rawData: item.rawData,
+      }));
+    const teams = sortGameTeams(teamStates.map((teamState) => teamState.record));
+    const teamsById = new Map(teams.map((team) => [team.teamId, team]));
+    const teamStatesById = new Map(teamStates.map((teamState) => [teamState.record.teamId, teamState]));
+    const concedingTeam = teamsById.get(input.concedingTeamId);
+    if (!concedingTeam) {
+      throw new GoalCreationError(
+        "invalid_conceding_team",
+        400,
+        "concedingTeamId must be an active team for this game.",
+      );
+    }
+
+    const scoringTeam = input.scoringTeamId ? teamsById.get(input.scoringTeamId) : null;
+    if (!input.ownGoal && !scoringTeam) {
+      throw new GoalCreationError(
+        "invalid_scoring_team",
+        400,
+        "scoringTeamId must be an active team for this game.",
+      );
+    }
+
+    const roster = await this.listGameRoster(input.gameId);
+    const rosterByPlayerId = new Map(roster.map((assignment) => [assignment.playerId, assignment]));
+    const scorerRoster = rosterByPlayerId.get(input.scorerPlayerId);
+    if (!scorerRoster) {
+      throw new GoalCreationError(
+        "scorer_not_rostered",
+        400,
+        "Scorer must be rostered in this game.",
+      );
+    }
+
+    if (!input.ownGoal && scorerRoster.teamId !== input.scoringTeamId) {
+      throw new GoalCreationError(
+        "scorer_not_on_scoring_team",
+        400,
+        "Scorer must be rostered on the scoring team for a standard goal.",
+      );
+    }
+
+    if (input.ownGoal && scorerRoster.teamId !== input.concedingTeamId) {
+      throw new GoalCreationError(
+        "scorer_not_on_conceding_team",
+        400,
+        "Own-goal scorer must be rostered on the conceding team.",
+      );
+    }
+
+    for (const assistPlayerId of input.assistPlayerIds) {
+      if (!rosterByPlayerId.has(assistPlayerId)) {
+        throw new GoalCreationError(
+          "assist_not_rostered",
+          400,
+          "Assist players must be rostered in this game.",
+        );
+      }
     }
 
     const now = this.clock.now();
+    const startedAtMs = Date.parse(activeThird.startedAt);
+    const nowMs = Date.parse(now);
+    const elapsedSeconds =
+      Number.isFinite(startedAtMs) && Number.isFinite(nowMs)
+        ? Math.max(0, Math.floor((nowMs - startedAtMs) / 1000))
+        : 0;
+    const display = formatThirdDisplayTime(elapsedSeconds, game.thirdLengthMinutes);
+    const thirdMinute =
+      display.phase === "stoppage"
+        ? game.thirdLengthMinutes
+        : Math.floor(display.elapsedSeconds / 60) + 1;
+    const gameMinute = (activeThird.third - 1) * game.thirdLengthMinutes + thirdMinute;
     const payload = {
       gameId: input.gameId,
       eventId: input.eventId,
-      third: input.third,
-      gameMinute: input.gameMinute,
+      third: activeThird.third,
+      thirdMinute,
+      gameMinute,
+      elapsedSeconds: display.elapsedSeconds,
+      stoppageMinute: display.stoppageMinute,
+      displayTime: display.displayTime,
       scoringTeamId: input.scoringTeamId,
       concedingTeamId: input.concedingTeamId,
       scorerPlayerId: input.scorerPlayerId,
@@ -1156,14 +1372,145 @@ export class ThreeFcRepository {
       ownGoal: input.ownGoal,
     };
 
-    await this.putEntity(
-      gamePk(input.gameId),
-      goalSk(input.third, input.gameMinute, input.eventId),
-      ENTITY_TYPE.goal,
-      payload,
-      now,
-    );
-    return withTimestamps(payload, now, now);
+    const nextTeams = teams.map((team) => {
+      const scored = !input.ownGoal && team.teamId === input.scoringTeamId
+        ? team.scored + 1
+        : team.scored;
+      const conceded = team.teamId === input.concedingTeamId
+        ? team.conceded + 1
+        : team.conceded;
+
+      return {
+        ...team,
+        scored,
+        conceded,
+        updatedAt:
+          scored !== team.scored || conceded !== team.conceded
+            ? now
+            : team.updatedAt,
+      };
+    });
+    const changedTeams = nextTeams.filter((team) => {
+      const original = teamsById.get(team.teamId);
+      return original ? team.scored !== original.scored || team.conceded !== original.conceded : false;
+    });
+    const goalSortKey = goalSk(activeThird.third, gameMinute, display.elapsedSeconds, input.eventId);
+    const goalEventIdKey = goalEventIdSk(input.eventId);
+
+    try {
+      await this.client.send(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            ...changedTeams.map((team) => {
+              const original = teamStatesById.get(team.teamId);
+              if (!original) {
+                throw new GoalCreationError(
+                  "scoreboard_state_changed",
+                  409,
+                  "Scoreboard changed while creating this goal. Reload the game and try again.",
+                );
+              }
+
+              return {
+                Put: {
+                  TableName: this.tableName,
+                  Item: buildItemWithTimestamps(
+                    gamePk(team.gameId),
+                    teamSk(team.teamId),
+                    ENTITY_TYPE.gameTeam,
+                    {
+                      gameId: team.gameId,
+                      teamId: team.teamId,
+                      name: team.name,
+                      color: team.color,
+                      scored: team.scored,
+                      conceded: team.conceded,
+                    },
+                    team.createdAt,
+                    now,
+                  ),
+                  ConditionExpression: "#updatedAt = :expectedUpdatedAt AND #data = :expectedData",
+                  ExpressionAttributeNames: {
+                    "#updatedAt": "updatedAt",
+                    "#data": "data",
+                  },
+                  ExpressionAttributeValues: {
+                    ":expectedUpdatedAt": { S: original.record.updatedAt },
+                    ":expectedData": { S: original.rawData },
+                  },
+                },
+              };
+            }),
+            {
+              Put: {
+                TableName: this.tableName,
+                Item: buildItem(
+                  gamePk(input.gameId),
+                  goalSortKey,
+                  ENTITY_TYPE.goal,
+                  payload,
+                  now,
+                ),
+                ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
+              },
+            },
+            {
+              Put: {
+                TableName: this.tableName,
+                Item: buildItem(
+                  gamePk(input.gameId),
+                  goalEventIdKey,
+                  ENTITY_TYPE.goalEventId,
+                  {
+                    gameId: input.gameId,
+                    eventId: input.eventId,
+                    goalSk: goalSortKey,
+                  },
+                  now,
+                ),
+                ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
+              },
+            },
+          ],
+        }),
+      );
+    } catch (error) {
+      if (!isConditionalWriteFailure(error)) {
+        throw error;
+      }
+
+      const [existingGoal, existingGoalEventId] = await Promise.all([
+        this.getEntity(gamePk(input.gameId), goalSortKey),
+        this.getEntity(gamePk(input.gameId), goalEventIdKey),
+      ]);
+      if (
+        existingGoal?.entityType === ENTITY_TYPE.goal ||
+        existingGoalEventId?.entityType === ENTITY_TYPE.goalEventId
+      ) {
+        throw new GoalCreationError(
+          "goal_already_created",
+          409,
+          "Goal event has already been created for this request.",
+        );
+      }
+
+      throw new GoalCreationError(
+        "scoreboard_state_changed",
+        409,
+        "Scoreboard changed while creating this goal. Reload the game and try again.",
+      );
+    }
+
+    const goal = withTimestamps(payload, now, now);
+    const persistedTimeline = await this.listGoalEvents(input.gameId);
+
+    return {
+      goal,
+      scoreboard: {
+        teams: sortGameTeams(nextTeams),
+      },
+      timeline: persistedTimeline,
+    };
   }
 
   async listGoalEvents(gameId: string): Promise<GoalEventRecord[]> {
@@ -1174,7 +1521,7 @@ export class ThreeFcRepository {
       .filter((item) => item.entityType === ENTITY_TYPE.goal)
       .map((item) =>
         withTimestamps(
-          item.data as Omit<GoalEventRecord, "createdAt" | "updatedAt">,
+          normalizeGoalEventPayload(item.data),
           item.createdAt,
           item.updatedAt,
         ),

--- a/api/src/data/types.ts
+++ b/api/src/data/types.ts
@@ -37,6 +37,8 @@ export interface GameTeamRecord {
   teamId: TeamId;
   name: string;
   color: string | null;
+  scored: number;
+  conceded: number;
   createdAt: string;
   updatedAt: string;
 }
@@ -108,7 +110,11 @@ export interface GoalEventRecord {
   gameId: string;
   eventId: string;
   third: 1 | 2 | 3;
+  thirdMinute: number;
   gameMinute: number;
+  elapsedSeconds: number;
+  stoppageMinute: number | null;
+  displayTime: string;
   scoringTeamId: TeamId | null;
   concedingTeamId: TeamId;
   scorerPlayerId: string;
@@ -211,16 +217,22 @@ export interface AssignRosterInput {
   playerId: string;
 }
 
-export interface CreateGoalEventInput {
+export interface CreateGoalInput {
   gameId: string;
   eventId: string;
-  third: ThirdNumber;
-  gameMinute: number;
   scoringTeamId: TeamId | null;
   concedingTeamId: TeamId;
   scorerPlayerId: string;
   assistPlayerIds: string[];
   ownGoal: boolean;
+}
+
+export interface CreateGoalResult {
+  goal: GoalEventRecord;
+  scoreboard: {
+    teams: GameTeamRecord[];
+  };
+  timeline: GoalEventRecord[];
 }
 
 export interface ThirdTransitionInput {

--- a/api/src/lambda-core.ts
+++ b/api/src/lambda-core.ts
@@ -39,6 +39,7 @@ import {
 } from "./auth/session.js";
 import {
   createGameRequestSchema,
+  createGoalRequestSchema,
   createLeagueRequestSchema,
   createSeasonRequestSchema,
   createSessionRequestSchema,
@@ -48,8 +49,8 @@ import {
   quickCreateGamePlayerRequestSchema,
   upsertTeamRequestSchema,
 } from "./contracts/core-write.js";
-import { GameTimerTransitionError, ThreeFcRepository } from "./data/repository.js";
-import type { GameStatus } from "./data/types.js";
+import { GameTimerTransitionError, GoalCreationError, ThreeFcRepository } from "./data/repository.js";
+import type { CreateGoalResult, GameStatus } from "./data/types.js";
 import { logAuthRateLimit, logRequest, logRequestError } from "./logging.js";
 
 export interface ApiGatewayHttpEvent {
@@ -201,6 +202,8 @@ interface RepositoryContract {
     teamId: TeamId;
     name: string;
     color: string | null;
+    scored: number;
+    conceded: number;
     createdAt: string;
     updatedAt: string;
   }>;
@@ -210,6 +213,8 @@ interface RepositoryContract {
       teamId: TeamId;
       name: string;
       color: string | null;
+      scored: number;
+      conceded: number;
       createdAt: string;
       updatedAt: string;
     }>
@@ -424,6 +429,15 @@ interface RepositoryContract {
       updatedAt: string;
     }>
   >;
+  createGoal(input: {
+    gameId: string;
+    eventId: string;
+    scoringTeamId: TeamId | null;
+    concedingTeamId: TeamId;
+    scorerPlayerId: string;
+    assistPlayerIds: string[];
+    ownGoal: boolean;
+  }): Promise<CreateGoalResult | null>;
   getLeagueAccess(
     leagueId: string,
     userId: string,
@@ -802,6 +816,22 @@ function timerTransitionConflictResponse(
   );
 }
 
+function goalCreationErrorResponse(
+  origin: string | undefined,
+  allowedOrigins: string[],
+  error: GoalCreationError,
+): ApiGatewayHttpResponse {
+  return createJsonResponse(
+    error.statusCode,
+    {
+      error: error.statusCode === 409 ? "conflict" : "bad_request",
+      code: error.code,
+      message: error.message,
+    },
+    buildCorsHeaders(origin, allowedOrigins),
+  );
+}
+
 function toPublicPlayer(player: {
   playerId: string;
   nickname: string;
@@ -945,6 +975,8 @@ async function readGameTeams(
       teamId: seasonTeam.teamId,
       name: seasonTeam.name,
       color: seasonTeam.color,
+      scored: 0,
+      conceded: 0,
       createdAt: game.createdAt,
       updatedAt: game.updatedAt,
     });
@@ -1063,6 +1095,28 @@ function buildIdempotencyRequestHash(scope: string, payload: unknown): string {
   return createHash("sha256")
     .update(`${scope}:${JSON.stringify(normalizePayloadForHashing(payload))}`)
     .digest("hex");
+}
+
+function buildGoalEventId(input: {
+  idempotencyKey: string | undefined;
+  sessionEmail: string;
+  method: string;
+  route: string;
+}): string {
+  const parsedIdempotencyKey = input.idempotencyKey
+    ? idempotencyKeyHeaderSchema.safeParse(input.idempotencyKey)
+    : null;
+
+  if (!parsedIdempotencyKey?.success) {
+    return `goal-${randomUUID()}`;
+  }
+
+  const scope = buildIdempotencyScope(input.sessionEmail, input.method, input.route);
+  const digest = createHash("sha256")
+    .update(`${scope}:${parsedIdempotencyKey.data}`)
+    .digest("hex")
+    .slice(0, 32);
+  return `goal-idem-${digest}`;
 }
 
 function parseStoredIdempotencyResponseBody(responseBody: string): unknown {
@@ -2057,6 +2111,106 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
             buildGameResponse(updated),
             buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
           );
+        }
+
+        const createGoalMatch = route.match(/^\/v1\/games\/([^/]+)\/goals$/);
+        if (method === "POST" && createGoalMatch) {
+          const gameId = decodeRouteParam(createGoalMatch[1]);
+          const game = await dependencies.repository.getGame(gameId);
+          if (!game) {
+            status = 404;
+            return notFound(origin, dependencies.corsAllowedOrigins, `Game ${gameId} was not found.`);
+          }
+
+          let rawBody: Record<string, unknown>;
+          try {
+            rawBody = parseJsonBody(event);
+          } catch {
+            status = 400;
+            return badRequest(origin, dependencies.corsAllowedOrigins, "Request body must be valid JSON.");
+          }
+
+          const parsedBody = createGoalRequestSchema.safeParse(rawBody);
+          if (!parsedBody.success) {
+            status = 400;
+            return badRequest(
+              origin,
+              dependencies.corsAllowedOrigins,
+              formatSchemaValidationError(parsedBody.error),
+            );
+          }
+
+          let mutationResponse: ApiGatewayHttpResponse;
+          try {
+            mutationResponse = await executeIdempotentMutation({
+              repository: dependencies.repository,
+              idempotencyKey,
+              sessionEmail: session.email,
+              method,
+              route,
+              requestPayload: parsedBody.data,
+              origin,
+              allowedOrigins: dependencies.corsAllowedOrigins,
+              execute: async () => {
+                const currentGame = await dependencies.repository.getGame(gameId);
+                if (!currentGame) {
+                  return notFound(
+                    origin,
+                    dependencies.corsAllowedOrigins,
+                    `Game ${gameId} was not found.`,
+                  );
+                }
+
+                if (!currentGame.thirds.some((third) => third.startedAt && !third.finishedAt)) {
+                  throw new GoalCreationError(
+                    "no_active_third",
+                    409,
+                    "A goal can only be created while a third is running.",
+                  );
+                }
+
+                await ensureGameTeamsForGame(dependencies.repository, currentGame);
+                const result = await dependencies.repository.createGoal({
+                  gameId,
+                  eventId: buildGoalEventId({
+                    idempotencyKey,
+                    sessionEmail: session.email,
+                    method,
+                    route,
+                  }),
+                  scoringTeamId: parsedBody.data.scoringTeamId,
+                  concedingTeamId: parsedBody.data.concedingTeamId,
+                  scorerPlayerId: parsedBody.data.scorerPlayerId,
+                  assistPlayerIds: parsedBody.data.assistPlayerIds,
+                  ownGoal: parsedBody.data.ownGoal,
+                });
+
+                if (!result) {
+                  return notFound(
+                    origin,
+                    dependencies.corsAllowedOrigins,
+                    `Game ${gameId} was not found.`,
+                  );
+                }
+
+                return createJsonResponse(
+                  201,
+                  result,
+                  buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
+                );
+              },
+            });
+          } catch (error) {
+            if (error instanceof GoalCreationError) {
+              status = error.statusCode;
+              return goalCreationErrorResponse(origin, dependencies.corsAllowedOrigins, error);
+            }
+
+            throw error;
+          }
+
+          status = mutationResponse.statusCode;
+          return mutationResponse;
         }
 
         const listGameTeamsMatch = route.match(/^\/v1\/games\/([^/]+)\/teams$/);

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -49,6 +49,7 @@ import {
 } from "./auth/session.js";
 import {
   createGameRequestSchema,
+  createGoalRequestSchema,
   createLeagueRequestSchema,
   createSeasonRequestSchema,
   createSessionRequestSchema,
@@ -58,7 +59,7 @@ import {
   quickCreateGamePlayerRequestSchema,
   upsertTeamRequestSchema,
 } from "./contracts/core-write.js";
-import { GameTimerTransitionError, ThreeFcRepository } from "./data/repository.js";
+import { GameTimerTransitionError, GoalCreationError, ThreeFcRepository } from "./data/repository.js";
 import { buildHealthResponse } from "./index.js";
 import { logAuthRateLimit, logRequest, logRequestError } from "./logging.js";
 
@@ -376,6 +377,19 @@ function timerTransitionConflict(
   return 409;
 }
 
+function goalCreationError(
+  request: IncomingMessage,
+  response: ServerResponse,
+  error: GoalCreationError,
+): number {
+  sendJsonWithCors(request, response, error.statusCode, {
+    error: error.statusCode === 409 ? "conflict" : "bad_request",
+    code: error.code,
+    message: error.message,
+  });
+  return error.statusCode;
+}
+
 function toPublicPlayer(player: {
   playerId: string;
   nickname: string;
@@ -507,6 +521,8 @@ async function readGameTeams(game: {
       teamId: seasonTeam.teamId,
       name: seasonTeam.name,
       color: seasonTeam.color,
+      scored: 0,
+      conceded: 0,
       createdAt: game.createdAt,
       updatedAt: game.updatedAt,
     });
@@ -646,6 +662,29 @@ function buildIdempotencyRequestHash(scope: string, payload: unknown): string {
   return createHash("sha256")
     .update(`${scope}:${JSON.stringify(normalizePayloadForHashing(payload))}`)
     .digest("hex");
+}
+
+function buildGoalEventId(input: {
+  request: IncomingMessage;
+  sessionEmail: string;
+  method: string;
+  route: string;
+}): string {
+  const rawIdempotencyKey = readHeaderValue(input.request, "idempotency-key");
+  const parsedIdempotencyKey = rawIdempotencyKey
+    ? idempotencyKeyHeaderSchema.safeParse(rawIdempotencyKey)
+    : null;
+
+  if (!parsedIdempotencyKey?.success) {
+    return `goal-${randomUUID()}`;
+  }
+
+  const scope = buildIdempotencyScope(input.sessionEmail, input.method, input.route);
+  const digest = createHash("sha256")
+    .update(`${scope}:${parsedIdempotencyKey.data}`)
+    .digest("hex")
+    .slice(0, 32);
+  return `goal-idem-${digest}`;
 }
 
 function parseStoredIdempotencyResponseBody(responseBody: string): unknown {
@@ -1824,6 +1863,110 @@ async function start(): Promise<void> {
 
         status = 200;
         sendJsonWithCors(request, response, status, buildGameResponse(updated));
+        return;
+      }
+
+      const createGoalMatch = route.match(/^\/v1\/games\/([^/]+)\/goals$/);
+      if (method === "POST" && createGoalMatch) {
+        if (!authGate.session) {
+          status = 500;
+          sendJsonWithCors(request, response, status, {
+            error: "internal_error",
+            message: "Session should be available for authenticated route.",
+          });
+          return;
+        }
+
+        const gameId = decodeURIComponent(createGoalMatch[1]);
+        const game = await repository.getGame(gameId);
+        if (!game) {
+          status = notFound(request, response, `Game ${gameId} was not found.`);
+          return;
+        }
+
+        let rawBody: Record<string, unknown>;
+        try {
+          rawBody = await parseJsonBody(request);
+        } catch {
+          status = badRequest(request, response, "Request body must be valid JSON.");
+          return;
+        }
+
+        const parsedBody = createGoalRequestSchema.safeParse(rawBody);
+        if (!parsedBody.success) {
+          status = badRequest(request, response, formatSchemaValidationError(parsedBody.error));
+          return;
+        }
+
+        try {
+          const sessionEmail = authGate.session.email;
+          status = await executeIdempotentMutation({
+            request,
+            response,
+            sessionEmail,
+            method,
+            route,
+            requestPayload: parsedBody.data,
+            execute: async () => {
+              const currentGame = await repository.getGame(gameId);
+              if (!currentGame) {
+                return {
+                  statusCode: 404,
+                  payload: {
+                    error: "not_found",
+                    message: `Game ${gameId} was not found.`,
+                  },
+                };
+              }
+
+              if (!currentGame.thirds.some((third) => third.startedAt && !third.finishedAt)) {
+                throw new GoalCreationError(
+                  "no_active_third",
+                  409,
+                  "A goal can only be created while a third is running.",
+                );
+              }
+
+              await ensureGameTeamsForGame(currentGame);
+              const result = await repository.createGoal({
+                gameId,
+                eventId: buildGoalEventId({
+                  request,
+                  sessionEmail,
+                  method,
+                  route,
+                }),
+                scoringTeamId: parsedBody.data.scoringTeamId,
+                concedingTeamId: parsedBody.data.concedingTeamId,
+                scorerPlayerId: parsedBody.data.scorerPlayerId,
+                assistPlayerIds: parsedBody.data.assistPlayerIds,
+                ownGoal: parsedBody.data.ownGoal,
+              });
+
+              if (!result) {
+                return {
+                  statusCode: 404,
+                  payload: {
+                    error: "not_found",
+                    message: `Game ${gameId} was not found.`,
+                  },
+                };
+              }
+
+              return {
+                statusCode: 201,
+                payload: result,
+              };
+            },
+          });
+        } catch (error) {
+          if (error instanceof GoalCreationError) {
+            status = goalCreationError(request, response, error);
+            return;
+          }
+
+          throw error;
+        }
         return;
       }
 

--- a/api/src/tests/acl.test.ts
+++ b/api/src/tests/acl.test.ts
@@ -79,6 +79,10 @@ test("resolveProtectedMutationRoute maps supported mutation endpoints", () => {
     operation: "finishGameThird",
     gameId: "game-1",
   });
+  assert.deepEqual(resolveProtectedMutationRoute("POST", "/v1/games/game-1/goals"), {
+    operation: "createGoal",
+    gameId: "game-1",
+  });
   assert.equal(resolveProtectedMutationRoute("GET", "/v1/leagues"), null);
 });
 
@@ -270,6 +274,59 @@ test("game-scoped timer mutation allows scorekeepers", async () => {
 
   assert.equal(result.allowed, true);
   assert.equal(result.operation, "startGameThird");
+  assert.deepEqual(result.scope, {
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "session-1",
+  });
+});
+
+test("game-scoped goal mutation allows scorekeepers", async () => {
+  const result = await authorizeProtectedMutation(
+    "POST",
+    "/v1/games/game-1/goals",
+    "scorekeeper-user",
+    new InMemoryAclLookup({
+      games: {
+        "game-1": {
+          leagueId: "league-1",
+          seasonId: "season-1",
+          sessionId: "session-1",
+          gameId: "game-1",
+          status: "live",
+          gameStartTs: "2026-02-23T10:00:00.000Z",
+          ...defaultTimerFields(),
+          createdAt: "2026-02-23T00:00:00.000Z",
+          updatedAt: "2026-02-23T00:00:00.000Z",
+        },
+      },
+      seasons: {
+        "season-1": {
+          leagueId: "league-1",
+          seasonId: "season-1",
+          name: "Season 1",
+          slug: null,
+          startsOn: null,
+          endsOn: null,
+          createdAt: "2026-02-23T00:00:00.000Z",
+          updatedAt: "2026-02-23T00:00:00.000Z",
+        },
+      },
+      leagueAccess: {
+        "league-1:scorekeeper-user": {
+          leagueId: "league-1",
+          userId: "scorekeeper-user",
+          role: "scorekeeper",
+          grantedByUserId: "admin-user",
+          createdAt: "2026-02-23T00:00:00.000Z",
+          updatedAt: "2026-02-23T00:00:00.000Z",
+        },
+      },
+    }),
+  );
+
+  assert.equal(result.allowed, true);
+  assert.equal(result.operation, "createGoal");
   assert.deepEqual(result.scope, {
     leagueId: "league-1",
     seasonId: "season-1",

--- a/api/src/tests/lambda-core.test.ts
+++ b/api/src/tests/lambda-core.test.ts
@@ -736,6 +736,11 @@ function createHarness(config: HarnessConfig = {}) {
               return minuteSort;
             }
 
+            const elapsedSort = left.elapsedSeconds - right.elapsedSeconds;
+            if (elapsedSort !== 0) {
+              return elapsedSort;
+            }
+
             return left.eventId.localeCompare(right.eventId);
           });
 

--- a/api/src/tests/lambda-core.test.ts
+++ b/api/src/tests/lambda-core.test.ts
@@ -674,10 +674,10 @@ function createHarness(config: HarnessConfig = {}) {
           Math.floor((Date.parse(now) - Date.parse(activeThird.startedAt)) / 1000),
         );
         const display = formatThirdDisplayTime(elapsedSeconds, game.thirdLengthMinutes);
-        const thirdMinute =
-          display.phase === "stoppage"
-            ? game.thirdLengthMinutes
-            : Math.floor(display.elapsedSeconds / 60) + 1;
+        const thirdMinute = Math.min(
+          game.thirdLengthMinutes,
+          Math.floor(display.elapsedSeconds / 60) + 1,
+        );
         const gameMinute = (activeThird.third - 1) * game.thirdLengthMinutes + thirdMinute;
         const goal = {
           gameId: input.gameId,

--- a/api/src/tests/lambda-core.test.ts
+++ b/api/src/tests/lambda-core.test.ts
@@ -9,11 +9,13 @@ import type { RateLimitDecision } from "../auth/rate-limit.js";
 import {
   createDefaultThirdTimerSegments,
   DEFAULT_THIRD_LENGTH_MINUTES,
+  formatThirdDisplayTime,
+  TEAM_IDS,
   type TeamId,
   type ThirdLengthMinutes,
   type ThirdTimerSegment,
 } from "@3fc/contracts";
-import { GameTimerTransitionError } from "../data/repository.js";
+import { GameTimerTransitionError, GoalCreationError } from "../data/repository.js";
 
 interface MockSessionRecord {
   sessionId: string;
@@ -89,9 +91,14 @@ interface MockGameTeamRecord {
   teamId: TeamId;
   name: string;
   color: string | null;
+  scored: number;
+  conceded: number;
   createdAt: string;
   updatedAt: string;
 }
+
+type MockGameTeamInput = Omit<MockGameTeamRecord, "scored" | "conceded"> &
+  Partial<Pick<MockGameTeamRecord, "scored" | "conceded">>;
 
 interface MockPlayerRecord {
   playerId: string;
@@ -112,6 +119,24 @@ interface MockRosterAssignmentRecord {
 interface MockGamePlayerRecord {
   gameId: string;
   playerId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface MockGoalEventRecord {
+  gameId: string;
+  eventId: string;
+  third: 1 | 2 | 3;
+  thirdMinute: number;
+  gameMinute: number;
+  elapsedSeconds: number;
+  stoppageMinute: number | null;
+  displayTime: string;
+  scoringTeamId: TeamId | null;
+  concedingTeamId: TeamId;
+  scorerPlayerId: string;
+  assistPlayerIds: string[];
+  ownGoal: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -174,7 +199,7 @@ interface HarnessConfig {
   seasonSessions?: Record<string, MockSessionEntity>;
   games?: Record<string, MockGameInput>;
   seasonTeams?: Record<string, MockSeasonTeamRecord>;
-  gameTeams?: Record<string, MockGameTeamRecord>;
+  gameTeams?: Record<string, MockGameTeamInput>;
   players?: Record<string, MockPlayerRecord>;
   rosterAssignments?: Record<string, MockRosterAssignmentRecord>;
   gamePlayers?: Record<string, MockGamePlayerRecord>;
@@ -216,6 +241,15 @@ function createHarness(config: HarnessConfig = {}) {
   const createdSeasonTeams: Array<{ seasonId: string; teamId: TeamId; name: string; color?: string | null }> = [];
   const createdGameTeams: Array<{ gameId: string; teamId: TeamId; name: string; color?: string | null }> = [];
   const createdPlayers: Array<{ playerId: string; nickname: string; claimedByUserId?: string | null }> = [];
+  const createdGoals: Array<{
+    gameId: string;
+    eventId: string;
+    scoringTeamId: TeamId | null;
+    concedingTeamId: TeamId;
+    scorerPlayerId: string;
+    assistPlayerIds: string[];
+    ownGoal: boolean;
+  }> = [];
   const assignedRosterPlayers: Array<{ gameId: string; teamId: TeamId; playerId: string }> = [];
   const linkedGamePlayers: Array<{ gameId: string; playerId: string }> = [];
   const magicLinkStarts: string[] = [];
@@ -240,7 +274,16 @@ function createHarness(config: HarnessConfig = {}) {
   const seasonTeams = new Map<string, MockSeasonTeamRecord>(
     Object.entries(config.seasonTeams ?? {}),
   );
-  const gameTeams = new Map<string, MockGameTeamRecord>(Object.entries(config.gameTeams ?? {}));
+  const gameTeams = new Map<string, MockGameTeamRecord>(
+    Object.entries(config.gameTeams ?? {}).map(([key, team]) => [
+      key,
+      {
+        ...team,
+        scored: team.scored ?? 0,
+        conceded: team.conceded ?? 0,
+      },
+    ]),
+  );
   const players = new Map<string, MockPlayerRecord>(Object.entries(config.players ?? {}));
   const rosterAssignments = new Map<string, MockRosterAssignmentRecord>(
     Object.entries(config.rosterAssignments ?? {}),
@@ -248,6 +291,7 @@ function createHarness(config: HarnessConfig = {}) {
   const gamePlayers = new Map<string, MockGamePlayerRecord>(
     Object.entries(config.gamePlayers ?? {}),
   );
+  const goalEvents = new Map<string, MockGoalEventRecord>();
 
   const handler = createLambdaCoreHandler({
     sessionCookieName: "threefc_session",
@@ -355,6 +399,8 @@ function createHarness(config: HarnessConfig = {}) {
           teamId: input.teamId,
           name: input.name,
           color: input.color ?? null,
+          scored: existing?.scored ?? 0,
+          conceded: existing?.conceded ?? 0,
           createdAt: existing?.createdAt ?? "2026-02-23T00:00:00.000Z",
           updatedAt: "2026-02-23T00:00:00.000Z",
         };
@@ -606,6 +652,101 @@ function createHarness(config: HarnessConfig = {}) {
       async listGameRoster(gameId: string) {
         return [...rosterAssignments.values()].filter((assignment) => assignment.gameId === gameId);
       },
+      async createGoal(input) {
+        createdGoals.push(input);
+        const game = games.get(input.gameId);
+        if (!game) {
+          return null;
+        }
+
+        const activeThird = game.thirds.find((third) => third.startedAt && !third.finishedAt);
+        if (!activeThird?.startedAt) {
+          throw new GoalCreationError(
+            "no_active_third",
+            409,
+            "A goal can only be created while a third is running.",
+          );
+        }
+
+        const now = "2026-02-23T00:00:03.000Z";
+        const elapsedSeconds = Math.max(
+          0,
+          Math.floor((Date.parse(now) - Date.parse(activeThird.startedAt)) / 1000),
+        );
+        const display = formatThirdDisplayTime(elapsedSeconds, game.thirdLengthMinutes);
+        const thirdMinute =
+          display.phase === "stoppage"
+            ? game.thirdLengthMinutes
+            : Math.floor(display.elapsedSeconds / 60) + 1;
+        const gameMinute = (activeThird.third - 1) * game.thirdLengthMinutes + thirdMinute;
+        const goal = {
+          gameId: input.gameId,
+          eventId: input.eventId,
+          third: activeThird.third,
+          thirdMinute,
+          gameMinute,
+          elapsedSeconds: display.elapsedSeconds,
+          stoppageMinute: display.stoppageMinute,
+          displayTime: display.displayTime,
+          scoringTeamId: input.scoringTeamId,
+          concedingTeamId: input.concedingTeamId,
+          scorerPlayerId: input.scorerPlayerId,
+          assistPlayerIds: input.assistPlayerIds,
+          ownGoal: input.ownGoal,
+          createdAt: now,
+          updatedAt: now,
+        };
+
+        goalEvents.set(`${input.gameId}:${input.eventId}`, goal);
+        for (const [key, team] of gameTeams.entries()) {
+          if (team.gameId !== input.gameId) {
+            continue;
+          }
+
+          const scored = !input.ownGoal && team.teamId === input.scoringTeamId
+            ? team.scored + 1
+            : team.scored;
+          const conceded = team.teamId === input.concedingTeamId
+            ? team.conceded + 1
+            : team.conceded;
+
+          if (scored !== team.scored || conceded !== team.conceded) {
+            gameTeams.set(key, {
+              ...team,
+              scored,
+              conceded,
+              updatedAt: now,
+            });
+          }
+        }
+
+        const teams = [...gameTeams.values()]
+          .filter((team) => team.gameId === input.gameId)
+          .sort((left, right) => TEAM_IDS.indexOf(left.teamId) - TEAM_IDS.indexOf(right.teamId));
+        const timeline = [...goalEvents.values()]
+          .filter((entry) => entry.gameId === input.gameId)
+          .sort((left, right) => {
+            const thirdSort = left.third - right.third;
+            if (thirdSort !== 0) {
+              return thirdSort;
+            }
+
+            const minuteSort = left.gameMinute - right.gameMinute;
+            if (minuteSort !== 0) {
+              return minuteSort;
+            }
+
+            return left.eventId.localeCompare(right.eventId);
+          });
+
+        return {
+          goal,
+          scoreboard: {
+            teams,
+          },
+          timeline,
+        };
+      },
       async getLeagueAccess(leagueId: string, userId: string) {
         return config.leagueAccess?.[`${leagueId}:${userId}`] ?? null;
       },
@@ -645,6 +786,7 @@ function createHarness(config: HarnessConfig = {}) {
     createdSeasonTeams,
     createdGameTeams,
     createdPlayers,
+    createdGoals,
     assignedRosterPlayers,
     linkedGamePlayers,
     magicLinkStarts,
@@ -652,6 +794,142 @@ function createHarness(config: HarnessConfig = {}) {
     magicLinkRateLimitChecks,
     idempotencyRecords,
   };
+}
+
+function createGoalHarness(input: {
+  email?: string;
+  role?: "admin" | "scorekeeper" | "viewer";
+  runningThird?: boolean;
+} = {}) {
+  const email = input.email ?? "scorekeeper@example.com";
+  const role = input.role ?? "scorekeeper";
+  const runningThird = input.runningThird ?? true;
+  const thirds = createDefaultThirdTimerSegments();
+  if (runningThird) {
+    thirds[0] = {
+      ...thirds[0],
+      startedAt: "2026-02-23T00:00:00.000Z",
+    };
+  }
+
+  return createHarness({
+    sessions: {
+      "session-1": {
+        sessionId: "session-1",
+        email,
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    games: {
+      "game-1": {
+        gameId: "game-1",
+        leagueId: "league-1",
+        seasonId: "season-1",
+        sessionId: "session-1",
+        status: runningThird ? "live" : "scheduled",
+        gameStartTs: "2026-02-23T10:00:00.000Z",
+        thirdLengthMinutes: 20,
+        thirds,
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    seasons: {
+      "season-1": {
+        leagueId: "league-1",
+        seasonId: "season-1",
+        name: "Season 1",
+        slug: null,
+        startsOn: null,
+        endsOn: null,
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueAccess: {
+      [`league-1:${email}`]: {
+        leagueId: "league-1",
+        userId: email,
+        role,
+        grantedByUserId: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    gameTeams: {
+      "game-1:red": {
+        gameId: "game-1",
+        teamId: "red",
+        name: "Red",
+        color: "#d83b36",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+      "game-1:blue": {
+        gameId: "game-1",
+        teamId: "blue",
+        name: "Blue",
+        color: "#2364d2",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+      "game-1:yellow": {
+        gameId: "game-1",
+        teamId: "yellow",
+        name: "Yellow",
+        color: "#e0a612",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    players: {
+      "player-red": {
+        playerId: "player-red",
+        nickname: "Red Player",
+        claimedByUserId: null,
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+      "player-blue": {
+        playerId: "player-blue",
+        nickname: "Blue Player",
+        claimedByUserId: null,
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+      "player-yellow": {
+        playerId: "player-yellow",
+        nickname: "Yellow Player",
+        claimedByUserId: null,
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    rosterAssignments: {
+      "game-1:player-red": {
+        gameId: "game-1",
+        teamId: "red",
+        playerId: "player-red",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+      "game-1:player-blue": {
+        gameId: "game-1",
+        teamId: "blue",
+        playerId: "player-blue",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+      "game-1:player-yellow": {
+        gameId: "game-1",
+        teamId: "yellow",
+        playerId: "player-yellow",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
 }
 
 test("core lambda rejects protected mutation without session cookie", async () => {
@@ -1345,6 +1623,261 @@ test("core lambda rejects viewer third timer mutations through ACL", async () =>
     code: "scorekeeper_required",
     message: "Admin or scorekeeper role is required for league league-1.",
   });
+});
+
+test("core lambda creates goals with idempotency replay and conflict behavior", async () => {
+  const harness = createGoalHarness();
+  const requestBody = {
+    scoringTeamId: "red",
+    concedingTeamId: "blue",
+    scorerPlayerId: "player-red",
+    assistPlayerIds: ["player-blue", "player-yellow"],
+    ownGoal: false,
+  };
+
+  const response = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/games/game-1/goals",
+      headers: {
+        Cookie: "threefc_session=session-1",
+        "Idempotency-Key": "goal-create-1",
+      },
+      body: requestBody,
+    }),
+  );
+
+  assert.equal(response.statusCode, 201);
+  const body = JSON.parse(response.body) as {
+    goal: {
+      eventId: string;
+      third: number;
+      thirdMinute: number;
+      gameMinute: number;
+      elapsedSeconds: number;
+      displayTime: string;
+      scoringTeamId: string | null;
+      concedingTeamId: string;
+      assistPlayerIds: string[];
+    };
+    scoreboard: {
+      teams: Array<{ teamId: string; scored: number; conceded: number }>;
+    };
+    timeline: Array<{ eventId: string }>;
+  };
+  assert.match(body.goal.eventId, /^goal-idem-/);
+  assert.equal(body.goal.third, 1);
+  assert.equal(body.goal.thirdMinute, 1);
+  assert.equal(body.goal.gameMinute, 1);
+  assert.equal(body.goal.elapsedSeconds, 3);
+  assert.equal(body.goal.displayTime, "00:03");
+  assert.equal(body.goal.scoringTeamId, "red");
+  assert.equal(body.goal.concedingTeamId, "blue");
+  assert.deepEqual(body.goal.assistPlayerIds, ["player-blue", "player-yellow"]);
+  assert.deepEqual(
+    body.scoreboard.teams.map((team) => ({
+      teamId: team.teamId,
+      scored: team.scored,
+      conceded: team.conceded,
+    })),
+    [
+      { teamId: "red", scored: 1, conceded: 0 },
+      { teamId: "blue", scored: 0, conceded: 1 },
+      { teamId: "yellow", scored: 0, conceded: 0 },
+    ],
+  );
+  assert.deepEqual(body.timeline.map((goal) => goal.eventId), [body.goal.eventId]);
+  assert.equal(harness.createdGoals.length, 1);
+
+  const finishResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/games/game-1/thirds/1/finish",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+    }),
+  );
+  assert.equal(finishResponse.statusCode, 200);
+
+  const replayResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/games/game-1/goals",
+      headers: {
+        Cookie: "threefc_session=session-1",
+        "Idempotency-Key": "goal-create-1",
+      },
+      body: requestBody,
+    }),
+  );
+  assert.equal(replayResponse.statusCode, 201);
+  assert.deepEqual(JSON.parse(replayResponse.body), body);
+  assert.equal(harness.createdGoals.length, 1);
+
+  const conflictResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/games/game-1/goals",
+      headers: {
+        Cookie: "threefc_session=session-1",
+        "Idempotency-Key": "goal-create-1",
+      },
+      body: {
+        ...requestBody,
+        concedingTeamId: "yellow",
+      },
+    }),
+  );
+
+  assert.equal(conflictResponse.statusCode, 409);
+  assert.deepEqual(JSON.parse(conflictResponse.body), {
+    error: "idempotency_conflict",
+    message: "Idempotency key has already been used with a different payload.",
+  });
+});
+
+test("core lambda rejects goal creation when no third is running", async () => {
+  const harness = createGoalHarness({
+    runningThird: false,
+  });
+
+  const response = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/games/game-1/goals",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+      body: {
+        scoringTeamId: "red",
+        concedingTeamId: "blue",
+        scorerPlayerId: "player-red",
+        assistPlayerIds: [],
+        ownGoal: false,
+      },
+    }),
+  );
+
+  assert.equal(response.statusCode, 409);
+  assert.deepEqual(JSON.parse(response.body), {
+    error: "conflict",
+    code: "no_active_third",
+    message: "A goal can only be created while a third is running.",
+  });
+});
+
+test("core lambda rejects viewer goal creation through ACL", async () => {
+  const harness = createGoalHarness({
+    email: "viewer@example.com",
+    role: "viewer",
+  });
+
+  const response = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/games/game-1/goals",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+      body: {
+        scoringTeamId: "red",
+        concedingTeamId: "blue",
+        scorerPlayerId: "player-red",
+        assistPlayerIds: [],
+        ownGoal: false,
+      },
+    }),
+  );
+
+  assert.equal(response.statusCode, 403);
+  assert.deepEqual(JSON.parse(response.body), {
+    error: "forbidden",
+    code: "scorekeeper_required",
+    message: "Admin or scorekeeper role is required for league league-1.",
+  });
+  assert.equal(harness.createdGoals.length, 0);
+});
+
+test("core lambda rejects invalid assist payloads before creating goals", async () => {
+  const harness = createGoalHarness();
+
+  const response = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/games/game-1/goals",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+      body: {
+        scoringTeamId: "red",
+        concedingTeamId: "blue",
+        scorerPlayerId: "player-red",
+        assistPlayerIds: ["player-blue", "player-yellow", "player-a", "player-b"],
+        ownGoal: false,
+      },
+    }),
+  );
+
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(JSON.parse(response.body), {
+    error: "Field `assistPlayerIds` must contain no more than 3 player IDs.",
+  });
+  assert.equal(harness.createdGoals.length, 0);
+});
+
+test("core lambda rejects duplicate assist IDs before creating goals", async () => {
+  const harness = createGoalHarness();
+
+  const response = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/games/game-1/goals",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+      body: {
+        scoringTeamId: "red",
+        concedingTeamId: "blue",
+        scorerPlayerId: "player-red",
+        assistPlayerIds: ["player-blue", "player-blue"],
+        ownGoal: false,
+      },
+    }),
+  );
+
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(JSON.parse(response.body), {
+    error: "Field `assistPlayerIds` must be unique.",
+  });
+  assert.equal(harness.createdGoals.length, 0);
+});
+
+test("core lambda rejects same-team standard goals before creating goals", async () => {
+  const harness = createGoalHarness();
+
+  const response = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/games/game-1/goals",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+      body: {
+        scoringTeamId: "red",
+        concedingTeamId: "red",
+        scorerPlayerId: "player-red",
+        assistPlayerIds: [],
+        ownGoal: false,
+      },
+    }),
+  );
+
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(JSON.parse(response.body), {
+    error: "Field `concedingTeamId` must differ from scoringTeamId for standard goals.",
+  });
+  assert.equal(harness.createdGoals.length, 0);
 });
 
 test("core lambda rejects third length changes on finished games", async () => {

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -20,8 +20,15 @@ import { ThreeFcRepository } from "../data/repository.js";
 
 type Item = Record<string, AttributeValue>;
 
+interface ObservedQuery {
+  pk: string;
+  skPrefix: string;
+  consistentRead?: boolean;
+}
+
 class InMemoryDynamoClient {
   private readonly items = new Map<string, Item>();
+  private readonly queries: ObservedQuery[] = [];
   private beforeNextPut: (() => void) | null = null;
 
   seedItem(item: Item): void {
@@ -32,6 +39,10 @@ class InMemoryDynamoClient {
 
   readItem(pk: string, sk: string): Item | undefined {
     return this.items.get(`${pk}|${sk}`);
+  }
+
+  readQueries(): readonly ObservedQuery[] {
+    return this.queries;
   }
 
   runBeforeNextPut(callback: () => void): void {
@@ -89,6 +100,11 @@ class InMemoryDynamoClient {
       const values = command.input.ExpressionAttributeValues ?? {};
       const pk = this.readString(values[":pk"], ":pk");
       const prefix = this.readString(values[":skPrefix"], ":skPrefix");
+      this.queries.push({
+        pk,
+        skPrefix: prefix,
+        consistentRead: command.input.ConsistentRead,
+      });
 
       const items = [...this.items.values()]
         .filter((item) => this.readString(item.pk, "pk") === pk)
@@ -926,7 +942,7 @@ async function setupScoringGame(repository: ThreeFcRepository): Promise<void> {
 }
 
 test("repository creates standard goals with timer stamping, mixed-team assists, and persisted tallies", async () => {
-  const repository = createRepository();
+  const { repository, client } = createRepositoryHarness();
   await setupScoringGame(repository);
   await repository.startGameThird({ gameId: "game-1", third: 1 });
 
@@ -972,6 +988,13 @@ test("repository creates standard goals with timer stamping, mixed-team assists,
     ],
   );
   assert.deepEqual(result.timeline.map((goal) => goal.eventId), ["goal-1"]);
+  assert.deepEqual(
+    client
+      .readQueries()
+      .filter((query) => query.pk === "GAME#game-1" && query.skPrefix === "GOAL#")
+      .map((query) => query.consistentRead),
+    [true],
+  );
 });
 
 test("repository rejects duplicate goal event IDs without double-counting tallies", async () => {

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -540,11 +540,11 @@ test("repository normalizes partial legacy goal records to documented response b
       S: JSON.stringify({
         gameId: "game-1",
         eventId: "goal-legacy",
-        third: 1,
+        third: 9,
         elapsedSeconds: 0,
         stoppageMinute: 0,
-        scoringTeamId: "red",
-        concedingTeamId: "blue",
+        scoringTeamId: "green",
+        concedingTeamId: "orange",
         scorerPlayerId: "player-red",
         assistPlayerIds: [],
         ownGoal: false,
@@ -553,9 +553,12 @@ test("repository normalizes partial legacy goal records to documented response b
   });
 
   const [goal] = await repository.listGoalEvents("game-1");
+  assert.equal(goal.third, 1);
   assert.equal(goal.thirdMinute, 1);
   assert.equal(goal.gameMinute, 1);
   assert.equal(goal.stoppageMinute, null);
+  assert.equal(goal.scoringTeamId, null);
+  assert.equal(goal.concedingTeamId, "red");
 });
 
 test("repository supports league discovery by user ACL", async () => {

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -151,7 +151,20 @@ class InMemoryDynamoClient {
           )
         ) {
           const error = new Error("Conditional transaction request failed.");
-          (error as Error & { name: string }).name = "ConditionalCheckFailedException";
+          (
+            error as Error & {
+              name: string;
+              CancellationReasons: Array<{ Code: string }>;
+            }
+          ).name = "TransactionCanceledException";
+          (
+            error as Error & {
+              name: string;
+              CancellationReasons: Array<{ Code: string }>;
+            }
+          ).CancellationReasons = puts.map((candidate) => ({
+            Code: candidate === put ? "ConditionalCheckFailed" : "None",
+          }));
           throw error;
         }
       }
@@ -1041,6 +1054,44 @@ test("repository rejects stale scoreboard writes without creating the goal", asy
 
   assert.deepEqual(await repository.listGoalEvents("game-1"), []);
   assert.equal((await repository.listTeamsForGame("game-1")).find((team) => team.teamId === "blue")?.conceded, 7);
+});
+
+test("repository rethrows non-conditional transaction cancellation when creating goals", async () => {
+  const { repository, client } = createRepositoryHarness();
+  await setupScoringGame(repository);
+  await repository.startGameThird({ gameId: "game-1", third: 1 });
+
+  client.runBeforeNextPut(() => {
+    const error = new Error("Transaction validation failed.");
+    (
+      error as Error & {
+        name: string;
+        CancellationReasons: Array<{ Code: string }>;
+      }
+    ).name = "TransactionCanceledException";
+    (
+      error as Error & {
+        name: string;
+        CancellationReasons: Array<{ Code: string }>;
+      }
+    ).CancellationReasons = [{ Code: "ValidationError" }];
+    throw error;
+  });
+
+  await assert.rejects(
+    repository.createGoal({
+      gameId: "game-1",
+      eventId: "goal-transaction-cancelled",
+      scoringTeamId: "red",
+      concedingTeamId: "blue",
+      scorerPlayerId: "player-red",
+      assistPlayerIds: [],
+      ownGoal: false,
+    }),
+    /Transaction validation failed/,
+  );
+
+  assert.deepEqual(await repository.listGoalEvents("game-1"), []);
 });
 
 test("repository own goals increment conceding only and require scorer on conceding team", async () => {

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -751,7 +751,7 @@ test("repository rejects stale timer transition writes without overwriting newer
       thirds: Array<{ third: number; startedAt: string | null; finishedAt: string | null }>;
     };
     data.status = "live";
-    data.thirds[0].startedAt = "2026-02-22T00:00:99.000Z";
+    data.thirds[0].startedAt = "2026-02-22T00:01:29.000Z";
     item.data.S = JSON.stringify(data);
     item.updatedAt = { S: "2026-02-22T00:01:39.000Z" };
     client.seedItem(item);
@@ -762,7 +762,7 @@ test("repository rejects stale timer transition writes without overwriting newer
     /Timer state changed while applying this transition/,
   );
   const externallyStarted = await repository.getGame("game-1");
-  assert.equal(externallyStarted?.thirds[0].startedAt, "2026-02-22T00:00:99.000Z");
+  assert.equal(externallyStarted?.thirds[0].startedAt, "2026-02-22T00:01:29.000Z");
 
   client.runBeforeNextPut(() => {
     const item = client.readItem("GAME#game-1", "METADATA");
@@ -772,9 +772,9 @@ test("repository rejects stale timer transition writes without overwriting newer
     const data = JSON.parse(item.data.S) as {
       thirds: Array<{ third: number; startedAt: string | null; finishedAt: string | null }>;
     };
-    data.thirds[0].finishedAt = "2026-02-22T00:01:99.000Z";
+    data.thirds[0].finishedAt = "2026-02-22T00:02:39.000Z";
     item.data.S = JSON.stringify(data);
-    item.updatedAt = { S: "2026-02-22T00:01:99.000Z" };
+    item.updatedAt = { S: "2026-02-22T00:02:39.000Z" };
     client.seedItem(item);
   });
 
@@ -783,7 +783,7 @@ test("repository rejects stale timer transition writes without overwriting newer
     /Timer state changed while applying this transition/,
   );
   const externallyFinished = await repository.getGame("game-1");
-  assert.equal(externallyFinished?.thirds[0].finishedAt, "2026-02-22T00:01:99.000Z");
+  assert.equal(externallyFinished?.thirds[0].finishedAt, "2026-02-22T00:02:39.000Z");
 });
 
 test("timer display formatting switches to stoppage after nominal length", () => {
@@ -795,10 +795,17 @@ test("timer display formatting switches to stoppage after nominal length", () =>
     stoppageMinute: null,
   });
   assert.deepEqual(formatThirdDisplayTime(1200, 20), {
-    displayTime: "20+01",
-    phase: "stoppage",
+    displayTime: "20:00",
+    phase: "regulation",
     elapsedSeconds: 1200,
     stoppageSeconds: 0,
+    stoppageMinute: null,
+  });
+  assert.deepEqual(formatThirdDisplayTime(1201, 20), {
+    displayTime: "20+01",
+    phase: "stoppage",
+    elapsedSeconds: 1201,
+    stoppageSeconds: 1,
     stoppageMinute: 1,
   });
   assert.deepEqual(formatThirdDisplayTime(1260, 20), {
@@ -1089,7 +1096,7 @@ test("repository rejects stale scoreboard writes without creating the goal", asy
     };
     data.conceded = 7;
     item.data.S = JSON.stringify(data);
-    item.updatedAt = { S: "2026-02-22T00:00:99.000Z" };
+    item.updatedAt = { S: "2026-02-22T00:01:39.000Z" };
     client.seedItem(item);
   });
 

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -561,6 +561,33 @@ test("repository normalizes partial legacy goal records to documented response b
   assert.equal(goal.concedingTeamId, "red");
 });
 
+test("repository normalizes malformed game team records to documented response bounds", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  client.seedItem({
+    pk: { S: "GAME#game-legacy" },
+    sk: { S: "TEAM#green" },
+    entityType: { S: "gameTeam" },
+    createdAt: { S: "2026-02-22T00:00:00.000Z" },
+    updatedAt: { S: "2026-02-22T00:00:00.000Z" },
+    data: {
+      S: JSON.stringify({
+        gameId: "game-legacy",
+        teamId: "green",
+        name: "Legacy Team",
+        color: null,
+        scored: -1,
+        conceded: -2,
+      }),
+    },
+  });
+
+  const [team] = await repository.listTeamsForGame("game-legacy");
+  assert.equal(team.teamId, "red");
+  assert.equal(team.scored, 0);
+  assert.equal(team.conceded, 0);
+});
+
 test("repository supports league discovery by user ACL", async () => {
   const repository = createRepository();
 

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -259,6 +259,18 @@ class IncrementingClock {
   }
 }
 
+class MutableClock {
+  constructor(private stamp: string) {}
+
+  set(stamp: string): void {
+    this.stamp = stamp;
+  }
+
+  now(): string {
+    return this.stamp;
+  }
+}
+
 function createRepository(): ThreeFcRepository {
   return new ThreeFcRepository(new InMemoryDynamoClient(), "threefc_test", new IncrementingClock());
 }
@@ -574,8 +586,8 @@ test("repository normalizes malformed game team records to documented response b
       S: JSON.stringify({
         gameId: "game-legacy",
         teamId: "green",
-        name: "Legacy Team",
-        color: null,
+        name: 42,
+        color: 99,
         scored: -1,
         conceded: -2,
       }),
@@ -584,6 +596,8 @@ test("repository normalizes malformed game team records to documented response b
 
   const [team] = await repository.listTeamsForGame("game-legacy");
   assert.equal(team.teamId, "red");
+  assert.equal(team.name, "");
+  assert.equal(team.color, null);
   assert.equal(team.scored, 0);
   assert.equal(team.conceded, 0);
 });
@@ -1063,6 +1077,35 @@ test("repository creates standard goals with timer stamping, mixed-team assists,
       .map((query) => query.consistentRead),
     [true],
   );
+});
+
+test("repository stamps regulation-boundary goals at the final regulation minute", async () => {
+  const clock = new MutableClock("2026-02-22T00:00:00.000Z");
+  const repository = new ThreeFcRepository(
+    new InMemoryDynamoClient(),
+    "threefc_test",
+    clock,
+  );
+  await setupScoringGame(repository);
+  clock.set("2026-02-22T00:00:00.000Z");
+  await repository.startGameThird({ gameId: "game-1", third: 1 });
+  clock.set("2026-02-22T00:20:00.000Z");
+
+  const result = await repository.createGoal({
+    gameId: "game-1",
+    eventId: "goal-boundary",
+    scoringTeamId: "red",
+    concedingTeamId: "blue",
+    scorerPlayerId: "player-red",
+    assistPlayerIds: [],
+    ownGoal: false,
+  });
+
+  assert.ok(result);
+  assert.equal(result.goal.thirdMinute, 20);
+  assert.equal(result.goal.gameMinute, 20);
+  assert.equal(result.goal.displayTime, "20:00");
+  assert.equal(result.goal.stoppageMinute, null);
 });
 
 test("repository rejects duplicate goal event IDs without double-counting tallies", async () => {

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -8,6 +8,7 @@ import {
   type AttributeValue,
   PutItemCommand,
   QueryCommand,
+  TransactWriteItemsCommand,
 } from "@aws-sdk/client-dynamodb";
 import {
   createDefaultThirdTimerSegments,
@@ -112,6 +113,60 @@ class InMemoryDynamoClient {
       const pk = this.readString(key.pk, "pk");
       const sk = this.readString(key.sk, "sk");
       this.items.delete(`${pk}|${sk}`);
+      return {};
+    }
+
+    if (command instanceof TransactWriteItemsCommand) {
+      const puts = (command.input.TransactItems ?? []).flatMap((item) => {
+        if (!item.Put) {
+          throw new Error("Test client only supports Put transaction items.");
+        }
+
+        return [item.Put];
+      });
+
+      if (this.beforeNextPut) {
+        const callback = this.beforeNextPut;
+        this.beforeNextPut = null;
+        callback();
+      }
+
+      for (const put of puts) {
+        const item = put.Item;
+        if (!item) {
+          throw new Error("TransactWriteItemsCommand Put is missing Item.");
+        }
+
+        const pk = this.readString(item.pk, "pk");
+        const sk = this.readString(item.sk, "sk");
+        const id = `${pk}|${sk}`;
+
+        if (
+          put.ConditionExpression &&
+          !this.conditionMatches(
+            put.ConditionExpression,
+            this.items.get(id),
+            put.ExpressionAttributeNames ?? {},
+            put.ExpressionAttributeValues ?? {},
+          )
+        ) {
+          const error = new Error("Conditional transaction request failed.");
+          (error as Error & { name: string }).name = "ConditionalCheckFailedException";
+          throw error;
+        }
+      }
+
+      for (const put of puts) {
+        const item = put.Item;
+        if (!item) {
+          throw new Error("TransactWriteItemsCommand Put is missing Item.");
+        }
+
+        const pk = this.readString(item.pk, "pk");
+        const sk = this.readString(item.sk, "sk");
+        this.items.set(`${pk}|${sk}`, item);
+      }
+
       return {};
     }
 
@@ -311,49 +366,135 @@ test("repository query supports deterministic session->games ordering", async ()
 });
 
 test("repository query supports deterministic game timeline ordering", async () => {
-  const repository = createRepository();
+  const { repository, client } = createRepositoryHarness();
 
-  await repository.createGoalEvent({
-    gameId: "game-1",
-    eventId: "goal-3",
-    third: 2,
-    gameMinute: 10,
-    scoringTeamId: "yellow",
-    concedingTeamId: "blue",
-    scorerPlayerId: "player-3",
-    assistPlayerIds: [],
-    ownGoal: false,
-  });
-
-  await repository.createGoalEvent({
-    gameId: "game-1",
-    eventId: "goal-1",
-    third: 1,
-    gameMinute: 2,
-    scoringTeamId: "red",
-    concedingTeamId: "yellow",
-    scorerPlayerId: "player-1",
-    assistPlayerIds: [],
-    ownGoal: false,
-  });
-
-  await repository.createGoalEvent({
-    gameId: "game-1",
-    eventId: "goal-2",
-    third: 1,
-    gameMinute: 8,
-    scoringTeamId: "blue",
-    concedingTeamId: "red",
-    scorerPlayerId: "player-2",
-    assistPlayerIds: ["player-4"],
-    ownGoal: false,
-  });
+  for (const goal of [
+    {
+      eventId: "goal-3",
+      sk: "GOAL#2#0030#0000550#goal-3",
+      third: 2,
+      thirdMinute: 10,
+      gameMinute: 30,
+      elapsedSeconds: 550,
+      displayTime: "09:10",
+      scoringTeamId: "yellow",
+      concedingTeamId: "blue",
+      scorerPlayerId: "player-3",
+      assistPlayerIds: [],
+      ownGoal: false,
+    },
+    {
+      eventId: "goal-1",
+      sk: "GOAL#1#0002#0000070#goal-1",
+      third: 1,
+      thirdMinute: 2,
+      gameMinute: 2,
+      elapsedSeconds: 70,
+      displayTime: "01:10",
+      scoringTeamId: "red",
+      concedingTeamId: "yellow",
+      scorerPlayerId: "player-1",
+      assistPlayerIds: [],
+      ownGoal: false,
+    },
+    {
+      eventId: "goal-2",
+      sk: "GOAL#1#0008#0000430#goal-2",
+      third: 1,
+      thirdMinute: 8,
+      gameMinute: 8,
+      elapsedSeconds: 430,
+      displayTime: "07:10",
+      scoringTeamId: "blue",
+      concedingTeamId: "red",
+      scorerPlayerId: "player-2",
+      assistPlayerIds: ["player-4"],
+      ownGoal: false,
+    },
+  ] as const) {
+    client.seedItem({
+      pk: { S: "GAME#game-1" },
+      sk: { S: goal.sk },
+      entityType: { S: "goal" },
+      createdAt: { S: "2026-02-22T00:00:00.000Z" },
+      updatedAt: { S: "2026-02-22T00:00:00.000Z" },
+      data: {
+        S: JSON.stringify({
+          gameId: "game-1",
+          eventId: goal.eventId,
+          third: goal.third,
+          thirdMinute: goal.thirdMinute,
+          gameMinute: goal.gameMinute,
+          elapsedSeconds: goal.elapsedSeconds,
+          stoppageMinute: null,
+          displayTime: goal.displayTime,
+          scoringTeamId: goal.scoringTeamId,
+          concedingTeamId: goal.concedingTeamId,
+          scorerPlayerId: goal.scorerPlayerId,
+          assistPlayerIds: goal.assistPlayerIds,
+          ownGoal: goal.ownGoal,
+        }),
+      },
+    });
+  }
 
   const timeline = await repository.listGoalEvents("game-1");
   assert.equal(timeline.length, 3);
   assert.deepEqual(
     timeline.map((goal) => goal.eventId),
     ["goal-1", "goal-2", "goal-3"],
+  );
+});
+
+test("repository orders stoppage goals by elapsed time before event ID", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  for (const goal of [
+    {
+      eventId: "goal-z-later",
+      sk: "GOAL#1#0020#0001265#goal-z-later",
+      elapsedSeconds: 1265,
+      stoppageMinute: 2,
+      displayTime: "20+02",
+    },
+    {
+      eventId: "goal-a-earlier",
+      sk: "GOAL#1#0020#0001205#goal-a-earlier",
+      elapsedSeconds: 1205,
+      stoppageMinute: 1,
+      displayTime: "20+01",
+    },
+  ] as const) {
+    client.seedItem({
+      pk: { S: "GAME#game-1" },
+      sk: { S: goal.sk },
+      entityType: { S: "goal" },
+      createdAt: { S: "2026-02-22T00:00:00.000Z" },
+      updatedAt: { S: "2026-02-22T00:00:00.000Z" },
+      data: {
+        S: JSON.stringify({
+          gameId: "game-1",
+          eventId: goal.eventId,
+          third: 1,
+          thirdMinute: 20,
+          gameMinute: 20,
+          elapsedSeconds: goal.elapsedSeconds,
+          stoppageMinute: goal.stoppageMinute,
+          displayTime: goal.displayTime,
+          scoringTeamId: "red",
+          concedingTeamId: "blue",
+          scorerPlayerId: "player-red",
+          assistPlayerIds: [],
+          ownGoal: false,
+        }),
+      },
+    });
+  }
+
+  const timeline = await repository.listGoalEvents("game-1");
+  assert.deepEqual(
+    timeline.map((goal) => goal.eventId),
+    ["goal-a-earlier", "goal-z-later"],
   );
 });
 
@@ -734,6 +875,282 @@ test("repository supports idempotency record create/get semantics", async () => 
   assert.equal(record?.responseBody, JSON.stringify({ leagueId: "league-1" }));
 });
 
+async function setupScoringGame(repository: ThreeFcRepository): Promise<void> {
+  await repository.createGame({
+    gameId: "game-1",
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "session-1",
+    gameStartTs: "2026-02-22T10:00:00Z",
+  });
+  for (const team of [
+    { teamId: "red" as const, name: "Red" },
+    { teamId: "blue" as const, name: "Blue" },
+    { teamId: "yellow" as const, name: "Yellow" },
+  ]) {
+    await repository.createGameTeamOverride({
+      gameId: "game-1",
+      teamId: team.teamId,
+      name: team.name,
+      color: null,
+    });
+  }
+  for (const player of [
+    { playerId: "player-red", nickname: "Red Player", teamId: "red" as const },
+    { playerId: "player-blue", nickname: "Blue Player", teamId: "blue" as const },
+    { playerId: "player-yellow", nickname: "Yellow Player", teamId: "yellow" as const },
+  ]) {
+    await repository.createPlayer({
+      playerId: player.playerId,
+      nickname: player.nickname,
+    });
+    await repository.assignRosterPlayer({
+      gameId: "game-1",
+      teamId: player.teamId,
+      playerId: player.playerId,
+    });
+  }
+}
+
+test("repository creates standard goals with timer stamping, mixed-team assists, and persisted tallies", async () => {
+  const repository = createRepository();
+  await setupScoringGame(repository);
+  await repository.startGameThird({ gameId: "game-1", third: 1 });
+
+  const result = await repository.createGoal({
+    gameId: "game-1",
+    eventId: "goal-1",
+    scoringTeamId: "red",
+    concedingTeamId: "blue",
+    scorerPlayerId: "player-red",
+    assistPlayerIds: ["player-blue", "player-yellow"],
+    ownGoal: false,
+  });
+
+  assert.ok(result);
+  assert.equal(result.goal.third, 1);
+  assert.equal(result.goal.thirdMinute, 1);
+  assert.equal(result.goal.gameMinute, 1);
+  assert.equal(result.goal.displayTime, "00:01");
+  assert.equal(result.goal.stoppageMinute, null);
+  assert.deepEqual(result.goal.assistPlayerIds, ["player-blue", "player-yellow"]);
+  assert.deepEqual(
+    result.scoreboard.teams.map((team) => ({
+      teamId: team.teamId,
+      scored: team.scored,
+      conceded: team.conceded,
+    })),
+    [
+      { teamId: "red", scored: 1, conceded: 0 },
+      { teamId: "blue", scored: 0, conceded: 1 },
+      { teamId: "yellow", scored: 0, conceded: 0 },
+    ],
+  );
+  assert.deepEqual(
+    (await repository.listTeamsForGame("game-1")).map((team) => ({
+      teamId: team.teamId,
+      scored: team.scored,
+      conceded: team.conceded,
+    })),
+    [
+      { teamId: "red", scored: 1, conceded: 0 },
+      { teamId: "blue", scored: 0, conceded: 1 },
+      { teamId: "yellow", scored: 0, conceded: 0 },
+    ],
+  );
+  assert.deepEqual(result.timeline.map((goal) => goal.eventId), ["goal-1"]);
+});
+
+test("repository rejects duplicate goal event IDs without double-counting tallies", async () => {
+  const repository = createRepository();
+  await setupScoringGame(repository);
+  await repository.startGameThird({ gameId: "game-1", third: 1 });
+
+  await repository.createGoal({
+    gameId: "game-1",
+    eventId: "goal-idem-duplicate",
+    scoringTeamId: "red",
+    concedingTeamId: "blue",
+    scorerPlayerId: "player-red",
+    assistPlayerIds: [],
+    ownGoal: false,
+  });
+
+  await assert.rejects(
+    repository.createGoal({
+      gameId: "game-1",
+      eventId: "goal-idem-duplicate",
+      scoringTeamId: "red",
+      concedingTeamId: "blue",
+      scorerPlayerId: "player-red",
+      assistPlayerIds: [],
+      ownGoal: false,
+    }),
+    /Goal event has already been created/,
+  );
+
+  assert.deepEqual(
+    (await repository.listTeamsForGame("game-1")).map((team) => ({
+      teamId: team.teamId,
+      scored: team.scored,
+      conceded: team.conceded,
+    })),
+    [
+      { teamId: "red", scored: 1, conceded: 0 },
+      { teamId: "blue", scored: 0, conceded: 1 },
+      { teamId: "yellow", scored: 0, conceded: 0 },
+    ],
+  );
+  assert.deepEqual((await repository.listGoalEvents("game-1")).map((goal) => goal.eventId), [
+    "goal-idem-duplicate",
+  ]);
+});
+
+test("repository rejects stale scoreboard writes without creating the goal", async () => {
+  const { repository, client } = createRepositoryHarness();
+  await setupScoringGame(repository);
+  await repository.startGameThird({ gameId: "game-1", third: 1 });
+
+  client.runBeforeNextPut(() => {
+    const item = client.readItem("GAME#game-1", "TEAM#blue");
+    if (!item?.data?.S) {
+      throw new Error("Expected blue team item.");
+    }
+
+    const data = JSON.parse(item.data.S) as {
+      conceded: number;
+    };
+    data.conceded = 7;
+    item.data.S = JSON.stringify(data);
+    item.updatedAt = { S: "2026-02-22T00:00:99.000Z" };
+    client.seedItem(item);
+  });
+
+  await assert.rejects(
+    repository.createGoal({
+      gameId: "game-1",
+      eventId: "goal-stale",
+      scoringTeamId: "red",
+      concedingTeamId: "blue",
+      scorerPlayerId: "player-red",
+      assistPlayerIds: [],
+      ownGoal: false,
+    }),
+    /Scoreboard changed while creating this goal/,
+  );
+
+  assert.deepEqual(await repository.listGoalEvents("game-1"), []);
+  assert.equal((await repository.listTeamsForGame("game-1")).find((team) => team.teamId === "blue")?.conceded, 7);
+});
+
+test("repository own goals increment conceding only and require scorer on conceding team", async () => {
+  const repository = createRepository();
+  await setupScoringGame(repository);
+  await repository.startGameThird({ gameId: "game-1", third: 1 });
+
+  const result = await repository.createGoal({
+    gameId: "game-1",
+    eventId: "goal-own",
+    scoringTeamId: null,
+    concedingTeamId: "blue",
+    scorerPlayerId: "player-blue",
+    assistPlayerIds: [],
+    ownGoal: true,
+  });
+
+  assert.ok(result);
+  assert.equal(result.goal.scoringTeamId, null);
+  assert.equal(result.goal.ownGoal, true);
+  assert.deepEqual(
+    result.scoreboard.teams.map((team) => ({
+      teamId: team.teamId,
+      scored: team.scored,
+      conceded: team.conceded,
+    })),
+    [
+      { teamId: "red", scored: 0, conceded: 0 },
+      { teamId: "blue", scored: 0, conceded: 1 },
+      { teamId: "yellow", scored: 0, conceded: 0 },
+    ],
+  );
+
+  await assert.rejects(
+    repository.createGoal({
+      gameId: "game-1",
+      eventId: "goal-own-invalid",
+      scoringTeamId: null,
+      concedingTeamId: "blue",
+      scorerPlayerId: "player-red",
+      assistPlayerIds: [],
+      ownGoal: true,
+    }),
+    /Own-goal scorer must be rostered on the conceding team/,
+  );
+});
+
+test("repository rejects goal creation unless a third is running", async () => {
+  const repository = createRepository();
+  await setupScoringGame(repository);
+
+  await assert.rejects(
+    repository.createGoal({
+      gameId: "game-1",
+      eventId: "goal-no-timer",
+      scoringTeamId: "red",
+      concedingTeamId: "blue",
+      scorerPlayerId: "player-red",
+      assistPlayerIds: [],
+      ownGoal: false,
+    }),
+    /only be created while a third is running/,
+  );
+});
+
+test("repository validates goal roster and team rules", async () => {
+  const repository = createRepository();
+  await setupScoringGame(repository);
+  await repository.startGameThird({ gameId: "game-1", third: 1 });
+
+  await assert.rejects(
+    repository.createGoal({
+      gameId: "game-1",
+      eventId: "goal-unrostered-scorer",
+      scoringTeamId: "red",
+      concedingTeamId: "blue",
+      scorerPlayerId: "player-missing",
+      assistPlayerIds: [],
+      ownGoal: false,
+    }),
+    /Scorer must be rostered/,
+  );
+
+  await assert.rejects(
+    repository.createGoal({
+      gameId: "game-1",
+      eventId: "goal-wrong-team",
+      scoringTeamId: "red",
+      concedingTeamId: "blue",
+      scorerPlayerId: "player-blue",
+      assistPlayerIds: [],
+      ownGoal: false,
+    }),
+    /Scorer must be rostered on the scoring team/,
+  );
+
+  await assert.rejects(
+    repository.createGoal({
+      gameId: "game-1",
+      eventId: "goal-unrostered-assist",
+      scoringTeamId: "red",
+      concedingTeamId: "blue",
+      scorerPlayerId: "player-red",
+      assistPlayerIds: ["player-missing"],
+      ownGoal: false,
+    }),
+    /Assist players must be rostered/,
+  );
+});
+
 test("repository rejects missing partition-key inputs", async () => {
   const repository = createRepository();
 
@@ -756,11 +1173,9 @@ test("repository enforces goal validation rules", async () => {
   const repository = createRepository();
 
   await assert.rejects(
-    repository.createGoalEvent({
+    repository.createGoal({
       gameId: "game-1",
       eventId: "goal-invalid",
-      third: 1,
-      gameMinute: 1,
       scoringTeamId: "red",
       concedingTeamId: "blue",
       scorerPlayerId: "player-1",
@@ -771,11 +1186,9 @@ test("repository enforces goal validation rules", async () => {
   );
 
   await assert.rejects(
-    repository.createGoalEvent({
+    repository.createGoal({
       gameId: "game-1",
       eventId: "goal-own",
-      third: 1,
-      gameMinute: 1,
       scoringTeamId: "red",
       concedingTeamId: "blue",
       scorerPlayerId: "player-1",

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -527,6 +527,37 @@ test("repository orders stoppage goals by elapsed time before event ID", async (
   );
 });
 
+test("repository normalizes partial legacy goal records to documented response bounds", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  client.seedItem({
+    pk: { S: "GAME#game-1" },
+    sk: { S: "GOAL#1#0000#0000000#goal-legacy" },
+    entityType: { S: "goal" },
+    createdAt: { S: "2026-02-22T00:00:00.000Z" },
+    updatedAt: { S: "2026-02-22T00:00:00.000Z" },
+    data: {
+      S: JSON.stringify({
+        gameId: "game-1",
+        eventId: "goal-legacy",
+        third: 1,
+        elapsedSeconds: 0,
+        stoppageMinute: 0,
+        scoringTeamId: "red",
+        concedingTeamId: "blue",
+        scorerPlayerId: "player-red",
+        assistPlayerIds: [],
+        ownGoal: false,
+      }),
+    },
+  });
+
+  const [goal] = await repository.listGoalEvents("game-1");
+  assert.equal(goal.thirdMinute, 1);
+  assert.equal(goal.gameMinute, 1);
+  assert.equal(goal.stoppageMinute, null);
+});
+
 test("repository supports league discovery by user ACL", async () => {
   const repository = createRepository();
 
@@ -722,7 +753,7 @@ test("repository rejects stale timer transition writes without overwriting newer
     data.status = "live";
     data.thirds[0].startedAt = "2026-02-22T00:00:99.000Z";
     item.data.S = JSON.stringify(data);
-    item.updatedAt = { S: "2026-02-22T00:00:99.000Z" };
+    item.updatedAt = { S: "2026-02-22T00:01:39.000Z" };
     client.seedItem(item);
   });
 

--- a/api/src/tests/session.test.ts
+++ b/api/src/tests/session.test.ts
@@ -44,6 +44,7 @@ test("isAuthenticatedApiRoute marks protected routes only", () => {
   assert.equal(isAuthenticatedApiRoute("GET", "/v1/games/game-1"), true);
   assert.equal(isAuthenticatedApiRoute("PATCH", "/v1/games/game-1"), true);
   assert.equal(isAuthenticatedApiRoute("DELETE", "/v1/games/game-1"), true);
+  assert.equal(isAuthenticatedApiRoute("POST", "/v1/games/game-1/goals"), true);
   assert.equal(isAuthenticatedApiRoute("GET", "/v1/auth/session"), true);
   assert.equal(isAuthenticatedApiRoute("POST", "/v1/leagues"), true);
   assert.equal(isAuthenticatedApiRoute("POST", "/v1/leagues/league-1/seasons"), true);

--- a/docs/dynamodb-single-table.md
+++ b/docs/dynamodb-single-table.md
@@ -35,7 +35,10 @@ This document defines the baseline key structure and access patterns for the
   - `sk=METADATA`
 - Goal event timeline:
   - `pk=GAME#{gameId}`
-  - `sk=GOAL#{third}#{gameMinuteSortable}#{eventId}`
+  - `sk=GOAL#{third}#{gameMinuteSortable}#{elapsedSecondsSortable}#{eventId}`
+- Goal event id marker:
+  - `pk=GAME#{gameId}`
+  - `sk=GOAL_EVENT#{eventId}`
 - Roster assignment:
   - `pk=GAME#{gameId}`
   - `sk=ROSTER#{teamId}#{playerId}`

--- a/docs/openapi/v1-core-write.yaml
+++ b/docs/openapi/v1-core-write.yaml
@@ -3,7 +3,7 @@ info:
   title: 3FC Core Write API
   version: 0.1.0
   description: |
-    Authenticated core write routes for league/season/session/game creation, M2 roster setup, and third timer control.
+    Authenticated core write routes for league/season/session/game creation, M2 roster setup, third timer control, and goal scoring.
 servers:
   - url: https://qa-api.3fc.football
     description: QA
@@ -195,6 +195,44 @@ paths:
           $ref: "#/components/responses/NotFound"
         "409":
           $ref: "#/components/responses/Conflict"
+  /v1/games/{gameId}/goals:
+    post:
+      summary: Create a goal event and update game scoring tallies
+      operationId: createGoal
+      parameters:
+        - name: gameId
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateGoalRequest"
+      responses:
+        "201":
+          description: Goal created with updated scoreboard and timeline
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateGoalResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          description: State conflict, including no running third, idempotency conflict, duplicate goal request, or stale scoreboard state
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /v1/seasons/{seasonId}/teams:
     get:
       summary: List season default teams
@@ -633,6 +671,42 @@ components:
             - red
             - blue
             - yellow
+    CreateGoalRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - scoringTeamId
+        - concedingTeamId
+        - scorerPlayerId
+        - ownGoal
+      properties:
+        scoringTeamId:
+          type:
+            - string
+            - "null"
+          enum:
+            - red
+            - blue
+            - yellow
+            - null
+        concedingTeamId:
+          type: string
+          enum:
+            - red
+            - blue
+            - yellow
+        scorerPlayerId:
+          type: string
+          minLength: 1
+        assistPlayerIds:
+          type: array
+          default: []
+          maxItems: 3
+          items:
+            type: string
+            minLength: 1
+        ownGoal:
+          type: boolean
     League:
       type: object
       required:
@@ -876,6 +950,8 @@ components:
         - teamId
         - name
         - color
+        - scored
+        - conceded
         - createdAt
         - updatedAt
       properties:
@@ -893,6 +969,12 @@ components:
           type:
             - string
             - "null"
+        scored:
+          type: integer
+          minimum: 0
+        conceded:
+          type: integer
+          minimum: 0
         createdAt:
           type: string
           format: date-time
@@ -960,6 +1042,105 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/RosterAssignment"
+    GoalEvent:
+      type: object
+      required:
+        - gameId
+        - eventId
+        - third
+        - thirdMinute
+        - gameMinute
+        - elapsedSeconds
+        - stoppageMinute
+        - displayTime
+        - scoringTeamId
+        - concedingTeamId
+        - scorerPlayerId
+        - assistPlayerIds
+        - ownGoal
+        - createdAt
+        - updatedAt
+      properties:
+        gameId:
+          type: string
+        eventId:
+          type: string
+        third:
+          type: integer
+          enum:
+            - 1
+            - 2
+            - 3
+        thirdMinute:
+          type: integer
+          minimum: 1
+        gameMinute:
+          type: integer
+          minimum: 1
+        elapsedSeconds:
+          type: integer
+          minimum: 0
+        stoppageMinute:
+          type:
+            - integer
+            - "null"
+          minimum: 1
+        displayTime:
+          type: string
+        scoringTeamId:
+          type:
+            - string
+            - "null"
+          enum:
+            - red
+            - blue
+            - yellow
+            - null
+        concedingTeamId:
+          type: string
+          enum:
+            - red
+            - blue
+            - yellow
+        scorerPlayerId:
+          type: string
+        assistPlayerIds:
+          type: array
+          maxItems: 3
+          items:
+            type: string
+        ownGoal:
+          type: boolean
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    GameScoreboard:
+      type: object
+      required:
+        - teams
+      properties:
+        teams:
+          type: array
+          items:
+            $ref: "#/components/schemas/GameTeam"
+    CreateGoalResponse:
+      type: object
+      required:
+        - goal
+        - scoreboard
+        - timeline
+      properties:
+        goal:
+          $ref: "#/components/schemas/GoalEvent"
+        scoreboard:
+          $ref: "#/components/schemas/GameScoreboard"
+        timeline:
+          type: array
+          items:
+            $ref: "#/components/schemas/GoalEvent"
     ErrorResponse:
       type: object
       additionalProperties: true

--- a/docs/openapi/v1-core-write.yaml
+++ b/docs/openapi/v1-core-write.yaml
@@ -702,6 +702,7 @@ components:
           type: array
           default: []
           maxItems: 3
+          uniqueItems: true
           items:
             type: string
             minLength: 1

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -54,7 +54,8 @@ gameId.
 - Game (metadata): PK=GAME#{gameId} SK=METADATA (leagueId, seasonId, sessionId,
   date, location, thirdLength, status).
 - GoalEvent (timeline): PK=GAME#{gameId}
-  SK=GOAL#{third}#{gameMinuteSortable}#{eventId}
+  SK=GOAL#{third}#{gameMinuteSortable}#{elapsedSecondsSortable}#{eventId}
+- GoalEvent id marker: PK=GAME#{gameId} SK=GOAL_EVENT#{eventId}
 - Roster assignment: PK=GAME#{gameId} SK=ROSTER#{teamId}#{playerId}
 - Session→Game index: PK=SESSION#{sessionId} SK=GAME#{gameStartTs}#{gameId}
 - Player: PK=PLAYER#{playerId} SK=PROFILE

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -37,7 +37,7 @@ export interface GoalEventInput {
   scoringTeamId: TeamId | null;
   concedingTeamId: TeamId;
   scorerPlayerId: string;
-  assistPlayerIds: string[];
+  assistPlayerIds?: string[];
   ownGoal: boolean;
 }
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -184,7 +184,7 @@ export function formatThirdDisplayTime(
   const safeElapsedSeconds = Math.max(0, Math.floor(elapsedSeconds));
   const nominalSeconds = thirdLengthMinutes * 60;
 
-  if (safeElapsedSeconds < nominalSeconds) {
+  if (safeElapsedSeconds <= nominalSeconds) {
     const minutes = Math.floor(safeElapsedSeconds / 60);
     const seconds = safeElapsedSeconds % 60;
     return {

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -34,7 +34,6 @@ export const DEFAULT_TEAMS = [
 ] as const satisfies readonly DefaultTeamDefinition[];
 
 export interface GoalEventInput {
-  gameId: string;
   scoringTeamId: TeamId | null;
   concedingTeamId: TeamId;
   scorerPlayerId: string;

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -35,12 +35,50 @@ export const DEFAULT_TEAMS = [
 
 export interface GoalEventInput {
   gameId: string;
-  third: 1 | 2 | 3;
   scoringTeamId: TeamId | null;
   concedingTeamId: TeamId;
   scorerPlayerId: string;
   assistPlayerIds: string[];
   ownGoal: boolean;
+}
+
+export interface GoalEvent {
+  gameId: string;
+  eventId: string;
+  third: ThirdNumber;
+  thirdMinute: number;
+  gameMinute: number;
+  elapsedSeconds: number;
+  stoppageMinute: number | null;
+  displayTime: string;
+  scoringTeamId: TeamId | null;
+  concedingTeamId: TeamId;
+  scorerPlayerId: string;
+  assistPlayerIds: string[];
+  ownGoal: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GameScoreboardTeam {
+  gameId: string;
+  teamId: TeamId;
+  name: string;
+  color: string | null;
+  scored: number;
+  conceded: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GameScoreboard {
+  teams: GameScoreboardTeam[];
+}
+
+export interface CreateGoalResponse {
+  goal: GoalEvent;
+  scoreboard: GameScoreboard;
+  timeline: GoalEvent[];
 }
 
 export interface ThirdTimerSegment {

--- a/serverless.api-core.yml
+++ b/serverless.api-core.yml
@@ -173,6 +173,12 @@ functions:
           method: OPTIONS
           path: /v1/games/{gameId}/thirds/{third}/finish
       - httpApi:
+          method: POST
+          path: /v1/games/{gameId}/goals
+      - httpApi:
+          method: OPTIONS
+          path: /v1/games/{gameId}/goals
+      - httpApi:
           method: GET
           path: /v1/games/{gameId}/teams
       - httpApi:


### PR DESCRIPTION
<!-- review-packet-version:1 -->

## Behavioural claim

Adds the M2 goal scoring API so an authenticated scorekeeper can create goal events, persist the timeline, and return normalized scoring state for the game flow.

## Specification and acceptance evidence

| Acceptance criterion | Evidence | Result |
| --- | --- | --- |
| Scorekeeper goal creation persists timeline and aggregate state, including legacy-field normalization and regulation-boundary timing. | `npm run test -w @3fc/api` on rebased branch `codex/m2-03-goal-create` | PASS |
| Goal validation preserves 3FC scoring invariants for scorer, assisters, own goals, team scored, and team conceded. | `npm run test -w @3fc/api` on rebased branch `codex/m2-03-goal-create` | PASS |

## Scope boundaries

Included: goal creation API, contracts, repository storage, OpenAPI documentation, serverless route wiring, and API tests.

Excluded: goal correction/undo flows, live scoring UI controls, finish-game/result locking, and join-code player registration.

## Change classification

- Declared risk: `high`
- [ ] `documentation-only` - Documentation only
- [ ] `tests-only` - Tests only
- [x] `application-behaviour` - Application or API behaviour
- [ ] `backlog-maintenance` - Canonical backlog maintenance
- [ ] `dependency-tooling` - Dependency or tooling
- [x] `public-contract` - Public API or repository contract
- [ ] `data-migration` - Database schema or data migration
- [ ] `permission-trust-boundary` - Permission or trust boundary
- [x] `durable-state-ownership` - Durable state or ownership
- [ ] `destructive-behaviour` - Destructive or difficult-to-reverse behaviour
- [ ] `new-production-dependency` - New production dependency
- [ ] `authentication-authorisation` - Authentication or authorisation
- [ ] `privacy-regulated-data` - Privacy or regulated data
- [ ] `infrastructure-production-configuration` - Infrastructure or deployment control
- [ ] `review-policy` - Review policy, packet, or workflow

## Architecture and invariants

- [ ] `architecture:none`
- [x] `architecture:documented`
- [ ] `architecture:judgement-required`

### Affected invariants

| Invariant | How this PR affects it | Why it remains valid | Evidence |
| --- | --- | --- | --- |
| INV-002 | Adds a new protected scorekeeper write route for creating goal events. | The route is wired through the existing session and league-scoped scorekeeper authorization boundary before repository writes occur. | `npm run test -w @3fc/api`; `api/src/tests/acl.test.ts`; `api/src/tests/lambda-core.test.ts` |
| INV-003 | Adds an idempotent goal creation write keyed by `Idempotency-Key`. | Matching replay returns the stored result and conflicting key reuse is rejected before duplicate goal state is created. | `npm run test -w @3fc/api`; `api/src/tests/lambda-core.test.ts`; `api/src/tests/repository.test.ts` |
| INV-004 | Adds goal event storage and game scoring state updates to the documented single-table model. | Goal events remain owned by the globally addressable game record and use documented PK/SK access patterns. | `npm run test -w @3fc/api`; `docs/dynamodb-single-table.md`; `api/src/tests/repository.test.ts` |
| INV-005 | Introduces normal-goal and own-goal tally computation for team `scored` and `conceded`. | Own goals increment only the conceding tally and never add team scored or player goal credit. | `npm run test -w @3fc/api`; `api/src/tests/lambda-core.test.ts`; `api/src/tests/repository.test.ts` |
| INV-008 | Adds scorer and assister validation to goal creation. | The API enforces at most three unique assisters, rejects scorer-as-assister, and accepts any rostered game player as an assister. | `npm run test -w @3fc/api`; `api/src/tests/lambda-core.test.ts` |

### Architecture or decision record

Existing goal/event ownership and scoring rules remain documented in `docs/spec.md`, `docs/dynamodb-single-table.md`, `docs/openapi/v1-core-write.yaml`, and `docs/architecture/invariants.md`.

## Failure and rollback

### Failure behaviour

Invalid goal payloads fail with stable validation errors, unauthorized writes fail before persistence, idempotency conflicts are rejected, and failed repository writes leave no partial goal event state.

### Rollback approach

Revert the merge commit for this PR and redeploy the API/app from the previous main release; no migration or destructive data rewrite is introduced.

### Rollback evidence

The PR only adds code, contracts, route wiring, and documentation for new goal creation behaviour; `npm run test -w @3fc/api` passes on the rebased branch.

## Automated and agent review disposition

### Unresolved blocking findings

None.

### Rejected findings and evidence

None.

## Human judgement

- [x] `human-judgement:none`
- [ ] `human-judgement:required`

### Decision requiring judgement

None.

### Options considered

None.

### Reason selected

None.

### Reversal cost

None.

## Review focus

Please inspect the goal idempotency boundary, own-goal/team-tally behaviour, and DynamoDB ownership shape for the new event records.

Fixes #27
