### PR TITLE
[codex] Add M2 goal correction APIs

### DIFF
--- a/api/src/auth/acl.ts
+++ b/api/src/auth/acl.ts
@@ -12,6 +12,9 @@ const ROUTES = {
   startGameThird: /^\/v1\/games\/([^/]+)\/thirds\/([^/]*)\/start$/,
   finishGameThird: /^\/v1\/games\/([^/]+)\/thirds\/([^/]*)\/finish$/,
   createGoal: /^\/v1\/games\/([^/]+)\/goals$/,
+  updateGoal: /^\/v1\/games\/([^/]+)\/goals\/([^/]+)$/,
+  deleteGoal: /^\/v1\/games\/([^/]+)\/goals\/([^/]+)$/,
+  undoLastGoal: /^\/v1\/games\/([^/]+)\/goals\/undo-last$/,
 } as const;
 
 export type ProtectedMutationOperation =
@@ -25,7 +28,10 @@ export type ProtectedMutationOperation =
   | "assignRosterPlayer"
   | "startGameThird"
   | "finishGameThird"
-  | "createGoal";
+  | "createGoal"
+  | "updateGoal"
+  | "deleteGoal"
+  | "undoLastGoal";
 
 export interface ProtectedMutationRoute {
   operation: ProtectedMutationOperation;
@@ -146,6 +152,30 @@ export function resolveProtectedMutationRoute(
     return {
       operation: "createGoal",
       gameId: decodeRouteParam(createGoalMatch[1]),
+    };
+  }
+
+  const updateGoalMatch = upperMethod === "PATCH" ? route.match(ROUTES.updateGoal) : null;
+  if (updateGoalMatch) {
+    return {
+      operation: "updateGoal",
+      gameId: decodeRouteParam(updateGoalMatch[1]),
+    };
+  }
+
+  const deleteGoalMatch = upperMethod === "DELETE" ? route.match(ROUTES.deleteGoal) : null;
+  if (deleteGoalMatch) {
+    return {
+      operation: "deleteGoal",
+      gameId: decodeRouteParam(deleteGoalMatch[1]),
+    };
+  }
+
+  const undoLastGoalMatch = upperMethod === "POST" ? route.match(ROUTES.undoLastGoal) : null;
+  if (undoLastGoalMatch) {
+    return {
+      operation: "undoLastGoal",
+      gameId: decodeRouteParam(undoLastGoalMatch[1]),
     };
   }
 

--- a/api/src/auth/session.ts
+++ b/api/src/auth/session.ts
@@ -115,6 +115,18 @@ export function isAuthenticatedApiRoute(method: string, route: string): boolean 
     return true;
   }
 
+  if (method === "PATCH" && /^\/v1\/games\/[^/]+\/goals\/[^/]+$/.test(route)) {
+    return true;
+  }
+
+  if (method === "DELETE" && /^\/v1\/games\/[^/]+\/goals\/[^/]+$/.test(route)) {
+    return true;
+  }
+
+  if (method === "POST" && /^\/v1\/games\/[^/]+\/goals\/undo-last$/.test(route)) {
+    return true;
+  }
+
   if (method === "GET" && route === "/v1/auth/session") {
     return true;
   }

--- a/api/src/contracts/core-write.ts
+++ b/api/src/contracts/core-write.ts
@@ -128,6 +128,62 @@ export const createGoalRequestSchema = z
     }
   });
 
+export const updateGoalRequestSchema = z
+  .object({
+    scoringTeamId: teamIdSchema.nullable().optional(),
+    concedingTeamId: teamIdSchema.optional(),
+    scorerPlayerId: nonEmptyTrimmedString.optional(),
+    assistPlayerIds: z
+      .array(nonEmptyTrimmedString)
+      .max(MAX_ASSISTS, `must contain no more than ${MAX_ASSISTS} player IDs`)
+      .optional(),
+    ownGoal: z.boolean().optional(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (
+      value.scoringTeamId === undefined &&
+      value.concedingTeamId === undefined &&
+      value.scorerPlayerId === undefined &&
+      value.assistPlayerIds === undefined &&
+      value.ownGoal === undefined
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "must include at least one goal field to update",
+      });
+    }
+
+    if (value.assistPlayerIds !== undefined) {
+      const uniqueAssistPlayerIds = new Set(value.assistPlayerIds);
+
+      if (uniqueAssistPlayerIds.size !== value.assistPlayerIds.length) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["assistPlayerIds"],
+          message: "must be unique",
+        });
+      }
+
+      if (
+        value.scorerPlayerId !== undefined &&
+        uniqueAssistPlayerIds.has(value.scorerPlayerId)
+      ) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["assistPlayerIds"],
+          message: "must not include the scorer",
+        });
+      }
+    }
+  });
+
+export const undoLastGoalRequestSchema = z
+  .object({
+    expectedEventId: nonEmptyTrimmedString,
+  })
+  .strict();
+
 export type CreateLeagueRequest = z.infer<typeof createLeagueRequestSchema>;
 export type CreateSeasonRequest = z.infer<typeof createSeasonRequestSchema>;
 export type CreateSessionRequest = z.infer<typeof createSessionRequestSchema>;
@@ -136,6 +192,8 @@ export type UpsertTeamRequest = z.infer<typeof upsertTeamRequestSchema>;
 export type QuickCreateGamePlayerRequest = z.infer<typeof quickCreateGamePlayerRequestSchema>;
 export type AssignRosterPlayerRequest = z.infer<typeof assignRosterPlayerRequestSchema>;
 export type CreateGoalRequest = z.infer<typeof createGoalRequestSchema>;
+export type UpdateGoalRequest = z.infer<typeof updateGoalRequestSchema>;
+export type UndoLastGoalRequest = z.infer<typeof undoLastGoalRequestSchema>;
 
 export function formatSchemaValidationError(error: z.ZodError): string {
   if (error.issues.length === 0) {

--- a/api/src/data/keys.ts
+++ b/api/src/data/keys.ts
@@ -75,6 +75,18 @@ export function goalEventIdSk(eventId: string): string {
   return `GOAL_EVENT#${eventId}`;
 }
 
+export function goalStateSk(): string {
+  return "GOAL_STATE";
+}
+
+export function goalAuditSk(createdAt: string, auditId: string): string {
+  return `AUDIT#GOAL#${createdAt}#${auditId}`;
+}
+
+export function goalCorrectionOperationSk(operationId: string): string {
+  return `GOAL_CORRECTION#${operationId}`;
+}
+
 export function goalSk(
   third: 1 | 2 | 3,
   gameMinute: number,

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -2472,7 +2472,8 @@ export class ThreeFcRepository {
 
     if (
       input.expectedLatestEventId &&
-      existingGoalState?.state.latestEventId !== input.expectedLatestEventId
+      existingGoalState &&
+      existingGoalState.state.latestEventId !== input.expectedLatestEventId
     ) {
       throw new GoalCorrectionError(
         "latest_goal_changed",

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -10,6 +10,7 @@ import {
   TransactWriteItemsCommand,
   type AttributeValue,
 } from "@aws-sdk/client-dynamodb";
+import { randomUUID } from "node:crypto";
 import {
   createDefaultThirdTimerSegments,
   DEFAULT_THIRD_LENGTH_MINUTES,
@@ -30,7 +31,10 @@ import {
   gamePlayerSk,
   gameSessionIndexPk,
   gameSessionIndexSk,
+  goalAuditSk,
+  goalCorrectionOperationSk,
   goalEventIdSk,
+  goalStateSk,
   goalSk,
   idempotencyPk,
   leaguePk,
@@ -57,10 +61,17 @@ import type {
   CreateSessionGameInput,
   CreateSessionInput,
   CreateTeamInput,
+  DeleteGoalInput,
+  DeleteGoalResult,
   GameTeamRecord,
   GamePlayerRecord,
   GameRecord,
+  GoalAuditAction,
+  GoalAuditRecord,
+  GoalAuditSnapshotRecord,
+  GoalCorrectionOperationRecord,
   GoalEventRecord,
+  GoalStateRecord,
   IdempotencyRecord,
   LeagueAclRecord,
   LeagueRecord,
@@ -74,6 +85,9 @@ import type {
   TeamRecord,
   GrantLeagueAccessInput,
   ThirdTransitionInput,
+  UndoLastGoalInput,
+  UpdateGoalInput,
+  UpdateGoalResult,
 } from "./types.js";
 
 const ENTITY_TYPE = {
@@ -90,6 +104,9 @@ const ENTITY_TYPE = {
   roster: "roster",
   goal: "goal",
   goalEventId: "goalEventId",
+  goalState: "goalState",
+  goalAudit: "goalAudit",
+  goalCorrectionOperation: "goalCorrectionOperation",
   idempotency: "idempotency",
 } as const;
 
@@ -146,6 +163,30 @@ export class GoalCreationError extends Error {
   }
 }
 
+export class GoalCorrectionError extends Error {
+  constructor(
+    readonly code: string,
+    readonly statusCode: 400 | 409,
+    message: string,
+  ) {
+    super(message);
+    this.name = "GoalCorrectionError";
+  }
+}
+
+type GoalRuleErrorKind = "creation" | "correction";
+
+function goalRuleError(
+  kind: GoalRuleErrorKind,
+  code: string,
+  statusCode: 400 | 409,
+  message: string,
+): GoalCreationError | GoalCorrectionError {
+  return kind === "creation"
+    ? new GoalCreationError(code, statusCode, message)
+    : new GoalCorrectionError(code, statusCode, message);
+}
+
 function requireNonEmpty(name: string, value: string): void {
   if (value.trim().length === 0) {
     throw new Error(`${name} must be a non-empty string.`);
@@ -161,6 +202,21 @@ function requireThirdNumber(third: number): asserts third is ThirdNumber {
 function requireTeamId(teamId: string | null, fieldName: string): asserts teamId is TeamId {
   if (teamId === null || !TEAM_IDS.includes(teamId as TeamId)) {
     throw new GoalCreationError(
+      "invalid_team",
+      400,
+      `${fieldName} must be red, blue, or yellow.`,
+    );
+  }
+}
+
+function requireGoalTeamId(
+  teamId: string | null,
+  fieldName: string,
+  errorKind: GoalRuleErrorKind,
+): asserts teamId is TeamId {
+  if (teamId === null || !TEAM_IDS.includes(teamId as TeamId)) {
+    throw goalRuleError(
+      errorKind,
       "invalid_team",
       400,
       `${fieldName} must be red, blue, or yellow.`,
@@ -268,6 +324,75 @@ function normalizeGoalEventPayload(data: unknown): Omit<GoalEventRecord, "create
   };
 }
 
+function normalizeGoalStatePayload(data: unknown): Omit<GoalStateRecord, "createdAt" | "updatedAt"> {
+  const raw = data as Partial<Omit<GoalStateRecord, "createdAt" | "updatedAt">>;
+
+  return {
+    gameId: raw.gameId ?? "",
+    latestEventId: typeof raw.latestEventId === "string" ? raw.latestEventId : null,
+    latestGoalSk: typeof raw.latestGoalSk === "string" ? raw.latestGoalSk : null,
+    revision: normalizeNonNegativeInteger(raw.revision),
+  };
+}
+
+function normalizeGoalAuditSnapshot(data: unknown): GoalAuditSnapshotRecord | null {
+  if (!data || typeof data !== "object") {
+    return null;
+  }
+
+  const raw = data as Partial<GoalAuditSnapshotRecord>;
+  const third = raw.third ?? 1;
+
+  return {
+    eventId: raw.eventId ?? "",
+    third,
+    thirdMinute: normalizeNonNegativeInteger(raw.thirdMinute),
+    gameMinute: normalizeNonNegativeInteger(raw.gameMinute),
+    elapsedSeconds: normalizeNonNegativeInteger(raw.elapsedSeconds),
+    stoppageMinute:
+      raw.stoppageMinute === null || Number.isInteger(raw.stoppageMinute)
+        ? (raw.stoppageMinute ?? null)
+        : null,
+    displayTime: raw.displayTime ?? String(raw.gameMinute ?? ""),
+    scoringTeamId: raw.scoringTeamId ?? null,
+    concedingTeamId: raw.concedingTeamId ?? "red",
+    scorerPlayerId: raw.scorerPlayerId ?? "",
+    assistPlayerIds: Array.isArray(raw.assistPlayerIds)
+      ? raw.assistPlayerIds.filter((playerId): playerId is string => typeof playerId === "string")
+      : [],
+    ownGoal: raw.ownGoal ?? false,
+  };
+}
+
+function normalizeGoalAuditPayload(data: unknown): Omit<GoalAuditRecord, "createdAt" | "updatedAt"> {
+  const raw = data as Partial<Omit<GoalAuditRecord, "createdAt" | "updatedAt">>;
+
+  return {
+    auditId: raw.auditId ?? "",
+    gameId: raw.gameId ?? "",
+    eventId: raw.eventId ?? "",
+    actorUserId: raw.actorUserId ?? "",
+    action: raw.action ?? "goal_updated",
+    before: normalizeGoalAuditSnapshot(raw.before),
+    after: normalizeGoalAuditSnapshot(raw.after),
+  };
+}
+
+function normalizeGoalCorrectionOperationPayload(
+  data: unknown,
+): Omit<GoalCorrectionOperationRecord, "createdAt" | "updatedAt"> {
+  const raw = data as Partial<Omit<GoalCorrectionOperationRecord, "createdAt" | "updatedAt">>;
+
+  return {
+    gameId: raw.gameId ?? "",
+    eventId: raw.eventId ?? "",
+    operationId: raw.operationId ?? "",
+    requestHash: raw.requestHash ?? "",
+    action: raw.action ?? "goal_updated",
+    result: raw.result as GoalCorrectionOperationRecord["result"],
+  };
+}
+
 function isThirdStarted(game: Pick<GameRecord, "thirds">): boolean {
   return game.thirds.some((third) => third.startedAt !== null);
 }
@@ -278,6 +403,46 @@ function compareTeamIds(left: TeamId, right: TeamId): number {
 
 function sortGameTeams<T extends { teamId: TeamId }>(teams: T[]): T[] {
   return [...teams].sort((left, right) => compareTeamIds(left.teamId, right.teamId));
+}
+
+function compareGoalEvents(left: Pick<GoalEventRecord, "third" | "gameMinute" | "elapsedSeconds" | "eventId">, right: Pick<GoalEventRecord, "third" | "gameMinute" | "elapsedSeconds" | "eventId">): number {
+  const thirdSort = left.third - right.third;
+  if (thirdSort !== 0) {
+    return thirdSort;
+  }
+
+  const minuteSort = left.gameMinute - right.gameMinute;
+  if (minuteSort !== 0) {
+    return minuteSort;
+  }
+
+  const elapsedSort = left.elapsedSeconds - right.elapsedSeconds;
+  if (elapsedSort !== 0) {
+    return elapsedSort;
+  }
+
+  return left.eventId.localeCompare(right.eventId);
+}
+
+function latestGoalEvent(goals: GoalEventRecord[]): GoalEventRecord | null {
+  return [...goals].sort(compareGoalEvents).at(-1) ?? null;
+}
+
+function goalAuditSnapshot(goal: GoalEventRecord): GoalAuditSnapshotRecord {
+  return {
+    eventId: goal.eventId,
+    third: goal.third,
+    thirdMinute: goal.thirdMinute,
+    gameMinute: goal.gameMinute,
+    elapsedSeconds: goal.elapsedSeconds,
+    stoppageMinute: goal.stoppageMinute,
+    displayTime: goal.displayTime,
+    scoringTeamId: goal.scoringTeamId,
+    concedingTeamId: goal.concedingTeamId,
+    scorerPlayerId: goal.scorerPlayerId,
+    assistPlayerIds: goal.assistPlayerIds,
+    ownGoal: goal.ownGoal,
+  };
 }
 
 function isConditionalWriteFailure(error: unknown): boolean {
@@ -1248,9 +1413,499 @@ export class ThreeFcRepository {
       );
   }
 
+  private async readGoalTeamStates(
+    gameId: string,
+    options: { consistentRead?: boolean } = {},
+  ): Promise<{
+    teams: GameTeamRecord[];
+    teamStatesById: Map<TeamId, { record: GameTeamRecord; rawData: string }>;
+  }> {
+    const teamItems = await this.queryByPrefix(gamePk(gameId), "TEAM#", options);
+    const teamStates = teamItems
+      .filter((item) => item.entityType === ENTITY_TYPE.gameTeam)
+      .map((item) => ({
+        record: withTimestamps(
+          normalizeGameTeamPayload(item.data),
+          item.createdAt,
+          item.updatedAt,
+        ),
+        rawData: item.rawData,
+      }));
+
+    return {
+      teams: sortGameTeams(teamStates.map((teamState) => teamState.record)),
+      teamStatesById: new Map(teamStates.map((teamState) => [teamState.record.teamId, teamState])),
+    };
+  }
+
+  private validateGoalRules(
+    input: {
+      gameId: string;
+      scoringTeamId: TeamId | null;
+      concedingTeamId: TeamId;
+      scorerPlayerId: string;
+      assistPlayerIds: string[];
+      ownGoal: boolean;
+    },
+    teams: GameTeamRecord[],
+    roster: RosterAssignmentRecord[],
+    errorKind: GoalRuleErrorKind,
+  ): void {
+    requireGoalTeamId(input.concedingTeamId, "concedingTeamId", errorKind);
+    if (input.scoringTeamId !== null) {
+      requireGoalTeamId(input.scoringTeamId, "scoringTeamId", errorKind);
+    }
+
+    try {
+      validateAssistPlayerIds(input.scorerPlayerId, input.assistPlayerIds);
+    } catch (error) {
+      throw goalRuleError(
+        errorKind,
+        "invalid_assists",
+        400,
+        error instanceof Error ? error.message : "Assist player IDs are invalid.",
+      );
+    }
+
+    if (input.ownGoal && input.scoringTeamId !== null) {
+      throw goalRuleError(
+        errorKind,
+        "own_goal_scoring_team",
+        400,
+        "ownGoal=true requires scoringTeamId to be null.",
+      );
+    }
+
+    if (!input.ownGoal && input.scoringTeamId === null) {
+      throw goalRuleError(
+        errorKind,
+        "scoring_team_required",
+        400,
+        "scoringTeamId is required when ownGoal=false.",
+      );
+    }
+
+    if (!input.ownGoal && input.scoringTeamId === input.concedingTeamId) {
+      throw goalRuleError(
+        errorKind,
+        "same_team_goal",
+        400,
+        "scoringTeamId and concedingTeamId must be different for a standard goal.",
+      );
+    }
+
+    const teamsById = new Map(teams.map((team) => [team.teamId, team]));
+    const concedingTeam = teamsById.get(input.concedingTeamId);
+    if (!concedingTeam) {
+      throw goalRuleError(
+        errorKind,
+        "invalid_conceding_team",
+        400,
+        "concedingTeamId must be an active team for this game.",
+      );
+    }
+
+    const scoringTeam = input.scoringTeamId ? teamsById.get(input.scoringTeamId) : null;
+    if (!input.ownGoal && !scoringTeam) {
+      throw goalRuleError(
+        errorKind,
+        "invalid_scoring_team",
+        400,
+        "scoringTeamId must be an active team for this game.",
+      );
+    }
+
+    const rosterByPlayerId = new Map(roster.map((assignment) => [assignment.playerId, assignment]));
+    const scorerRoster = rosterByPlayerId.get(input.scorerPlayerId);
+    if (!scorerRoster) {
+      throw goalRuleError(
+        errorKind,
+        "scorer_not_rostered",
+        400,
+        "Scorer must be rostered in this game.",
+      );
+    }
+
+    if (!input.ownGoal && scorerRoster.teamId !== input.scoringTeamId) {
+      throw goalRuleError(
+        errorKind,
+        "scorer_not_on_scoring_team",
+        400,
+        "Scorer must be rostered on the scoring team for a standard goal.",
+      );
+    }
+
+    if (input.ownGoal && scorerRoster.teamId !== input.concedingTeamId) {
+      throw goalRuleError(
+        errorKind,
+        "scorer_not_on_conceding_team",
+        400,
+        "Own-goal scorer must be rostered on the conceding team.",
+      );
+    }
+
+    for (const assistPlayerId of input.assistPlayerIds) {
+      if (!rosterByPlayerId.has(assistPlayerId)) {
+        throw goalRuleError(
+          errorKind,
+          "assist_not_rostered",
+          400,
+          "Assist players must be rostered in this game.",
+        );
+      }
+    }
+  }
+
+  private recomputeTeamsFromGoals(
+    gameId: string,
+    teams: GameTeamRecord[],
+    timeline: GoalEventRecord[],
+    now: string,
+  ): GameTeamRecord[] {
+    const countsByTeamId = new Map<TeamId, { scored: number; conceded: number }>();
+    for (const team of teams) {
+      countsByTeamId.set(team.teamId, { scored: 0, conceded: 0 });
+    }
+
+    for (const goal of timeline) {
+      if (!goal.ownGoal && goal.scoringTeamId) {
+        const scoringCounts = countsByTeamId.get(goal.scoringTeamId);
+        if (scoringCounts) {
+          scoringCounts.scored += 1;
+        }
+      }
+
+      const concedingCounts = countsByTeamId.get(goal.concedingTeamId);
+      if (concedingCounts) {
+        concedingCounts.conceded += 1;
+      }
+    }
+
+    return sortGameTeams(
+      teams.map((team) => {
+        const counts = countsByTeamId.get(team.teamId) ?? { scored: 0, conceded: 0 };
+        const changed = team.scored !== counts.scored || team.conceded !== counts.conceded;
+        return {
+          ...team,
+          scored: counts.scored,
+          conceded: counts.conceded,
+          updatedAt: changed ? now : team.updatedAt,
+        };
+      }),
+    );
+  }
+
+  private async findGoalByEventId(
+    gameId: string,
+    eventId: string,
+    options: { consistentRead?: boolean } = {},
+  ): Promise<{ goal: GoalEventRecord; sk: string; stored: StoredEntity<unknown> } | null> {
+    const marker = await this.getEntity(gamePk(gameId), goalEventIdSk(eventId), options);
+    const markerGoalSk =
+      marker?.entityType === ENTITY_TYPE.goalEventId &&
+      typeof (marker.data as { goalSk?: unknown }).goalSk === "string"
+        ? (marker.data as { goalSk: string }).goalSk
+        : null;
+
+    if (markerGoalSk) {
+      const stored = await this.getEntity(gamePk(gameId), markerGoalSk, options);
+      if (stored?.entityType === ENTITY_TYPE.goal) {
+        return {
+          goal: withTimestamps(
+            normalizeGoalEventPayload(stored.data),
+            stored.createdAt,
+            stored.updatedAt,
+          ),
+          sk: stored.sk,
+          stored,
+        };
+      }
+    }
+
+    const goalItems = await this.queryByPrefix(gamePk(gameId), "GOAL#", options);
+    const stored = goalItems.find(
+      (item) =>
+        item.entityType === ENTITY_TYPE.goal &&
+        normalizeGoalEventPayload(item.data).eventId === eventId,
+    );
+
+    if (!stored) {
+      return null;
+    }
+
+    return {
+      goal: withTimestamps(normalizeGoalEventPayload(stored.data), stored.createdAt, stored.updatedAt),
+      sk: stored.sk,
+      stored,
+    };
+  }
+
+  private async getGoalState(
+    gameId: string,
+    options: { consistentRead?: boolean } = {},
+  ): Promise<{ state: GoalStateRecord; rawData: string } | null> {
+    const stored = await this.getEntity(gamePk(gameId), goalStateSk(), options);
+    if (!stored || stored.entityType !== ENTITY_TYPE.goalState) {
+      return null;
+    }
+
+    return {
+      state: withTimestamps(
+        normalizeGoalStatePayload(stored.data),
+        stored.createdAt,
+        stored.updatedAt,
+      ),
+      rawData: stored.rawData,
+    };
+  }
+
+  private buildGoalStateWrite(
+    gameId: string,
+    latest: GoalEventRecord | null,
+    latestGoalSk: string | null,
+    now: string,
+    existing: { state: GoalStateRecord; rawData: string } | null,
+  ) {
+    const payload = {
+      gameId,
+      latestEventId: latest?.eventId ?? null,
+      latestGoalSk,
+      revision: (existing?.state.revision ?? 0) + 1,
+    };
+    const basePut = {
+      TableName: this.tableName,
+      Item: buildItemWithTimestamps(
+        gamePk(gameId),
+        goalStateSk(),
+        ENTITY_TYPE.goalState,
+        payload,
+        existing?.state.createdAt ?? now,
+        now,
+      ),
+    };
+
+    if (!existing) {
+      return {
+        Put: {
+          ...basePut,
+          ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
+        },
+      };
+    }
+
+    return {
+      Put: {
+        ...basePut,
+        ConditionExpression: "#updatedAt = :expectedGoalStateUpdatedAt AND #data = :expectedGoalStateData",
+        ExpressionAttributeNames: {
+          "#updatedAt": "updatedAt",
+          "#data": "data",
+        },
+        ExpressionAttributeValues: {
+          ":expectedGoalStateUpdatedAt": { S: existing.state.updatedAt },
+          ":expectedGoalStateData": { S: existing.rawData },
+        },
+      },
+    };
+  }
+
+  private buildGoalAuditRecord(input: {
+    gameId: string;
+    eventId: string;
+    actorUserId: string;
+    action: GoalAuditAction;
+    before: GoalEventRecord | null;
+    after: GoalEventRecord | null;
+    now: string;
+  }): GoalAuditRecord {
+    return {
+      auditId: randomUUID(),
+      gameId: input.gameId,
+      eventId: input.eventId,
+      actorUserId: input.actorUserId,
+      action: input.action,
+      before: input.before ? goalAuditSnapshot(input.before) : null,
+      after: input.after ? goalAuditSnapshot(input.after) : null,
+      createdAt: input.now,
+      updatedAt: input.now,
+    };
+  }
+
+  private buildTeamPutTransactionItems(
+    teams: GameTeamRecord[],
+    originalTeamStatesById: Map<TeamId, { record: GameTeamRecord; rawData: string }>,
+    now: string,
+  ) {
+    return teams.map((team) => {
+      const original = originalTeamStatesById.get(team.teamId);
+      if (!original) {
+        throw new GoalCorrectionError(
+          "scoreboard_state_changed",
+          409,
+          "Scoreboard changed while correcting this goal. Reload the game and try again.",
+        );
+      }
+
+      return {
+        Put: {
+          TableName: this.tableName,
+          Item: buildItemWithTimestamps(
+            gamePk(team.gameId),
+            teamSk(team.teamId),
+            ENTITY_TYPE.gameTeam,
+            {
+              gameId: team.gameId,
+              teamId: team.teamId,
+              name: team.name,
+              color: team.color,
+              scored: team.scored,
+              conceded: team.conceded,
+            },
+            team.createdAt,
+            team.updatedAt === original.record.updatedAt ? original.record.updatedAt : now,
+          ),
+          ConditionExpression: "#updatedAt = :expectedUpdatedAt AND #data = :expectedData",
+          ExpressionAttributeNames: {
+            "#updatedAt": "updatedAt",
+            "#data": "data",
+          },
+          ExpressionAttributeValues: {
+            ":expectedUpdatedAt": { S: original.record.updatedAt },
+            ":expectedData": { S: original.rawData },
+          },
+        },
+      };
+    });
+  }
+
+  private buildGoalAuditPut(audit: GoalAuditRecord) {
+    return {
+      Put: {
+        TableName: this.tableName,
+        Item: buildItemWithTimestamps(
+          gamePk(audit.gameId),
+          goalAuditSk(audit.createdAt, audit.auditId),
+          ENTITY_TYPE.goalAudit,
+          {
+            auditId: audit.auditId,
+            gameId: audit.gameId,
+            eventId: audit.eventId,
+            actorUserId: audit.actorUserId,
+            action: audit.action,
+            before: audit.before,
+            after: audit.after,
+          },
+          audit.createdAt,
+          audit.updatedAt,
+        ),
+        ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
+      },
+    };
+  }
+
+  private normalizeCorrectionOperation(input: {
+    operationId?: string | null;
+    operationRequestHash?: string | null;
+  }): { operationId: string; requestHash: string } | null {
+    const operationId = input.operationId?.trim() ?? "";
+    const requestHash = input.operationRequestHash?.trim() ?? "";
+    if (!operationId && !requestHash) {
+      return null;
+    }
+
+    if (!operationId || !requestHash) {
+      throw new GoalCorrectionError(
+        "invalid_correction_operation",
+        400,
+        "Correction operation id and request hash must be provided together.",
+      );
+    }
+
+    return {
+      operationId,
+      requestHash,
+    };
+  }
+
+  private buildGoalCorrectionOperationPut(input: {
+    gameId: string;
+    eventId: string;
+    operationId: string;
+    requestHash: string;
+    action: Extract<GoalAuditAction, "goal_updated" | "goal_deleted" | "goal_undo_last">;
+    result: GoalCorrectionOperationRecord["result"];
+    now: string;
+  }) {
+    return {
+      Put: {
+        TableName: this.tableName,
+        Item: buildItem(
+          gamePk(input.gameId),
+          goalCorrectionOperationSk(input.operationId),
+          ENTITY_TYPE.goalCorrectionOperation,
+          {
+            gameId: input.gameId,
+            eventId: input.eventId,
+            operationId: input.operationId,
+            requestHash: input.requestHash,
+            action: input.action,
+            result: input.result,
+          },
+          input.now,
+        ),
+        ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
+      },
+    };
+  }
+
+  private async getGoalCorrectionOperation(
+    gameId: string,
+    operationId: string,
+  ): Promise<GoalCorrectionOperationRecord | null> {
+    const stored = await this.getEntity(
+      gamePk(gameId),
+      goalCorrectionOperationSk(operationId),
+      { consistentRead: true },
+    );
+    if (!stored || stored.entityType !== ENTITY_TYPE.goalCorrectionOperation) {
+      return null;
+    }
+
+    return withTimestamps(
+      normalizeGoalCorrectionOperationPayload(stored.data),
+      stored.createdAt,
+      stored.updatedAt,
+    );
+  }
+
+  private async replayGoalCorrectionOperation<T extends UpdateGoalResult | DeleteGoalResult>(
+    gameId: string,
+    operation: { operationId: string; requestHash: string } | null,
+  ): Promise<T | null> {
+    if (!operation) {
+      return null;
+    }
+
+    const existingOperation = await this.getGoalCorrectionOperation(gameId, operation.operationId);
+    if (!existingOperation) {
+      return null;
+    }
+
+    if (existingOperation.requestHash !== operation.requestHash) {
+      throw new GoalCorrectionError(
+        "idempotency_conflict",
+        409,
+        "Correction operation id has already been used with a different request payload.",
+      );
+    }
+
+    return existingOperation.result as T;
+  }
+
   async createGoal(input: CreateGoalInput): Promise<CreateGoalResult | null> {
     requireNonEmpty("gameId", input.gameId);
     requireNonEmpty("eventId", input.eventId);
+    requireNonEmpty("actorUserId", input.actorUserId);
     requireNonEmpty("concedingTeamId", input.concedingTeamId);
     requireNonEmpty("scorerPlayerId", input.scorerPlayerId);
     requireTeamId(input.concedingTeamId, "concedingTeamId");
@@ -1431,6 +2086,17 @@ export class ThreeFcRepository {
     });
     const goalSortKey = goalSk(activeThird.third, gameMinute, display.elapsedSeconds, input.eventId);
     const goalEventIdKey = goalEventIdSk(input.eventId);
+    const goal = withTimestamps(payload, now, now);
+    const existingGoalState = await this.getGoalState(input.gameId);
+    const audit = this.buildGoalAuditRecord({
+      gameId: input.gameId,
+      eventId: input.eventId,
+      actorUserId: input.actorUserId,
+      action: "goal_created",
+      before: null,
+      after: goal,
+      now,
+    });
 
     try {
       await this.client.send(
@@ -1506,6 +2172,8 @@ export class ThreeFcRepository {
                 ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
               },
             },
+            this.buildGoalStateWrite(input.gameId, goal, goalSortKey, now, existingGoalState),
+            this.buildGoalAuditPut(audit),
           ],
         }),
       );
@@ -1532,11 +2200,10 @@ export class ThreeFcRepository {
       throw new GoalCreationError(
         "scoreboard_state_changed",
         409,
-        "Scoreboard changed while creating this goal. Reload the game and try again.",
+        "Scoreboard changed while creating this goal, or goal state changed. Reload the game and try again.",
       );
     }
 
-    const goal = withTimestamps(payload, now, now);
     const persistedTimeline = await this.listGoalEvents(input.gameId);
 
     return {
@@ -1549,8 +2216,19 @@ export class ThreeFcRepository {
   }
 
   async listGoalEvents(gameId: string): Promise<GoalEventRecord[]> {
+    return this.listGoalEventsWithConsistency(gameId, true);
+  }
+
+  private async listGoalEventsForWrite(gameId: string): Promise<GoalEventRecord[]> {
+    return this.listGoalEventsWithConsistency(gameId, true);
+  }
+
+  private async listGoalEventsWithConsistency(
+    gameId: string,
+    consistentRead: boolean,
+  ): Promise<GoalEventRecord[]> {
     requireNonEmpty("gameId", gameId);
-    const items = await this.queryByPrefix(gamePk(gameId), "GOAL#", { consistentRead: true });
+    const items = await this.queryByPrefix(gamePk(gameId), "GOAL#", { consistentRead });
 
     return items
       .filter((item) => item.entityType === ENTITY_TYPE.goal)
@@ -1561,6 +2239,388 @@ export class ThreeFcRepository {
           item.updatedAt,
         ),
       );
+  }
+
+  async listGoalAuditEntries(gameId: string): Promise<GoalAuditRecord[]> {
+    requireNonEmpty("gameId", gameId);
+    const items = await this.queryByPrefix(gamePk(gameId), "AUDIT#GOAL#");
+
+    return items
+      .filter((item) => item.entityType === ENTITY_TYPE.goalAudit)
+      .map((item) =>
+        withTimestamps(
+          normalizeGoalAuditPayload(item.data),
+          item.createdAt,
+          item.updatedAt,
+        ),
+      );
+  }
+
+  async updateGoal(input: UpdateGoalInput): Promise<UpdateGoalResult | null> {
+    requireNonEmpty("gameId", input.gameId);
+    requireNonEmpty("eventId", input.eventId);
+    requireNonEmpty("actorUserId", input.actorUserId);
+    const operation = this.normalizeCorrectionOperation(input);
+    const replayed = await this.replayGoalCorrectionOperation<UpdateGoalResult>(
+      input.gameId,
+      operation,
+    );
+    if (replayed) {
+      return replayed;
+    }
+
+    const gameItem = await this.getEntity(
+      gamePk(input.gameId),
+      metadataSk(),
+      { consistentRead: true },
+    );
+    if (!gameItem || gameItem.entityType !== ENTITY_TYPE.game) {
+      return null;
+    }
+
+    const existing = await this.findGoalByEventId(
+      input.gameId,
+      input.eventId,
+      { consistentRead: true },
+    );
+    if (!existing) {
+      return null;
+    }
+
+    const previousGoal = existing.goal;
+    const goal = {
+      ...previousGoal,
+      scoringTeamId:
+        input.scoringTeamId === undefined ? previousGoal.scoringTeamId : input.scoringTeamId,
+      concedingTeamId: input.concedingTeamId ?? previousGoal.concedingTeamId,
+      scorerPlayerId: input.scorerPlayerId ?? previousGoal.scorerPlayerId,
+      assistPlayerIds: input.assistPlayerIds ?? previousGoal.assistPlayerIds,
+      ownGoal: input.ownGoal ?? previousGoal.ownGoal,
+    };
+    const { teams, teamStatesById } = await this.readGoalTeamStates(
+      input.gameId,
+      { consistentRead: true },
+    );
+    const roster = await this.listGameRoster(input.gameId);
+    this.validateGoalRules(goal, teams, roster, "correction");
+
+    const now = this.clock.now();
+    const updatedGoal = {
+      ...goal,
+      updatedAt: now,
+    };
+    const timeline = await this.listGoalEventsForWrite(input.gameId);
+    const nextTimeline = timeline
+      .map((entry) => (entry.eventId === input.eventId ? updatedGoal : entry))
+      .sort(compareGoalEvents);
+    const nextTeams = this.recomputeTeamsFromGoals(input.gameId, teams, nextTimeline, now);
+    const latestAfter = latestGoalEvent(nextTimeline);
+    const latestGoalSk = latestAfter
+      ? goalSk(latestAfter.third, latestAfter.gameMinute, latestAfter.elapsedSeconds, latestAfter.eventId)
+      : null;
+    const existingGoalState = await this.getGoalState(input.gameId, { consistentRead: true });
+    const audit = this.buildGoalAuditRecord({
+      gameId: input.gameId,
+      eventId: input.eventId,
+      actorUserId: input.actorUserId,
+      action: "goal_updated",
+      before: previousGoal,
+      after: updatedGoal,
+      now,
+    });
+    const result: UpdateGoalResult = {
+      goal: updatedGoal,
+      previousGoal,
+      scoreboard: {
+        teams: nextTeams,
+      },
+      timeline: nextTimeline,
+      audit,
+    };
+
+    try {
+      await this.client.send(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            ...this.buildTeamPutTransactionItems(nextTeams, teamStatesById, now),
+            {
+              Put: {
+                TableName: this.tableName,
+                Item: buildItemWithTimestamps(
+                  gamePk(input.gameId),
+                  existing.sk,
+                  ENTITY_TYPE.goal,
+                  {
+                    gameId: updatedGoal.gameId,
+                    eventId: updatedGoal.eventId,
+                    third: updatedGoal.third,
+                    thirdMinute: updatedGoal.thirdMinute,
+                    gameMinute: updatedGoal.gameMinute,
+                    elapsedSeconds: updatedGoal.elapsedSeconds,
+                    stoppageMinute: updatedGoal.stoppageMinute,
+                    displayTime: updatedGoal.displayTime,
+                    scoringTeamId: updatedGoal.scoringTeamId,
+                    concedingTeamId: updatedGoal.concedingTeamId,
+                    scorerPlayerId: updatedGoal.scorerPlayerId,
+                    assistPlayerIds: updatedGoal.assistPlayerIds,
+                    ownGoal: updatedGoal.ownGoal,
+                  },
+                  updatedGoal.createdAt,
+                  now,
+                ),
+                ConditionExpression: "#updatedAt = :expectedGoalUpdatedAt AND #data = :expectedGoalData",
+                ExpressionAttributeNames: {
+                  "#updatedAt": "updatedAt",
+                  "#data": "data",
+                },
+                ExpressionAttributeValues: {
+                  ":expectedGoalUpdatedAt": { S: existing.goal.updatedAt },
+                  ":expectedGoalData": { S: existing.stored.rawData },
+                },
+              },
+            },
+            this.buildGoalStateWrite(input.gameId, latestAfter, latestGoalSk, now, existingGoalState),
+            this.buildGoalAuditPut(audit),
+            ...(operation
+              ? [
+                  this.buildGoalCorrectionOperationPut({
+                    gameId: input.gameId,
+                    eventId: input.eventId,
+                    operationId: operation.operationId,
+                    requestHash: operation.requestHash,
+                    action: "goal_updated",
+                    result,
+                    now,
+                  }),
+                ]
+              : []),
+          ],
+        }),
+      );
+    } catch (error) {
+      if (!isConditionalWriteFailure(error)) {
+        throw error;
+      }
+
+      const replayedAfterConflict =
+        await this.replayGoalCorrectionOperation<UpdateGoalResult>(input.gameId, operation);
+      if (replayedAfterConflict) {
+        return replayedAfterConflict;
+      }
+
+      throw new GoalCorrectionError(
+        "goal_state_changed",
+        409,
+        "Goal or scoreboard state changed while updating this goal. Reload the game and try again.",
+      );
+    }
+
+    return result;
+  }
+
+  async deleteGoal(input: DeleteGoalInput): Promise<DeleteGoalResult | null> {
+    requireNonEmpty("gameId", input.gameId);
+    requireNonEmpty("eventId", input.eventId);
+    requireNonEmpty("actorUserId", input.actorUserId);
+    const operation = this.normalizeCorrectionOperation(input);
+    const replayed = await this.replayGoalCorrectionOperation<DeleteGoalResult>(
+      input.gameId,
+      operation,
+    );
+    if (replayed) {
+      return replayed;
+    }
+
+    const gameItem = await this.getEntity(
+      gamePk(input.gameId),
+      metadataSk(),
+      { consistentRead: true },
+    );
+    if (!gameItem || gameItem.entityType !== ENTITY_TYPE.game) {
+      return null;
+    }
+
+    const existing = await this.findGoalByEventId(
+      input.gameId,
+      input.eventId,
+      { consistentRead: true },
+    );
+    if (!existing) {
+      return null;
+    }
+
+    const timeline = await this.listGoalEventsForWrite(input.gameId);
+    const latestBefore = latestGoalEvent(timeline);
+    const existingGoalState = await this.getGoalState(input.gameId, { consistentRead: true });
+    if (
+      input.expectedLatestEventId &&
+      latestBefore?.eventId !== input.expectedLatestEventId
+    ) {
+      throw new GoalCorrectionError(
+        "latest_goal_changed",
+        409,
+        "Latest goal changed before undo could be applied. Reload the game and try again.",
+      );
+    }
+
+    if (
+      input.expectedLatestEventId &&
+      existingGoalState?.state.latestEventId !== input.expectedLatestEventId
+    ) {
+      throw new GoalCorrectionError(
+        "latest_goal_changed",
+        409,
+        "Latest goal changed before undo could be applied. Reload the game and try again.",
+      );
+    }
+
+    if (input.action === "goal_undo_last" && latestBefore?.eventId !== input.eventId) {
+      throw new GoalCorrectionError(
+        "not_latest_goal",
+        409,
+        "Undo can only delete the current most recent goal.",
+      );
+    }
+
+    const now = this.clock.now();
+    const nextTimeline = timeline
+      .filter((entry) => entry.eventId !== input.eventId)
+      .sort(compareGoalEvents);
+    const { teams, teamStatesById } = await this.readGoalTeamStates(
+      input.gameId,
+      { consistentRead: true },
+    );
+    const nextTeams = this.recomputeTeamsFromGoals(input.gameId, teams, nextTimeline, now);
+    const latestAfter = latestGoalEvent(nextTimeline);
+    const latestGoalSk = latestAfter
+      ? goalSk(latestAfter.third, latestAfter.gameMinute, latestAfter.elapsedSeconds, latestAfter.eventId)
+      : null;
+    const action = input.action ?? "goal_deleted";
+    const audit = this.buildGoalAuditRecord({
+      gameId: input.gameId,
+      eventId: input.eventId,
+      actorUserId: input.actorUserId,
+      action,
+      before: existing.goal,
+      after: null,
+      now,
+    });
+    const result: DeleteGoalResult = {
+      deletedGoal: existing.goal,
+      scoreboard: {
+        teams: nextTeams,
+      },
+      timeline: nextTimeline,
+      audit,
+    };
+
+    try {
+      await this.client.send(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            ...this.buildTeamPutTransactionItems(nextTeams, teamStatesById, now),
+            {
+              Delete: {
+                TableName: this.tableName,
+                Key: {
+                  pk: { S: gamePk(input.gameId) },
+                  sk: { S: existing.sk },
+                },
+                ConditionExpression: "#updatedAt = :expectedGoalUpdatedAt AND #data = :expectedGoalData",
+                ExpressionAttributeNames: {
+                  "#updatedAt": "updatedAt",
+                  "#data": "data",
+                },
+                ExpressionAttributeValues: {
+                  ":expectedGoalUpdatedAt": { S: existing.goal.updatedAt },
+                  ":expectedGoalData": { S: existing.stored.rawData },
+                },
+              },
+            },
+            {
+              Delete: {
+                TableName: this.tableName,
+                Key: {
+                  pk: { S: gamePk(input.gameId) },
+                  sk: { S: goalEventIdSk(input.eventId) },
+                },
+              },
+            },
+            this.buildGoalStateWrite(input.gameId, latestAfter, latestGoalSk, now, existingGoalState),
+            this.buildGoalAuditPut(audit),
+            ...(operation
+              ? [
+                  this.buildGoalCorrectionOperationPut({
+                    gameId: input.gameId,
+                    eventId: input.eventId,
+                    operationId: operation.operationId,
+                    requestHash: operation.requestHash,
+                    action,
+                    result,
+                    now,
+                  }),
+                ]
+              : []),
+          ],
+        }),
+      );
+    } catch (error) {
+      if (!isConditionalWriteFailure(error)) {
+        throw error;
+      }
+
+      const replayedAfterConflict =
+        await this.replayGoalCorrectionOperation<DeleteGoalResult>(input.gameId, operation);
+      if (replayedAfterConflict) {
+        return replayedAfterConflict;
+      }
+
+      throw new GoalCorrectionError(
+        "goal_state_changed",
+        409,
+        "Goal or scoreboard state changed while deleting this goal. Reload the game and try again.",
+      );
+    }
+
+    return result;
+  }
+
+  async undoLastGoal(input: UndoLastGoalInput): Promise<DeleteGoalResult | null> {
+    requireNonEmpty("gameId", input.gameId);
+    requireNonEmpty("actorUserId", input.actorUserId);
+    requireNonEmpty("expectedEventId", input.expectedEventId);
+    const operation = this.normalizeCorrectionOperation(input);
+    const replayed = await this.replayGoalCorrectionOperation<DeleteGoalResult>(
+      input.gameId,
+      operation,
+    );
+    if (replayed) {
+      return replayed;
+    }
+
+    const timeline = await this.listGoalEventsForWrite(input.gameId);
+    const latest = latestGoalEvent(timeline);
+    if (!latest) {
+      return null;
+    }
+
+    if (latest.eventId !== input.expectedEventId) {
+      throw new GoalCorrectionError(
+        "latest_goal_changed",
+        409,
+        "Latest goal changed before undo could be applied. Reload the game and try again.",
+      );
+    }
+
+    return this.deleteGoal({
+      gameId: input.gameId,
+      eventId: latest.eventId,
+      actorUserId: input.actorUserId,
+      operationId: input.operationId,
+      operationRequestHash: input.operationRequestHash,
+      action: "goal_undo_last",
+      expectedLatestEventId: input.expectedEventId,
+    });
   }
 
   async getIdempotencyRecord(scope: string, key: string): Promise<IdempotencyRecord | null> {
@@ -1701,7 +2761,11 @@ export class ThreeFcRepository {
     );
   }
 
-  private async getEntity(pk: string, sk: string): Promise<StoredEntity<unknown> | null> {
+  private async getEntity(
+    pk: string,
+    sk: string,
+    options: { consistentRead?: boolean } = {},
+  ): Promise<StoredEntity<unknown> | null> {
     const result = (await this.client.send(
       new GetItemCommand({
         TableName: this.tableName,
@@ -1709,6 +2773,7 @@ export class ThreeFcRepository {
           pk: { S: pk },
           sk: { S: sk },
         },
+        ConsistentRead: options.consistentRead,
       }),
     )) as GetItemCommandOutput;
 
@@ -1733,6 +2798,7 @@ export class ThreeFcRepository {
           ":pk": { S: pk },
           ":skPrefix": { S: skPrefix },
         },
+        ConsistentRead: options.consistentRead,
       }),
     )) as QueryCommandOutput;
 

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -2798,7 +2798,6 @@ export class ThreeFcRepository {
           ":pk": { S: pk },
           ":skPrefix": { S: skPrefix },
         },
-        ConsistentRead: options.consistentRead,
       }),
     )) as QueryCommandOutput;
 

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -341,26 +341,28 @@ function normalizeGoalAuditSnapshot(data: unknown): GoalAuditSnapshotRecord | nu
   }
 
   const raw = data as Partial<GoalAuditSnapshotRecord>;
-  const third = raw.third ?? 1;
+  const third = normalizeThirdNumber(raw.third);
+  const thirdMinute = normalizePositiveInteger(raw.thirdMinute);
+  const gameMinute = normalizePositiveInteger(raw.gameMinute);
 
   return {
     eventId: raw.eventId ?? "",
     third,
-    thirdMinute: normalizeNonNegativeInteger(raw.thirdMinute),
-    gameMinute: normalizeNonNegativeInteger(raw.gameMinute),
+    thirdMinute,
+    gameMinute,
     elapsedSeconds: normalizeNonNegativeInteger(raw.elapsedSeconds),
     stoppageMinute:
-      raw.stoppageMinute === null || Number.isInteger(raw.stoppageMinute)
-        ? (raw.stoppageMinute ?? null)
+      Number.isInteger(raw.stoppageMinute) && (raw.stoppageMinute as number) >= 1
+        ? (raw.stoppageMinute as number)
         : null,
-    displayTime: raw.displayTime ?? String(raw.gameMinute ?? ""),
-    scoringTeamId: raw.scoringTeamId ?? null,
-    concedingTeamId: raw.concedingTeamId ?? "red",
+    displayTime: typeof raw.displayTime === "string" ? raw.displayTime : String(gameMinute),
+    scoringTeamId: isTeamId(raw.scoringTeamId) ? raw.scoringTeamId : null,
+    concedingTeamId: isTeamId(raw.concedingTeamId) ? raw.concedingTeamId : "red",
     scorerPlayerId: raw.scorerPlayerId ?? "",
     assistPlayerIds: Array.isArray(raw.assistPlayerIds)
       ? raw.assistPlayerIds.filter((playerId): playerId is string => typeof playerId === "string")
       : [],
-    ownGoal: raw.ownGoal ?? false,
+    ownGoal: typeof raw.ownGoal === "boolean" ? raw.ownGoal : false,
   };
 }
 

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -425,7 +425,14 @@ function compareGoalEvents(left: Pick<GoalEventRecord, "third" | "gameMinute" | 
 }
 
 function latestGoalEvent(goals: GoalEventRecord[]): GoalEventRecord | null {
-  return [...goals].sort(compareGoalEvents).at(-1) ?? null;
+  let latest: GoalEventRecord | null = null;
+  for (const goal of goals) {
+    if (!latest || compareGoalEvents(latest, goal) < 0) {
+      latest = goal;
+    }
+  }
+
+  return latest;
 }
 
 function goalAuditSnapshot(goal: GoalEventRecord): GoalAuditSnapshotRecord {
@@ -2087,7 +2094,7 @@ export class ThreeFcRepository {
     const goalSortKey = goalSk(activeThird.third, gameMinute, display.elapsedSeconds, input.eventId);
     const goalEventIdKey = goalEventIdSk(input.eventId);
     const goal = withTimestamps(payload, now, now);
-    const existingGoalState = await this.getGoalState(input.gameId);
+    const existingGoalState = await this.getGoalState(input.gameId, { consistentRead: true });
     const audit = this.buildGoalAuditRecord({
       gameId: input.gameId,
       eventId: input.eventId,

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -366,6 +366,34 @@ function normalizeGoalAuditSnapshot(data: unknown): GoalAuditSnapshotRecord | nu
   };
 }
 
+const GOAL_AUDIT_ACTIONS = new Set<GoalAuditAction>([
+  "goal_created",
+  "goal_updated",
+  "goal_deleted",
+  "goal_undo_last",
+]);
+
+const GOAL_CORRECTION_ACTIONS = new Set<
+  Extract<GoalAuditAction, "goal_updated" | "goal_deleted" | "goal_undo_last">
+>(["goal_updated", "goal_deleted", "goal_undo_last"]);
+
+function normalizeGoalAuditAction(action: unknown): GoalAuditAction {
+  return typeof action === "string" && GOAL_AUDIT_ACTIONS.has(action as GoalAuditAction)
+    ? (action as GoalAuditAction)
+    : "goal_updated";
+}
+
+function normalizeGoalCorrectionAction(
+  action: unknown,
+): Extract<GoalAuditAction, "goal_updated" | "goal_deleted" | "goal_undo_last"> {
+  return typeof action === "string" &&
+    GOAL_CORRECTION_ACTIONS.has(
+      action as Extract<GoalAuditAction, "goal_updated" | "goal_deleted" | "goal_undo_last">,
+    )
+    ? (action as Extract<GoalAuditAction, "goal_updated" | "goal_deleted" | "goal_undo_last">)
+    : "goal_updated";
+}
+
 function normalizeGoalAuditPayload(data: unknown): Omit<GoalAuditRecord, "createdAt" | "updatedAt"> {
   const raw = data as Partial<Omit<GoalAuditRecord, "createdAt" | "updatedAt">>;
 
@@ -374,7 +402,7 @@ function normalizeGoalAuditPayload(data: unknown): Omit<GoalAuditRecord, "create
     gameId: raw.gameId ?? "",
     eventId: raw.eventId ?? "",
     actorUserId: raw.actorUserId ?? "",
-    action: raw.action ?? "goal_updated",
+    action: normalizeGoalAuditAction(raw.action),
     before: normalizeGoalAuditSnapshot(raw.before),
     after: normalizeGoalAuditSnapshot(raw.after),
   };
@@ -390,7 +418,7 @@ function normalizeGoalCorrectionOperationPayload(
     eventId: raw.eventId ?? "",
     operationId: raw.operationId ?? "",
     requestHash: raw.requestHash ?? "",
-    action: raw.action ?? "goal_updated",
+    action: normalizeGoalCorrectionAction(raw.action),
     result: raw.result as GoalCorrectionOperationRecord["result"],
   };
 }
@@ -407,7 +435,10 @@ function sortGameTeams<T extends { teamId: TeamId }>(teams: T[]): T[] {
   return [...teams].sort((left, right) => compareTeamIds(left.teamId, right.teamId));
 }
 
-function compareGoalEvents(left: Pick<GoalEventRecord, "third" | "gameMinute" | "elapsedSeconds" | "eventId">, right: Pick<GoalEventRecord, "third" | "gameMinute" | "elapsedSeconds" | "eventId">): number {
+function compareGoalEvents(
+  left: Pick<GoalEventRecord, "third" | "gameMinute" | "elapsedSeconds" | "createdAt" | "eventId">,
+  right: Pick<GoalEventRecord, "third" | "gameMinute" | "elapsedSeconds" | "createdAt" | "eventId">,
+): number {
   const thirdSort = left.third - right.third;
   if (thirdSort !== 0) {
     return thirdSort;
@@ -421,6 +452,11 @@ function compareGoalEvents(left: Pick<GoalEventRecord, "third" | "gameMinute" | 
   const elapsedSort = left.elapsedSeconds - right.elapsedSeconds;
   if (elapsedSort !== 0) {
     return elapsedSort;
+  }
+
+  const createdAtSort = left.createdAt.localeCompare(right.createdAt);
+  if (createdAtSort !== 0) {
+    return createdAtSort;
   }
 
   return left.eventId.localeCompare(right.eventId);
@@ -2213,7 +2249,7 @@ export class ThreeFcRepository {
       );
     }
 
-    const persistedTimeline = await this.listGoalEvents(input.gameId);
+    const persistedTimeline = await this.listGoalEventsForWrite(input.gameId);
 
     return {
       goal,
@@ -2247,7 +2283,8 @@ export class ThreeFcRepository {
           item.createdAt,
           item.updatedAt,
         ),
-      );
+      )
+      .sort(compareGoalEvents);
   }
 
   async listGoalAuditEntries(gameId: string): Promise<GoalAuditRecord[]> {

--- a/api/src/data/types.ts
+++ b/api/src/data/types.ts
@@ -124,6 +124,59 @@ export interface GoalEventRecord {
   updatedAt: string;
 }
 
+export type GoalAuditAction =
+  | "goal_created"
+  | "goal_updated"
+  | "goal_deleted"
+  | "goal_undo_last";
+
+export interface GoalAuditSnapshotRecord {
+  eventId: string;
+  third: 1 | 2 | 3;
+  thirdMinute: number;
+  gameMinute: number;
+  elapsedSeconds: number;
+  stoppageMinute: number | null;
+  displayTime: string;
+  scoringTeamId: TeamId | null;
+  concedingTeamId: TeamId;
+  scorerPlayerId: string;
+  assistPlayerIds: string[];
+  ownGoal: boolean;
+}
+
+export interface GoalAuditRecord {
+  auditId: string;
+  gameId: string;
+  eventId: string;
+  actorUserId: string;
+  action: GoalAuditAction;
+  before: GoalAuditSnapshotRecord | null;
+  after: GoalAuditSnapshotRecord | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GoalStateRecord {
+  gameId: string;
+  latestEventId: string | null;
+  latestGoalSk: string | null;
+  revision: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GoalCorrectionOperationRecord {
+  gameId: string;
+  eventId: string;
+  operationId: string;
+  requestHash: string;
+  action: Extract<GoalAuditAction, "goal_updated" | "goal_deleted" | "goal_undo_last">;
+  result: UpdateGoalResult | DeleteGoalResult;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface IdempotencyRecord {
   scope: string;
   key: string;
@@ -220,6 +273,7 @@ export interface AssignRosterInput {
 export interface CreateGoalInput {
   gameId: string;
   eventId: string;
+  actorUserId: string;
   scoringTeamId: TeamId | null;
   concedingTeamId: TeamId;
   scorerPlayerId: string;
@@ -233,6 +287,56 @@ export interface CreateGoalResult {
     teams: GameTeamRecord[];
   };
   timeline: GoalEventRecord[];
+}
+
+export interface UpdateGoalInput {
+  gameId: string;
+  eventId: string;
+  actorUserId: string;
+  operationId?: string | null;
+  operationRequestHash?: string | null;
+  scoringTeamId?: TeamId | null;
+  concedingTeamId?: TeamId;
+  scorerPlayerId?: string;
+  assistPlayerIds?: string[];
+  ownGoal?: boolean;
+}
+
+export interface UpdateGoalResult {
+  goal: GoalEventRecord;
+  previousGoal: GoalEventRecord;
+  scoreboard: {
+    teams: GameTeamRecord[];
+  };
+  timeline: GoalEventRecord[];
+  audit: GoalAuditRecord;
+}
+
+export interface DeleteGoalInput {
+  gameId: string;
+  eventId: string;
+  actorUserId: string;
+  operationId?: string | null;
+  operationRequestHash?: string | null;
+  action?: Extract<GoalAuditAction, "goal_deleted" | "goal_undo_last">;
+  expectedLatestEventId?: string;
+}
+
+export interface DeleteGoalResult {
+  deletedGoal: GoalEventRecord;
+  scoreboard: {
+    teams: GameTeamRecord[];
+  };
+  timeline: GoalEventRecord[];
+  audit: GoalAuditRecord;
+}
+
+export interface UndoLastGoalInput {
+  gameId: string;
+  actorUserId: string;
+  operationId?: string | null;
+  operationRequestHash?: string | null;
+  expectedEventId: string;
 }
 
 export interface ThirdTransitionInput {

--- a/api/src/lambda-core.ts
+++ b/api/src/lambda-core.ts
@@ -47,10 +47,12 @@ import {
   formatSchemaValidationError,
   idempotencyKeyHeaderSchema,
   quickCreateGamePlayerRequestSchema,
+  undoLastGoalRequestSchema,
+  updateGoalRequestSchema,
   upsertTeamRequestSchema,
 } from "./contracts/core-write.js";
-import { GameTimerTransitionError, GoalCreationError, ThreeFcRepository } from "./data/repository.js";
-import type { CreateGoalResult, GameStatus } from "./data/types.js";
+import { GameTimerTransitionError, GoalCorrectionError, GoalCreationError, ThreeFcRepository } from "./data/repository.js";
+import type { CreateGoalResult, DeleteGoalResult, GameStatus, UpdateGoalResult } from "./data/types.js";
 import { logAuthRateLimit, logRequest, logRequestError } from "./logging.js";
 
 export interface ApiGatewayHttpEvent {
@@ -432,12 +434,39 @@ interface RepositoryContract {
   createGoal(input: {
     gameId: string;
     eventId: string;
+    actorUserId: string;
     scoringTeamId: TeamId | null;
     concedingTeamId: TeamId;
     scorerPlayerId: string;
     assistPlayerIds: string[];
     ownGoal: boolean;
   }): Promise<CreateGoalResult | null>;
+  updateGoal(input: {
+    gameId: string;
+    eventId: string;
+    actorUserId: string;
+    operationId?: string | null;
+    operationRequestHash?: string | null;
+    scoringTeamId?: TeamId | null;
+    concedingTeamId?: TeamId;
+    scorerPlayerId?: string;
+    assistPlayerIds?: string[];
+    ownGoal?: boolean;
+  }): Promise<UpdateGoalResult | null>;
+  deleteGoal(input: {
+    gameId: string;
+    eventId: string;
+    actorUserId: string;
+    operationId?: string | null;
+    operationRequestHash?: string | null;
+  }): Promise<DeleteGoalResult | null>;
+  undoLastGoal(input: {
+    gameId: string;
+    actorUserId: string;
+    operationId?: string | null;
+    operationRequestHash?: string | null;
+    expectedEventId: string;
+  }): Promise<DeleteGoalResult | null>;
   getLeagueAccess(
     leagueId: string,
     userId: string,
@@ -832,6 +861,22 @@ function goalCreationErrorResponse(
   );
 }
 
+function goalCorrectionErrorResponse(
+  origin: string | undefined,
+  allowedOrigins: string[],
+  error: GoalCorrectionError,
+): ApiGatewayHttpResponse {
+  return createJsonResponse(
+    error.statusCode,
+    {
+      error: error.statusCode === 409 ? "conflict" : "bad_request",
+      code: error.code,
+      message: error.message,
+    },
+    buildCorsHeaders(origin, allowedOrigins),
+  );
+}
+
 function toPublicPlayer(player: {
   playerId: string;
   nickname: string;
@@ -1117,6 +1162,33 @@ function buildGoalEventId(input: {
     .digest("hex")
     .slice(0, 32);
   return `goal-idem-${digest}`;
+}
+
+function buildGoalCorrectionOperation(input: {
+  idempotencyKey: string | undefined;
+  sessionEmail: string;
+  method: string;
+  route: string;
+  requestPayload: unknown;
+}): { operationId: string; operationRequestHash: string } | null {
+  const parsedIdempotencyKey = input.idempotencyKey
+    ? idempotencyKeyHeaderSchema.safeParse(input.idempotencyKey)
+    : null;
+
+  if (!parsedIdempotencyKey?.success) {
+    return null;
+  }
+
+  const scope = buildIdempotencyScope(input.sessionEmail, input.method, input.route);
+  const digest = createHash("sha256")
+    .update(`${scope}:${parsedIdempotencyKey.data}`)
+    .digest("hex")
+    .slice(0, 32);
+
+  return {
+    operationId: `goal-correction-idem-${digest}`,
+    operationRequestHash: buildIdempotencyRequestHash(scope, input.requestPayload),
+  };
 }
 
 function parseStoredIdempotencyResponseBody(responseBody: string): unknown {
@@ -2178,6 +2250,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
                     method,
                     route,
                   }),
+                  actorUserId: session.email,
                   scoringTeamId: parsedBody.data.scoringTeamId,
                   concedingTeamId: parsedBody.data.concedingTeamId,
                   scorerPlayerId: parsedBody.data.scorerPlayerId,
@@ -2204,6 +2277,244 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
             if (error instanceof GoalCreationError) {
               status = error.statusCode;
               return goalCreationErrorResponse(origin, dependencies.corsAllowedOrigins, error);
+            }
+
+            throw error;
+          }
+
+          status = mutationResponse.statusCode;
+          return mutationResponse;
+        }
+
+        const updateGoalMatch = route.match(/^\/v1\/games\/([^/]+)\/goals\/([^/]+)$/);
+        if (method === "PATCH" && updateGoalMatch) {
+          const gameId = decodeRouteParam(updateGoalMatch[1]);
+          const eventId = decodeRouteParam(updateGoalMatch[2]);
+          const game = await dependencies.repository.getGame(gameId);
+          if (!game) {
+            status = 404;
+            return notFound(origin, dependencies.corsAllowedOrigins, `Game ${gameId} was not found.`);
+          }
+
+          let rawBody: Record<string, unknown>;
+          try {
+            rawBody = parseJsonBody(event);
+          } catch {
+            status = 400;
+            return badRequest(origin, dependencies.corsAllowedOrigins, "Request body must be valid JSON.");
+          }
+
+          const parsedBody = updateGoalRequestSchema.safeParse(rawBody);
+          if (!parsedBody.success) {
+            status = 400;
+            return badRequest(
+              origin,
+              dependencies.corsAllowedOrigins,
+              formatSchemaValidationError(parsedBody.error),
+            );
+          }
+
+          let mutationResponse: ApiGatewayHttpResponse;
+          try {
+            const correctionOperation = buildGoalCorrectionOperation({
+              idempotencyKey,
+              sessionEmail: session.email,
+              method,
+              route,
+              requestPayload: parsedBody.data,
+            });
+            mutationResponse = await executeIdempotentMutation({
+              repository: dependencies.repository,
+              idempotencyKey,
+              sessionEmail: session.email,
+              method,
+              route,
+              requestPayload: parsedBody.data,
+              origin,
+              allowedOrigins: dependencies.corsAllowedOrigins,
+              execute: async () => {
+                const result = await dependencies.repository.updateGoal({
+                  gameId,
+                  eventId,
+                  actorUserId: session.email,
+                  operationId: correctionOperation?.operationId,
+                  operationRequestHash: correctionOperation?.operationRequestHash,
+                  ...parsedBody.data,
+                });
+
+                if (!result) {
+                  return notFound(
+                    origin,
+                    dependencies.corsAllowedOrigins,
+                    `Goal ${eventId} was not found for game ${gameId}.`,
+                  );
+                }
+
+                return createJsonResponse(
+                  200,
+                  result,
+                  buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
+                );
+              },
+            });
+          } catch (error) {
+            if (error instanceof GoalCorrectionError) {
+              status = error.statusCode;
+              return error.code === "idempotency_conflict"
+                ? idempotencyConflictResponse(origin, dependencies.corsAllowedOrigins)
+                : goalCorrectionErrorResponse(origin, dependencies.corsAllowedOrigins, error);
+            }
+
+            throw error;
+          }
+
+          status = mutationResponse.statusCode;
+          return mutationResponse;
+        }
+
+        const deleteGoalMatch = route.match(/^\/v1\/games\/([^/]+)\/goals\/([^/]+)$/);
+        if (method === "DELETE" && deleteGoalMatch) {
+          const gameId = decodeRouteParam(deleteGoalMatch[1]);
+          const eventId = decodeRouteParam(deleteGoalMatch[2]);
+          const game = await dependencies.repository.getGame(gameId);
+          if (!game) {
+            status = 404;
+            return notFound(origin, dependencies.corsAllowedOrigins, `Game ${gameId} was not found.`);
+          }
+
+          let mutationResponse: ApiGatewayHttpResponse;
+          try {
+            const requestPayload = { eventId };
+            const correctionOperation = buildGoalCorrectionOperation({
+              idempotencyKey,
+              sessionEmail: session.email,
+              method,
+              route,
+              requestPayload,
+            });
+            mutationResponse = await executeIdempotentMutation({
+              repository: dependencies.repository,
+              idempotencyKey,
+              sessionEmail: session.email,
+              method,
+              route,
+              requestPayload,
+              origin,
+              allowedOrigins: dependencies.corsAllowedOrigins,
+              execute: async () => {
+                const result = await dependencies.repository.deleteGoal({
+                  gameId,
+                  eventId,
+                  actorUserId: session.email,
+                  operationId: correctionOperation?.operationId,
+                  operationRequestHash: correctionOperation?.operationRequestHash,
+                });
+
+                if (!result) {
+                  return notFound(
+                    origin,
+                    dependencies.corsAllowedOrigins,
+                    `Goal ${eventId} was not found for game ${gameId}.`,
+                  );
+                }
+
+                return createJsonResponse(
+                  200,
+                  result,
+                  buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
+                );
+              },
+            });
+          } catch (error) {
+            if (error instanceof GoalCorrectionError) {
+              status = error.statusCode;
+              return error.code === "idempotency_conflict"
+                ? idempotencyConflictResponse(origin, dependencies.corsAllowedOrigins)
+                : goalCorrectionErrorResponse(origin, dependencies.corsAllowedOrigins, error);
+            }
+
+            throw error;
+          }
+
+          status = mutationResponse.statusCode;
+          return mutationResponse;
+        }
+
+        const undoLastGoalMatch = route.match(/^\/v1\/games\/([^/]+)\/goals\/undo-last$/);
+        if (method === "POST" && undoLastGoalMatch) {
+          const gameId = decodeRouteParam(undoLastGoalMatch[1]);
+          const game = await dependencies.repository.getGame(gameId);
+          if (!game) {
+            status = 404;
+            return notFound(origin, dependencies.corsAllowedOrigins, `Game ${gameId} was not found.`);
+          }
+
+          let rawBody: Record<string, unknown>;
+          try {
+            rawBody = parseJsonBody(event);
+          } catch {
+            status = 400;
+            return badRequest(origin, dependencies.corsAllowedOrigins, "Request body must be valid JSON.");
+          }
+
+          const parsedBody = undoLastGoalRequestSchema.safeParse(rawBody);
+          if (!parsedBody.success) {
+            status = 400;
+            return badRequest(
+              origin,
+              dependencies.corsAllowedOrigins,
+              formatSchemaValidationError(parsedBody.error),
+            );
+          }
+
+          let mutationResponse: ApiGatewayHttpResponse;
+          try {
+            const correctionOperation = buildGoalCorrectionOperation({
+              idempotencyKey,
+              sessionEmail: session.email,
+              method,
+              route,
+              requestPayload: parsedBody.data,
+            });
+            mutationResponse = await executeIdempotentMutation({
+              repository: dependencies.repository,
+              idempotencyKey,
+              sessionEmail: session.email,
+              method,
+              route,
+              requestPayload: parsedBody.data,
+              origin,
+              allowedOrigins: dependencies.corsAllowedOrigins,
+              execute: async () => {
+                const result = await dependencies.repository.undoLastGoal({
+                  gameId,
+                  actorUserId: session.email,
+                  operationId: correctionOperation?.operationId,
+                  operationRequestHash: correctionOperation?.operationRequestHash,
+                  expectedEventId: parsedBody.data.expectedEventId,
+                });
+
+                if (!result) {
+                  return notFound(
+                    origin,
+                    dependencies.corsAllowedOrigins,
+                    `No goal events were found for game ${gameId}.`,
+                  );
+                }
+
+                return createJsonResponse(
+                  200,
+                  result,
+                  buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
+                );
+              },
+            });
+          } catch (error) {
+            if (error instanceof GoalCorrectionError) {
+              status = error.statusCode;
+              return error.code === "idempotency_conflict"
+                ? idempotencyConflictResponse(origin, dependencies.corsAllowedOrigins)
+                : goalCorrectionErrorResponse(origin, dependencies.corsAllowedOrigins, error);
             }
 
             throw error;

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -57,9 +57,11 @@ import {
   formatSchemaValidationError,
   idempotencyKeyHeaderSchema,
   quickCreateGamePlayerRequestSchema,
+  undoLastGoalRequestSchema,
+  updateGoalRequestSchema,
   upsertTeamRequestSchema,
 } from "./contracts/core-write.js";
-import { GameTimerTransitionError, GoalCreationError, ThreeFcRepository } from "./data/repository.js";
+import { GameTimerTransitionError, GoalCorrectionError, GoalCreationError, ThreeFcRepository } from "./data/repository.js";
 import { buildHealthResponse } from "./index.js";
 import { logAuthRateLimit, logRequest, logRequestError } from "./logging.js";
 
@@ -390,6 +392,19 @@ function goalCreationError(
   return error.statusCode;
 }
 
+function goalCorrectionError(
+  request: IncomingMessage,
+  response: ServerResponse,
+  error: GoalCorrectionError,
+): number {
+  sendJsonWithCors(request, response, error.statusCode, {
+    error: error.statusCode === 409 ? "conflict" : "bad_request",
+    code: error.code,
+    message: error.message,
+  });
+  return error.statusCode;
+}
+
 function toPublicPlayer(player: {
   playerId: string;
   nickname: string;
@@ -685,6 +700,34 @@ function buildGoalEventId(input: {
     .digest("hex")
     .slice(0, 32);
   return `goal-idem-${digest}`;
+}
+
+function buildGoalCorrectionOperation(input: {
+  request: IncomingMessage;
+  sessionEmail: string;
+  method: string;
+  route: string;
+  requestPayload: unknown;
+}): { operationId: string; operationRequestHash: string } | null {
+  const rawIdempotencyKey = readHeaderValue(input.request, "idempotency-key");
+  const parsedIdempotencyKey = rawIdempotencyKey
+    ? idempotencyKeyHeaderSchema.safeParse(rawIdempotencyKey)
+    : null;
+
+  if (!parsedIdempotencyKey?.success) {
+    return null;
+  }
+
+  const scope = buildIdempotencyScope(input.sessionEmail, input.method, input.route);
+  const digest = createHash("sha256")
+    .update(`${scope}:${parsedIdempotencyKey.data}`)
+    .digest("hex")
+    .slice(0, 32);
+
+  return {
+    operationId: `goal-correction-idem-${digest}`,
+    operationRequestHash: buildIdempotencyRequestHash(scope, input.requestPayload),
+  };
 }
 
 function parseStoredIdempotencyResponseBody(responseBody: string): unknown {
@@ -1936,6 +1979,7 @@ async function start(): Promise<void> {
                   method,
                   route,
                 }),
+                actorUserId: sessionEmail,
                 scoringTeamId: parsedBody.data.scoringTeamId,
                 concedingTeamId: parsedBody.data.concedingTeamId,
                 scorerPlayerId: parsedBody.data.scorerPlayerId,
@@ -1962,6 +2006,254 @@ async function start(): Promise<void> {
         } catch (error) {
           if (error instanceof GoalCreationError) {
             status = goalCreationError(request, response, error);
+            return;
+          }
+
+          throw error;
+        }
+        return;
+      }
+
+      const updateGoalMatch = route.match(/^\/v1\/games\/([^/]+)\/goals\/([^/]+)$/);
+      if (method === "PATCH" && updateGoalMatch) {
+        if (!authGate.session) {
+          status = 500;
+          sendJsonWithCors(request, response, status, {
+            error: "internal_error",
+            message: "Session should be available for authenticated route.",
+          });
+          return;
+        }
+
+        const gameId = decodeURIComponent(updateGoalMatch[1]);
+        const eventId = decodeURIComponent(updateGoalMatch[2]);
+        const game = await repository.getGame(gameId);
+        if (!game) {
+          status = notFound(request, response, `Game ${gameId} was not found.`);
+          return;
+        }
+
+        let rawBody: Record<string, unknown>;
+        try {
+          rawBody = await parseJsonBody(request);
+        } catch {
+          status = badRequest(request, response, "Request body must be valid JSON.");
+          return;
+        }
+
+        const parsedBody = updateGoalRequestSchema.safeParse(rawBody);
+        if (!parsedBody.success) {
+          status = badRequest(request, response, formatSchemaValidationError(parsedBody.error));
+          return;
+        }
+
+        try {
+          const sessionEmail = authGate.session.email;
+          const correctionOperation = buildGoalCorrectionOperation({
+            request,
+            sessionEmail,
+            method,
+            route,
+            requestPayload: parsedBody.data,
+          });
+          status = await executeIdempotentMutation({
+            request,
+            response,
+            sessionEmail,
+            method,
+            route,
+            requestPayload: parsedBody.data,
+            execute: async () => {
+              const result = await repository.updateGoal({
+                gameId,
+                eventId,
+                actorUserId: sessionEmail,
+                operationId: correctionOperation?.operationId,
+                operationRequestHash: correctionOperation?.operationRequestHash,
+                ...parsedBody.data,
+              });
+
+              if (!result) {
+                return {
+                  statusCode: 404,
+                  payload: {
+                    error: "not_found",
+                    message: `Goal ${eventId} was not found for game ${gameId}.`,
+                  },
+                };
+              }
+
+              return {
+                statusCode: 200,
+                payload: result,
+              };
+            },
+          });
+        } catch (error) {
+          if (error instanceof GoalCorrectionError) {
+            status = error.code === "idempotency_conflict"
+              ? idempotencyConflict(request, response)
+              : goalCorrectionError(request, response, error);
+            return;
+          }
+
+          throw error;
+        }
+        return;
+      }
+
+      const deleteGoalMatch = route.match(/^\/v1\/games\/([^/]+)\/goals\/([^/]+)$/);
+      if (method === "DELETE" && deleteGoalMatch) {
+        if (!authGate.session) {
+          status = 500;
+          sendJsonWithCors(request, response, status, {
+            error: "internal_error",
+            message: "Session should be available for authenticated route.",
+          });
+          return;
+        }
+
+        const gameId = decodeURIComponent(deleteGoalMatch[1]);
+        const eventId = decodeURIComponent(deleteGoalMatch[2]);
+        const game = await repository.getGame(gameId);
+        if (!game) {
+          status = notFound(request, response, `Game ${gameId} was not found.`);
+          return;
+        }
+
+        try {
+          const sessionEmail = authGate.session.email;
+          const requestPayload = { eventId };
+          const correctionOperation = buildGoalCorrectionOperation({
+            request,
+            sessionEmail,
+            method,
+            route,
+            requestPayload,
+          });
+          status = await executeIdempotentMutation({
+            request,
+            response,
+            sessionEmail,
+            method,
+            route,
+            requestPayload,
+            execute: async () => {
+              const result = await repository.deleteGoal({
+                gameId,
+                eventId,
+                actorUserId: sessionEmail,
+                operationId: correctionOperation?.operationId,
+                operationRequestHash: correctionOperation?.operationRequestHash,
+              });
+
+              if (!result) {
+                return {
+                  statusCode: 404,
+                  payload: {
+                    error: "not_found",
+                    message: `Goal ${eventId} was not found for game ${gameId}.`,
+                  },
+                };
+              }
+
+              return {
+                statusCode: 200,
+                payload: result,
+              };
+            },
+          });
+        } catch (error) {
+          if (error instanceof GoalCorrectionError) {
+            status = error.code === "idempotency_conflict"
+              ? idempotencyConflict(request, response)
+              : goalCorrectionError(request, response, error);
+            return;
+          }
+
+          throw error;
+        }
+        return;
+      }
+
+      const undoLastGoalMatch = route.match(/^\/v1\/games\/([^/]+)\/goals\/undo-last$/);
+      if (method === "POST" && undoLastGoalMatch) {
+        if (!authGate.session) {
+          status = 500;
+          sendJsonWithCors(request, response, status, {
+            error: "internal_error",
+            message: "Session should be available for authenticated route.",
+          });
+          return;
+        }
+
+        const gameId = decodeURIComponent(undoLastGoalMatch[1]);
+        const game = await repository.getGame(gameId);
+        if (!game) {
+          status = notFound(request, response, `Game ${gameId} was not found.`);
+          return;
+        }
+
+        let rawBody: Record<string, unknown>;
+        try {
+          rawBody = await parseJsonBody(request);
+        } catch {
+          status = badRequest(request, response, "Request body must be valid JSON.");
+          return;
+        }
+
+        const parsedBody = undoLastGoalRequestSchema.safeParse(rawBody);
+        if (!parsedBody.success) {
+          status = badRequest(request, response, formatSchemaValidationError(parsedBody.error));
+          return;
+        }
+
+        try {
+          const sessionEmail = authGate.session.email;
+          const correctionOperation = buildGoalCorrectionOperation({
+            request,
+            sessionEmail,
+            method,
+            route,
+            requestPayload: parsedBody.data,
+          });
+          status = await executeIdempotentMutation({
+            request,
+            response,
+            sessionEmail,
+            method,
+            route,
+            requestPayload: parsedBody.data,
+            execute: async () => {
+              const result = await repository.undoLastGoal({
+                gameId,
+                actorUserId: sessionEmail,
+                operationId: correctionOperation?.operationId,
+                operationRequestHash: correctionOperation?.operationRequestHash,
+                expectedEventId: parsedBody.data.expectedEventId,
+              });
+
+              if (!result) {
+                return {
+                  statusCode: 404,
+                  payload: {
+                    error: "not_found",
+                    message: `No goal events were found for game ${gameId}.`,
+                  },
+                };
+              }
+
+              return {
+                statusCode: 200,
+                payload: result,
+              };
+            },
+          });
+        } catch (error) {
+          if (error instanceof GoalCorrectionError) {
+            status = error.code === "idempotency_conflict"
+              ? idempotencyConflict(request, response)
+              : goalCorrectionError(request, response, error);
             return;
           }
 

--- a/api/src/tests/acl.test.ts
+++ b/api/src/tests/acl.test.ts
@@ -83,6 +83,18 @@ test("resolveProtectedMutationRoute maps supported mutation endpoints", () => {
     operation: "createGoal",
     gameId: "game-1",
   });
+  assert.deepEqual(resolveProtectedMutationRoute("PATCH", "/v1/games/game-1/goals/goal-1"), {
+    operation: "updateGoal",
+    gameId: "game-1",
+  });
+  assert.deepEqual(resolveProtectedMutationRoute("DELETE", "/v1/games/game-1/goals/goal-1"), {
+    operation: "deleteGoal",
+    gameId: "game-1",
+  });
+  assert.deepEqual(resolveProtectedMutationRoute("POST", "/v1/games/game-1/goals/undo-last"), {
+    operation: "undoLastGoal",
+    gameId: "game-1",
+  });
   assert.equal(resolveProtectedMutationRoute("GET", "/v1/leagues"), null);
 });
 

--- a/api/src/tests/lambda-core.test.ts
+++ b/api/src/tests/lambda-core.test.ts
@@ -15,7 +15,7 @@ import {
   type ThirdLengthMinutes,
   type ThirdTimerSegment,
 } from "@3fc/contracts";
-import { GameTimerTransitionError, GoalCreationError } from "../data/repository.js";
+import { GameTimerTransitionError, GoalCorrectionError, GoalCreationError } from "../data/repository.js";
 
 interface MockSessionRecord {
   sessionId: string;
@@ -244,6 +244,7 @@ function createHarness(config: HarnessConfig = {}) {
   const createdGoals: Array<{
     gameId: string;
     eventId: string;
+    actorUserId: string;
     scoringTeamId: TeamId | null;
     concedingTeamId: TeamId;
     scorerPlayerId: string;
@@ -292,6 +293,188 @@ function createHarness(config: HarnessConfig = {}) {
     Object.entries(config.gamePlayers ?? {}),
   );
   const goalEvents = new Map<string, MockGoalEventRecord>();
+  const goalAuditEntries: Array<{
+    auditId: string;
+    gameId: string;
+    eventId: string;
+    actorUserId: string;
+    action: "goal_created" | "goal_updated" | "goal_deleted" | "goal_undo_last";
+    before: MockGoalEventRecord | null;
+    after: MockGoalEventRecord | null;
+    createdAt: string;
+    updatedAt: string;
+  }> = [];
+
+  function sortedGameTeams(gameId: string): MockGameTeamRecord[] {
+    return [...gameTeams.values()]
+      .filter((team) => team.gameId === gameId)
+      .sort((left, right) => TEAM_IDS.indexOf(left.teamId) - TEAM_IDS.indexOf(right.teamId));
+  }
+
+  function sortedGoalTimeline(gameId: string): MockGoalEventRecord[] {
+    return [...goalEvents.values()]
+      .filter((entry) => entry.gameId === gameId)
+      .sort((left, right) => {
+        const thirdSort = left.third - right.third;
+        if (thirdSort !== 0) {
+          return thirdSort;
+        }
+
+        const minuteSort = left.gameMinute - right.gameMinute;
+        if (minuteSort !== 0) {
+          return minuteSort;
+        }
+
+        const elapsedSort = left.elapsedSeconds - right.elapsedSeconds;
+        if (elapsedSort !== 0) {
+          return elapsedSort;
+        }
+
+        return left.eventId.localeCompare(right.eventId);
+      });
+  }
+
+  function latestGoal(gameId: string): MockGoalEventRecord | null {
+    return sortedGoalTimeline(gameId).at(-1) ?? null;
+  }
+
+  function validateMockGoal(goal: {
+    gameId: string;
+    scoringTeamId: TeamId | null;
+    concedingTeamId: TeamId;
+    scorerPlayerId: string;
+    assistPlayerIds: string[];
+    ownGoal: boolean;
+  }): void {
+    const gameTeamIds = new Set(sortedGameTeams(goal.gameId).map((team) => team.teamId));
+    if (!gameTeamIds.has(goal.concedingTeamId)) {
+      throw new GoalCorrectionError(
+        "invalid_conceding_team",
+        400,
+        "concedingTeamId must be an active team for this game.",
+      );
+    }
+
+    if (!goal.ownGoal && (!goal.scoringTeamId || !gameTeamIds.has(goal.scoringTeamId))) {
+      throw new GoalCorrectionError(
+        "invalid_scoring_team",
+        400,
+        "scoringTeamId must be an active team for this game.",
+      );
+    }
+
+    if (goal.ownGoal && goal.scoringTeamId !== null) {
+      throw new GoalCorrectionError(
+        "own_goal_scoring_team",
+        400,
+        "ownGoal=true requires scoringTeamId to be null.",
+      );
+    }
+
+    if (!goal.ownGoal && goal.scoringTeamId === goal.concedingTeamId) {
+      throw new GoalCorrectionError(
+        "same_team_goal",
+        400,
+        "scoringTeamId and concedingTeamId must be different for a standard goal.",
+      );
+    }
+
+    const rosterByPlayerId = new Map(
+      [...rosterAssignments.values()]
+        .filter((assignment) => assignment.gameId === goal.gameId)
+        .map((assignment) => [assignment.playerId, assignment]),
+    );
+    const scorerRoster = rosterByPlayerId.get(goal.scorerPlayerId);
+    if (!scorerRoster) {
+      throw new GoalCorrectionError("scorer_not_rostered", 400, "Scorer must be rostered in this game.");
+    }
+
+    if (!goal.ownGoal && scorerRoster.teamId !== goal.scoringTeamId) {
+      throw new GoalCorrectionError(
+        "scorer_not_on_scoring_team",
+        400,
+        "Scorer must be rostered on the scoring team for a standard goal.",
+      );
+    }
+
+    if (goal.ownGoal && scorerRoster.teamId !== goal.concedingTeamId) {
+      throw new GoalCorrectionError(
+        "scorer_not_on_conceding_team",
+        400,
+        "Own-goal scorer must be rostered on the conceding team.",
+      );
+    }
+
+    for (const assistPlayerId of goal.assistPlayerIds) {
+      if (!rosterByPlayerId.has(assistPlayerId)) {
+        throw new GoalCorrectionError(
+          "assist_not_rostered",
+          400,
+          "Assist players must be rostered in this game.",
+        );
+      }
+    }
+  }
+
+  function recomputeMockGameTeams(gameId: string): MockGameTeamRecord[] {
+    const counts = new Map<TeamId, { scored: number; conceded: number }>();
+    for (const team of sortedGameTeams(gameId)) {
+      counts.set(team.teamId, { scored: 0, conceded: 0 });
+    }
+
+    for (const goal of sortedGoalTimeline(gameId)) {
+      if (!goal.ownGoal && goal.scoringTeamId) {
+        const scoringCounts = counts.get(goal.scoringTeamId);
+        if (scoringCounts) {
+          scoringCounts.scored += 1;
+        }
+      }
+
+      const concedingCounts = counts.get(goal.concedingTeamId);
+      if (concedingCounts) {
+        concedingCounts.conceded += 1;
+      }
+    }
+
+    for (const [key, team] of gameTeams.entries()) {
+      if (team.gameId !== gameId) {
+        continue;
+      }
+
+      const teamCounts = counts.get(team.teamId) ?? { scored: 0, conceded: 0 };
+      gameTeams.set(key, {
+        ...team,
+        scored: teamCounts.scored,
+        conceded: teamCounts.conceded,
+        updatedAt: "2026-02-23T00:00:04.000Z",
+      });
+    }
+
+    return sortedGameTeams(gameId);
+  }
+
+  function createMockGoalAudit(input: {
+    gameId: string;
+    eventId: string;
+    actorUserId: string;
+    action: "goal_created" | "goal_updated" | "goal_deleted" | "goal_undo_last";
+    before: MockGoalEventRecord | null;
+    after: MockGoalEventRecord | null;
+  }) {
+    const audit = {
+      auditId: `audit-${goalAuditEntries.length + 1}`,
+      gameId: input.gameId,
+      eventId: input.eventId,
+      actorUserId: input.actorUserId,
+      action: input.action,
+      before: input.before,
+      after: input.after,
+      createdAt: "2026-02-23T00:00:04.000Z",
+      updatedAt: "2026-02-23T00:00:04.000Z",
+    };
+    goalAuditEntries.push(audit);
+    return audit;
+  }
 
   const handler = createLambdaCoreHandler({
     sessionCookieName: "threefc_session",
@@ -668,7 +851,7 @@ function createHarness(config: HarnessConfig = {}) {
           );
         }
 
-        const now = "2026-02-23T00:00:03.000Z";
+        const now = `2026-02-23T00:00:${String(3 + goalEvents.size).padStart(2, "0")}.000Z`;
         const elapsedSeconds = Math.max(
           0,
           Math.floor((Date.parse(now) - Date.parse(activeThird.startedAt)) / 1000),
@@ -698,51 +881,16 @@ function createHarness(config: HarnessConfig = {}) {
         };
 
         goalEvents.set(`${input.gameId}:${input.eventId}`, goal);
-        for (const [key, team] of gameTeams.entries()) {
-          if (team.gameId !== input.gameId) {
-            continue;
-          }
-
-          const scored = !input.ownGoal && team.teamId === input.scoringTeamId
-            ? team.scored + 1
-            : team.scored;
-          const conceded = team.teamId === input.concedingTeamId
-            ? team.conceded + 1
-            : team.conceded;
-
-          if (scored !== team.scored || conceded !== team.conceded) {
-            gameTeams.set(key, {
-              ...team,
-              scored,
-              conceded,
-              updatedAt: now,
-            });
-          }
-        }
-
-        const teams = [...gameTeams.values()]
-          .filter((team) => team.gameId === input.gameId)
-          .sort((left, right) => TEAM_IDS.indexOf(left.teamId) - TEAM_IDS.indexOf(right.teamId));
-        const timeline = [...goalEvents.values()]
-          .filter((entry) => entry.gameId === input.gameId)
-          .sort((left, right) => {
-            const thirdSort = left.third - right.third;
-            if (thirdSort !== 0) {
-              return thirdSort;
-            }
-
-            const minuteSort = left.gameMinute - right.gameMinute;
-            if (minuteSort !== 0) {
-              return minuteSort;
-            }
-
-            const elapsedSort = left.elapsedSeconds - right.elapsedSeconds;
-            if (elapsedSort !== 0) {
-              return elapsedSort;
-            }
-
-            return left.eventId.localeCompare(right.eventId);
-          });
+        const teams = recomputeMockGameTeams(input.gameId);
+        const timeline = sortedGoalTimeline(input.gameId);
+        createMockGoalAudit({
+          gameId: input.gameId,
+          eventId: input.eventId,
+          actorUserId: input.actorUserId,
+          action: "goal_created",
+          before: null,
+          after: goal,
+        });
 
         return {
           goal,
@@ -750,6 +898,107 @@ function createHarness(config: HarnessConfig = {}) {
             teams,
           },
           timeline,
+        };
+      },
+      async updateGoal(input) {
+        const existing = goalEvents.get(`${input.gameId}:${input.eventId}`);
+        if (!games.has(input.gameId) || !existing) {
+          return null;
+        }
+
+        const updated = {
+          ...existing,
+          scoringTeamId:
+            input.scoringTeamId === undefined ? existing.scoringTeamId : input.scoringTeamId,
+          concedingTeamId: input.concedingTeamId ?? existing.concedingTeamId,
+          scorerPlayerId: input.scorerPlayerId ?? existing.scorerPlayerId,
+          assistPlayerIds: input.assistPlayerIds ?? existing.assistPlayerIds,
+          ownGoal: input.ownGoal ?? existing.ownGoal,
+          updatedAt: "2026-02-23T00:00:04.000Z",
+        };
+        validateMockGoal(updated);
+        goalEvents.set(`${input.gameId}:${input.eventId}`, updated);
+        const teams = recomputeMockGameTeams(input.gameId);
+        const timeline = sortedGoalTimeline(input.gameId);
+        const audit = createMockGoalAudit({
+          gameId: input.gameId,
+          eventId: input.eventId,
+          actorUserId: input.actorUserId,
+          action: "goal_updated",
+          before: existing,
+          after: updated,
+        });
+
+        return {
+          goal: updated,
+          previousGoal: existing,
+          scoreboard: {
+            teams,
+          },
+          timeline,
+          audit,
+        };
+      },
+      async deleteGoal(input) {
+        const existing = goalEvents.get(`${input.gameId}:${input.eventId}`);
+        if (!games.has(input.gameId) || !existing) {
+          return null;
+        }
+
+        goalEvents.delete(`${input.gameId}:${input.eventId}`);
+        const teams = recomputeMockGameTeams(input.gameId);
+        const timeline = sortedGoalTimeline(input.gameId);
+        const audit = createMockGoalAudit({
+          gameId: input.gameId,
+          eventId: input.eventId,
+          actorUserId: input.actorUserId,
+          action: "goal_deleted",
+          before: existing,
+          after: null,
+        });
+
+        return {
+          deletedGoal: existing,
+          scoreboard: {
+            teams,
+          },
+          timeline,
+          audit,
+        };
+      },
+      async undoLastGoal(input) {
+        const latest = latestGoal(input.gameId);
+        if (!games.has(input.gameId) || !latest) {
+          return null;
+        }
+
+        if (latest.eventId !== input.expectedEventId) {
+          throw new GoalCorrectionError(
+            "latest_goal_changed",
+            409,
+            "Latest goal changed before undo could be applied. Reload the game and try again.",
+          );
+        }
+
+        goalEvents.delete(`${input.gameId}:${latest.eventId}`);
+        const teams = recomputeMockGameTeams(input.gameId);
+        const timeline = sortedGoalTimeline(input.gameId);
+        const audit = createMockGoalAudit({
+          gameId: input.gameId,
+          eventId: latest.eventId,
+          actorUserId: input.actorUserId,
+          action: "goal_undo_last",
+          before: latest,
+          after: null,
+        });
+
+        return {
+          deletedGoal: latest,
+          scoreboard: {
+            teams,
+          },
+          timeline,
+          audit,
         };
       },
       async getLeagueAccess(leagueId: string, userId: string) {
@@ -798,6 +1047,7 @@ function createHarness(config: HarnessConfig = {}) {
     magicLinkCompletes,
     magicLinkRateLimitChecks,
     idempotencyRecords,
+    goalAuditEntries,
   };
 }
 
@@ -1740,6 +1990,350 @@ test("core lambda creates goals with idempotency replay and conflict behavior", 
     error: "idempotency_conflict",
     message: "Idempotency key has already been used with a different payload.",
   });
+});
+
+test("core lambda updates and deletes goals with idempotency replay", async () => {
+  const harness = createGoalHarness();
+  const createResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/games/game-1/goals",
+      headers: {
+        Cookie: "threefc_session=session-1",
+        "Idempotency-Key": "goal-correction-create-1",
+      },
+      body: {
+        scoringTeamId: "red",
+        concedingTeamId: "blue",
+        scorerPlayerId: "player-red",
+        assistPlayerIds: [],
+        ownGoal: false,
+      },
+    }),
+  );
+  assert.equal(createResponse.statusCode, 201);
+  const createdBody = JSON.parse(createResponse.body) as {
+    goal: { eventId: string };
+  };
+
+  const updateBody = {
+    scoringTeamId: "yellow",
+    concedingTeamId: "red",
+    scorerPlayerId: "player-yellow",
+    assistPlayerIds: ["player-blue"],
+    ownGoal: false,
+  };
+  const updateResponse = await harness.handler(
+    createEvent({
+      method: "PATCH",
+      path: `/v1/games/game-1/goals/${createdBody.goal.eventId}`,
+      headers: {
+        Cookie: "threefc_session=session-1",
+        "Idempotency-Key": "goal-update-1",
+      },
+      body: updateBody,
+    }),
+  );
+
+  assert.equal(updateResponse.statusCode, 200);
+  const updateResponseBody = JSON.parse(updateResponse.body) as {
+    goal: { scoringTeamId: string; concedingTeamId: string; scorerPlayerId: string };
+    scoreboard: { teams: Array<{ teamId: string; scored: number; conceded: number }> };
+    audit: { action: string; actorUserId: string };
+  };
+  assert.deepEqual(updateResponseBody.goal, {
+    ...updateResponseBody.goal,
+    scoringTeamId: "yellow",
+    concedingTeamId: "red",
+    scorerPlayerId: "player-yellow",
+  });
+  assert.deepEqual(
+    updateResponseBody.scoreboard.teams.map((team) => ({
+      teamId: team.teamId,
+      scored: team.scored,
+      conceded: team.conceded,
+    })),
+    [
+      { teamId: "red", scored: 0, conceded: 1 },
+      { teamId: "blue", scored: 0, conceded: 0 },
+      { teamId: "yellow", scored: 1, conceded: 0 },
+    ],
+  );
+  assert.equal(updateResponseBody.audit.action, "goal_updated");
+  assert.equal(updateResponseBody.audit.actorUserId, "scorekeeper@example.com");
+  assert.equal(harness.goalAuditEntries.length, 2);
+
+  const updateReplayResponse = await harness.handler(
+    createEvent({
+      method: "PATCH",
+      path: `/v1/games/game-1/goals/${createdBody.goal.eventId}`,
+      headers: {
+        Cookie: "threefc_session=session-1",
+        "Idempotency-Key": "goal-update-1",
+      },
+      body: updateBody,
+    }),
+  );
+  assert.equal(updateReplayResponse.statusCode, 200);
+  assert.deepEqual(JSON.parse(updateReplayResponse.body), updateResponseBody);
+  assert.equal(harness.goalAuditEntries.length, 2);
+
+  const deleteResponse = await harness.handler(
+    createEvent({
+      method: "DELETE",
+      path: `/v1/games/game-1/goals/${createdBody.goal.eventId}`,
+      headers: {
+        Cookie: "threefc_session=session-1",
+        "Idempotency-Key": "goal-delete-1",
+      },
+    }),
+  );
+  assert.equal(deleteResponse.statusCode, 200);
+  const deleteBody = JSON.parse(deleteResponse.body) as {
+    deletedGoal: { eventId: string };
+    timeline: Array<{ eventId: string }>;
+    scoreboard: { teams: Array<{ teamId: string; scored: number; conceded: number }> };
+    audit: { action: string };
+  };
+  assert.equal(deleteBody.deletedGoal.eventId, createdBody.goal.eventId);
+  assert.deepEqual(deleteBody.timeline, []);
+  assert.deepEqual(
+    deleteBody.scoreboard.teams.map((team) => ({
+      teamId: team.teamId,
+      scored: team.scored,
+      conceded: team.conceded,
+    })),
+    [
+      { teamId: "red", scored: 0, conceded: 0 },
+      { teamId: "blue", scored: 0, conceded: 0 },
+      { teamId: "yellow", scored: 0, conceded: 0 },
+    ],
+  );
+  assert.equal(deleteBody.audit.action, "goal_deleted");
+  assert.equal(harness.goalAuditEntries.length, 3);
+
+  const deleteReplayResponse = await harness.handler(
+    createEvent({
+      method: "DELETE",
+      path: `/v1/games/game-1/goals/${createdBody.goal.eventId}`,
+      headers: {
+        Cookie: "threefc_session=session-1",
+        "Idempotency-Key": "goal-delete-1",
+      },
+    }),
+  );
+  assert.equal(deleteReplayResponse.statusCode, 200);
+  assert.deepEqual(JSON.parse(deleteReplayResponse.body), deleteBody);
+  assert.equal(harness.goalAuditEntries.length, 3);
+});
+
+test("core lambda rejects viewer goal corrections through ACL", async () => {
+  const harness = createGoalHarness({
+    email: "viewer@example.com",
+    role: "viewer",
+  });
+
+  const response = await harness.handler(
+    createEvent({
+      method: "PATCH",
+      path: "/v1/games/game-1/goals/goal-1",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+      body: {
+        scorerPlayerId: "player-red",
+      },
+    }),
+  );
+
+  assert.equal(response.statusCode, 403);
+  assert.deepEqual(JSON.parse(response.body), {
+    error: "forbidden",
+    code: "scorekeeper_required",
+    message: "Admin or scorekeeper role is required for league league-1.",
+  });
+});
+
+test("core lambda rejects invalid goal correction payloads", async () => {
+  const harness = createGoalHarness();
+
+  const response = await harness.handler(
+    createEvent({
+      method: "PATCH",
+      path: "/v1/games/game-1/goals/goal-1",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+      body: {
+        assistPlayerIds: ["player-blue", "player-blue"],
+      },
+    }),
+  );
+
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(JSON.parse(response.body), {
+    error: "Field `assistPlayerIds` must be unique.",
+  });
+});
+
+test("core lambda requires expectedEventId for undo-last", async () => {
+  const harness = createGoalHarness();
+
+  const response = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/games/game-1/goals/undo-last",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+      body: {},
+    }),
+  );
+
+  assert.equal(response.statusCode, 400);
+  assert.match((JSON.parse(response.body) as { error: string }).error, /expectedEventId/);
+});
+
+test("core lambda undo-last deletes latest goal only and rejects stale expected event", async () => {
+  const harness = createGoalHarness();
+  const firstCreateResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/games/game-1/goals",
+      headers: {
+        Cookie: "threefc_session=session-1",
+        "Idempotency-Key": "goal-undo-create-1",
+      },
+      body: {
+        scoringTeamId: "red",
+        concedingTeamId: "blue",
+        scorerPlayerId: "player-red",
+        assistPlayerIds: [],
+        ownGoal: false,
+      },
+    }),
+  );
+  const secondCreateResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/games/game-1/goals",
+      headers: {
+        Cookie: "threefc_session=session-1",
+        "Idempotency-Key": "goal-undo-create-2",
+      },
+      body: {
+        scoringTeamId: "yellow",
+        concedingTeamId: "red",
+        scorerPlayerId: "player-yellow",
+        assistPlayerIds: [],
+        ownGoal: false,
+      },
+    }),
+  );
+  assert.equal(firstCreateResponse.statusCode, 201);
+  assert.equal(secondCreateResponse.statusCode, 201);
+  const firstGoalId = (JSON.parse(firstCreateResponse.body) as { goal: { eventId: string } }).goal.eventId;
+  const secondGoalId = (JSON.parse(secondCreateResponse.body) as { goal: { eventId: string } }).goal.eventId;
+
+  const staleUndoResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/games/game-1/goals/undo-last",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+      body: {
+        expectedEventId: firstGoalId,
+      },
+    }),
+  );
+  assert.equal(staleUndoResponse.statusCode, 409);
+  assert.deepEqual(JSON.parse(staleUndoResponse.body), {
+    error: "conflict",
+    code: "latest_goal_changed",
+    message: "Latest goal changed before undo could be applied. Reload the game and try again.",
+  });
+
+  const undoResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/games/game-1/goals/undo-last",
+      headers: {
+        Cookie: "threefc_session=session-1",
+        "Idempotency-Key": "goal-undo-1",
+      },
+      body: {
+        expectedEventId: secondGoalId,
+      },
+    }),
+  );
+
+  assert.equal(undoResponse.statusCode, 200);
+  const undoBody = JSON.parse(undoResponse.body) as {
+    deletedGoal: { eventId: string };
+    timeline: Array<{ eventId: string }>;
+    audit: { action: string };
+  };
+  assert.equal(undoBody.deletedGoal.eventId, secondGoalId);
+  assert.deepEqual(undoBody.timeline.map((goal) => goal.eventId), [firstGoalId]);
+  assert.equal(undoBody.audit.action, "goal_undo_last");
+
+  const auditCountAfterUndo = harness.goalAuditEntries.length;
+  const thirdCreateResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/games/game-1/goals",
+      headers: {
+        Cookie: "threefc_session=session-1",
+        "Idempotency-Key": "goal-undo-create-3",
+      },
+      body: {
+        scoringTeamId: "yellow",
+        concedingTeamId: "blue",
+        scorerPlayerId: "player-yellow",
+        assistPlayerIds: [],
+        ownGoal: false,
+      },
+    }),
+  );
+  assert.equal(thirdCreateResponse.statusCode, 201);
+  const thirdGoalId = (JSON.parse(thirdCreateResponse.body) as { goal: { eventId: string } }).goal.eventId;
+
+  const undoReplayResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/games/game-1/goals/undo-last",
+      headers: {
+        Cookie: "threefc_session=session-1",
+        "Idempotency-Key": "goal-undo-1",
+      },
+      body: {
+        expectedEventId: secondGoalId,
+      },
+    }),
+  );
+  assert.equal(undoReplayResponse.statusCode, 200);
+  assert.deepEqual(JSON.parse(undoReplayResponse.body), undoBody);
+  assert.equal(harness.goalAuditEntries.length, auditCountAfterUndo + 1);
+
+  const thirdUndoResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/games/game-1/goals/undo-last",
+      headers: {
+        Cookie: "threefc_session=session-1",
+        "Idempotency-Key": "goal-undo-3",
+      },
+      body: {
+        expectedEventId: thirdGoalId,
+      },
+    }),
+  );
+  assert.equal(thirdUndoResponse.statusCode, 200);
+  assert.equal(
+    (JSON.parse(thirdUndoResponse.body) as { deletedGoal: { eventId: string } }).deletedGoal.eventId,
+    thirdGoalId,
+  );
 });
 
 test("core lambda rejects goal creation when no third is running", async () => {

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -1254,6 +1254,53 @@ test("repository updates goals, recomputes tallies, and records audit entries", 
   );
 });
 
+test("repository normalizes malformed goal audit snapshots to documented response bounds", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  client.seedItem({
+    pk: { S: "GAME#game-1" },
+    sk: { S: "AUDIT#GOAL#2026-02-22T00:00:00.000Z#audit-legacy" },
+    entityType: { S: "goalAudit" },
+    createdAt: { S: "2026-02-22T00:00:00.000Z" },
+    updatedAt: { S: "2026-02-22T00:00:00.000Z" },
+    data: {
+      S: JSON.stringify({
+        auditId: "audit-legacy",
+        gameId: "game-1",
+        eventId: "goal-legacy",
+        actorUserId: "admin@example.com",
+        action: "goal_updated",
+        before: {
+          eventId: "goal-legacy",
+          third: 7,
+          thirdMinute: 0,
+          gameMinute: 0,
+          elapsedSeconds: -1,
+          stoppageMinute: 0,
+          scoringTeamId: "green",
+          concedingTeamId: "orange",
+          scorerPlayerId: "player-red",
+          assistPlayerIds: [123, "player-blue"],
+          ownGoal: "false",
+        },
+        after: null,
+      }),
+    },
+  });
+
+  const [audit] = await repository.listGoalAuditEntries("game-1");
+  assert.equal(audit.before?.third, 1);
+  assert.equal(audit.before?.thirdMinute, 1);
+  assert.equal(audit.before?.gameMinute, 1);
+  assert.equal(audit.before?.elapsedSeconds, 0);
+  assert.equal(audit.before?.stoppageMinute, null);
+  assert.equal(audit.before?.displayTime, "1");
+  assert.equal(audit.before?.scoringTeamId, null);
+  assert.equal(audit.before?.concedingTeamId, "red");
+  assert.deepEqual(audit.before?.assistPlayerIds, ["player-blue"]);
+  assert.equal(audit.before?.ownGoal, false);
+});
+
 test("repository replays duplicate correction operation IDs without duplicate PATCH side effects", async () => {
   const repository = createRepository();
   await setupScoringGame(repository);

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -1431,6 +1431,71 @@ test("repository undo-last deletes only the current latest goal and rejects stal
   );
 });
 
+test("repository undo-last backfills missing legacy goal state", async () => {
+  const { repository, client } = createRepositoryHarness();
+  await setupScoringGame(repository);
+
+  for (const goal of [
+    {
+      eventId: "goal-legacy-1",
+      sk: "GOAL#1#0001#0000060#goal-legacy-1",
+      elapsedSeconds: 60,
+      scoringTeamId: "red",
+      concedingTeamId: "blue",
+      scorerPlayerId: "player-red",
+    },
+    {
+      eventId: "goal-legacy-2",
+      sk: "GOAL#1#0002#0000120#goal-legacy-2",
+      elapsedSeconds: 120,
+      scoringTeamId: "yellow",
+      concedingTeamId: "red",
+      scorerPlayerId: "player-yellow",
+    },
+  ] as const) {
+    client.seedItem({
+      pk: { S: "GAME#game-1" },
+      sk: { S: goal.sk },
+      entityType: { S: "goal" },
+      createdAt: { S: "2026-02-22T00:00:00.000Z" },
+      updatedAt: { S: "2026-02-22T00:00:00.000Z" },
+      data: {
+        S: JSON.stringify({
+          gameId: "game-1",
+          eventId: goal.eventId,
+          third: 1,
+          thirdMinute: Math.floor(goal.elapsedSeconds / 60) + 1,
+          gameMinute: Math.floor(goal.elapsedSeconds / 60) + 1,
+          elapsedSeconds: goal.elapsedSeconds,
+          stoppageMinute: null,
+          displayTime: `${String(Math.floor(goal.elapsedSeconds / 60)).padStart(2, "0")}:00`,
+          scoringTeamId: goal.scoringTeamId,
+          concedingTeamId: goal.concedingTeamId,
+          scorerPlayerId: goal.scorerPlayerId,
+          assistPlayerIds: [],
+          ownGoal: false,
+        }),
+      },
+    });
+  }
+
+  const result = await repository.undoLastGoal({
+    gameId: "game-1",
+    actorUserId: "scorekeeper@example.com",
+    expectedEventId: "goal-legacy-2",
+  });
+
+  assert.ok(result);
+  assert.equal(result.deletedGoal.eventId, "goal-legacy-2");
+  assert.deepEqual(result.timeline.map((goal) => goal.eventId), ["goal-legacy-1"]);
+  const stateItem = client.readItem("GAME#game-1", "GOAL_STATE");
+  assert.ok(stateItem?.data?.S);
+  assert.equal(
+    (JSON.parse(stateItem.data.S) as { latestEventId: string | null }).latestEventId,
+    "goal-legacy-1",
+  );
+});
+
 test("repository undo-last rejects when strongly read goal-state latest is stale", async () => {
   const { repository, client } = createRepositoryHarness();
   await setupScoringGame(repository);

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -1137,6 +1137,7 @@ test("repository stamps regulation-boundary goals at the final regulation minute
   const result = await repository.createGoal({
     gameId: "game-1",
     eventId: "goal-boundary",
+    actorUserId: "scorekeeper@example.com",
     scoringTeamId: "red",
     concedingTeamId: "blue",
     scorerPlayerId: "player-red",

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -581,6 +581,64 @@ test("repository orders stoppage goals by elapsed time before event ID", async (
   );
 });
 
+test("repository uses creation order to break same-second goal ties", async () => {
+  const clock = new MutableClock("2026-02-22T00:00:00.000Z");
+  const repository = new ThreeFcRepository(
+    new InMemoryDynamoClient(),
+    "threefc_test",
+    clock,
+  );
+  await setupScoringGame(repository);
+  clock.set("2026-02-22T00:00:00.000Z");
+  await repository.startGameThird({ gameId: "game-1", third: 1 });
+
+  clock.set("2026-02-22T00:00:10.100Z");
+  await repository.createGoal({
+    gameId: "game-1",
+    eventId: "goal-z-earlier",
+    actorUserId: "scorekeeper@example.com",
+    scoringTeamId: "red",
+    concedingTeamId: "blue",
+    scorerPlayerId: "player-red",
+    assistPlayerIds: [],
+    ownGoal: false,
+  });
+  clock.set("2026-02-22T00:00:10.900Z");
+  await repository.createGoal({
+    gameId: "game-1",
+    eventId: "goal-a-later",
+    actorUserId: "scorekeeper@example.com",
+    scoringTeamId: "yellow",
+    concedingTeamId: "red",
+    scorerPlayerId: "player-yellow",
+    assistPlayerIds: [],
+    ownGoal: false,
+  });
+
+  assert.deepEqual((await repository.listGoalEvents("game-1")).map((goal) => goal.eventId), [
+    "goal-z-earlier",
+    "goal-a-later",
+  ]);
+  await assert.rejects(
+    repository.undoLastGoal({
+      gameId: "game-1",
+      actorUserId: "scorekeeper@example.com",
+      expectedEventId: "goal-z-earlier",
+    }),
+    /Latest goal changed/,
+  );
+
+  const result = await repository.undoLastGoal({
+    gameId: "game-1",
+    actorUserId: "scorekeeper@example.com",
+    expectedEventId: "goal-a-later",
+  });
+
+  assert.ok(result);
+  assert.equal(result.deletedGoal.eventId, "goal-a-later");
+  assert.deepEqual(result.timeline.map((goal) => goal.eventId), ["goal-z-earlier"]);
+});
+
 test("repository normalizes partial legacy goal records to documented response bounds", async () => {
   const { repository, client } = createRepositoryHarness();
 
@@ -1270,7 +1328,7 @@ test("repository normalizes malformed goal audit snapshots to documented respons
         gameId: "game-1",
         eventId: "goal-legacy",
         actorUserId: "admin@example.com",
-        action: "goal_updated",
+        action: "legacy_unknown",
         before: {
           eventId: "goal-legacy",
           third: 7,
@@ -1290,6 +1348,7 @@ test("repository normalizes malformed goal audit snapshots to documented respons
   });
 
   const [audit] = await repository.listGoalAuditEntries("game-1");
+  assert.equal(audit.action, "goal_updated");
   assert.equal(audit.before?.third, 1);
   assert.equal(audit.before?.thirdMinute, 1);
   assert.equal(audit.before?.gameMinute, 1);
@@ -1303,7 +1362,7 @@ test("repository normalizes malformed goal audit snapshots to documented respons
 });
 
 test("repository replays duplicate correction operation IDs without duplicate PATCH side effects", async () => {
-  const repository = createRepository();
+  const { repository, client } = createRepositoryHarness();
   await setupScoringGame(repository);
   await repository.startGameThird({ gameId: "game-1", third: 1 });
 
@@ -1326,6 +1385,26 @@ test("repository replays duplicate correction operation IDs without duplicate PA
     operationRequestHash: "hash-1",
     assistPlayerIds: ["player-yellow"],
   });
+  const operationItem = client.readItem("GAME#game-1", "GOAL_CORRECTION#correction-op-1");
+  assert.ok(operationItem);
+  const operationJson = operationItem.data.S;
+  if (typeof operationJson !== "string") {
+    throw new Error("Expected correction operation data to be stored as JSON.");
+  }
+  const operationData = JSON.parse(operationJson) as Record<string, unknown>;
+  operationItem.data = { S: JSON.stringify({ ...operationData, action: "legacy_unknown" }) };
+  client.seedItem(operationItem);
+
+  const storedOperation = await (
+    repository as unknown as {
+      getGoalCorrectionOperation(
+        gameId: string,
+        operationId: string,
+      ): Promise<{ action: string } | null>;
+    }
+  ).getGoalCorrectionOperation("game-1", "correction-op-1");
+  assert.equal(storedOperation?.action, "goal_updated");
+
   const second = await repository.updateGoal({
     gameId: "game-1",
     eventId: "goal-op-replay",

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -1593,7 +1593,7 @@ test("repository own goals increment conceding only and require scorer on conced
     repository.createGoal({
       gameId: "game-1",
       eventId: "goal-own-invalid",
-    actorUserId: "scorekeeper@example.com",
+      actorUserId: "scorekeeper@example.com",
       scoringTeamId: null,
       concedingTeamId: "blue",
       scorerPlayerId: "player-red",
@@ -1612,7 +1612,7 @@ test("repository rejects goal creation unless a third is running", async () => {
     repository.createGoal({
       gameId: "game-1",
       eventId: "goal-no-timer",
-    actorUserId: "scorekeeper@example.com",
+      actorUserId: "scorekeeper@example.com",
       scoringTeamId: "red",
       concedingTeamId: "blue",
       scorerPlayerId: "player-red",
@@ -1632,7 +1632,7 @@ test("repository validates goal roster and team rules", async () => {
     repository.createGoal({
       gameId: "game-1",
       eventId: "goal-unrostered-scorer",
-    actorUserId: "scorekeeper@example.com",
+      actorUserId: "scorekeeper@example.com",
       scoringTeamId: "red",
       concedingTeamId: "blue",
       scorerPlayerId: "player-missing",
@@ -1646,7 +1646,7 @@ test("repository validates goal roster and team rules", async () => {
     repository.createGoal({
       gameId: "game-1",
       eventId: "goal-wrong-team",
-    actorUserId: "scorekeeper@example.com",
+      actorUserId: "scorekeeper@example.com",
       scoringTeamId: "red",
       concedingTeamId: "blue",
       scorerPlayerId: "player-blue",
@@ -1660,7 +1660,7 @@ test("repository validates goal roster and team rules", async () => {
     repository.createGoal({
       gameId: "game-1",
       eventId: "goal-unrostered-assist",
-    actorUserId: "scorekeeper@example.com",
+      actorUserId: "scorekeeper@example.com",
       scoringTeamId: "red",
       concedingTeamId: "blue",
       scorerPlayerId: "player-red",
@@ -1696,7 +1696,7 @@ test("repository enforces goal validation rules", async () => {
     repository.createGoal({
       gameId: "game-1",
       eventId: "goal-invalid",
-    actorUserId: "scorekeeper@example.com",
+      actorUserId: "scorekeeper@example.com",
       scoringTeamId: "red",
       concedingTeamId: "blue",
       scorerPlayerId: "player-1",
@@ -1710,7 +1710,7 @@ test("repository enforces goal validation rules", async () => {
     repository.createGoal({
       gameId: "game-1",
       eventId: "goal-own",
-    actorUserId: "scorekeeper@example.com",
+      actorUserId: "scorekeeper@example.com",
       scoringTeamId: "red",
       concedingTeamId: "blue",
       scorerPlayerId: "player-1",

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -133,13 +133,13 @@ class InMemoryDynamoClient {
     }
 
     if (command instanceof TransactWriteItemsCommand) {
-      const puts = (command.input.TransactItems ?? []).flatMap((item) => {
-        if (!item.Put) {
-          throw new Error("Test client only supports Put transaction items.");
-        }
+      const writes = command.input.TransactItems ?? [];
 
-        return [item.Put];
-      });
+      for (const write of writes) {
+        if (!write.Put && !write.Delete) {
+          throw new Error("Test client only supports Put and Delete transaction items.");
+        }
+      }
 
       if (this.beforeNextPut) {
         const callback = this.beforeNextPut;
@@ -147,53 +147,95 @@ class InMemoryDynamoClient {
         callback();
       }
 
-      for (const put of puts) {
-        const item = put.Item;
-        if (!item) {
-          throw new Error("TransactWriteItemsCommand Put is missing Item.");
+      const throwConditionalCancellation = (failedWrite: (typeof writes)[number]): never => {
+        const error = new Error("Conditional transaction request failed.");
+        (
+          error as Error & {
+            name: string;
+            CancellationReasons: Array<{ Code: string }>;
+          }
+        ).name = "TransactionCanceledException";
+        (
+          error as Error & {
+            name: string;
+            CancellationReasons: Array<{ Code: string }>;
+          }
+        ).CancellationReasons = writes.map((write) => ({
+          Code: write === failedWrite ? "ConditionalCheckFailed" : "None",
+        }));
+        throw error;
+      };
+
+      for (const write of writes) {
+        if (write.Put) {
+          const item = write.Put.Item;
+          if (!item) {
+            throw new Error("TransactWriteItemsCommand Put is missing Item.");
+          }
+
+          const pk = this.readString(item.pk, "pk");
+          const sk = this.readString(item.sk, "sk");
+          const id = `${pk}|${sk}`;
+
+          if (
+            write.Put.ConditionExpression &&
+            !this.conditionMatches(
+              write.Put.ConditionExpression,
+              this.items.get(id),
+              write.Put.ExpressionAttributeNames ?? {},
+              write.Put.ExpressionAttributeValues ?? {},
+            )
+          ) {
+            throwConditionalCancellation(write);
+          }
         }
 
-        const pk = this.readString(item.pk, "pk");
-        const sk = this.readString(item.sk, "sk");
-        const id = `${pk}|${sk}`;
+        if (write.Delete) {
+          const key = write.Delete.Key;
+          if (!key) {
+            throw new Error("TransactWriteItemsCommand Delete is missing Key.");
+          }
 
-        if (
-          put.ConditionExpression &&
-          !this.conditionMatches(
-            put.ConditionExpression,
-            this.items.get(id),
-            put.ExpressionAttributeNames ?? {},
-            put.ExpressionAttributeValues ?? {},
-          )
-        ) {
-          const error = new Error("Conditional transaction request failed.");
-          (
-            error as Error & {
-              name: string;
-              CancellationReasons: Array<{ Code: string }>;
-            }
-          ).name = "TransactionCanceledException";
-          (
-            error as Error & {
-              name: string;
-              CancellationReasons: Array<{ Code: string }>;
-            }
-          ).CancellationReasons = puts.map((candidate) => ({
-            Code: candidate === put ? "ConditionalCheckFailed" : "None",
-          }));
-          throw error;
+          const pk = this.readString(key.pk, "pk");
+          const sk = this.readString(key.sk, "sk");
+          const id = `${pk}|${sk}`;
+
+          if (
+            write.Delete.ConditionExpression &&
+            !this.conditionMatches(
+              write.Delete.ConditionExpression,
+              this.items.get(id),
+              write.Delete.ExpressionAttributeNames ?? {},
+              write.Delete.ExpressionAttributeValues ?? {},
+            )
+          ) {
+            throwConditionalCancellation(write);
+          }
         }
       }
 
-      for (const put of puts) {
-        const item = put.Item;
-        if (!item) {
-          throw new Error("TransactWriteItemsCommand Put is missing Item.");
+      for (const write of writes) {
+        if (write.Put) {
+          const item = write.Put.Item;
+          if (!item) {
+            throw new Error("TransactWriteItemsCommand Put is missing Item.");
+          }
+
+          const pk = this.readString(item.pk, "pk");
+          const sk = this.readString(item.sk, "sk");
+          this.items.set(`${pk}|${sk}`, item);
         }
 
-        const pk = this.readString(item.pk, "pk");
-        const sk = this.readString(item.sk, "sk");
-        this.items.set(`${pk}|${sk}`, item);
+        if (write.Delete) {
+          const key = write.Delete.Key;
+          if (!key) {
+            throw new Error("TransactWriteItemsCommand Delete is missing Key.");
+          }
+
+          const pk = this.readString(key.pk, "pk");
+          const sk = this.readString(key.sk, "sk");
+          this.items.delete(`${pk}|${sk}`);
+        }
       }
 
       return {};
@@ -1031,6 +1073,7 @@ test("repository creates standard goals with timer stamping, mixed-team assists,
   const result = await repository.createGoal({
     gameId: "game-1",
     eventId: "goal-1",
+    actorUserId: "scorekeeper@example.com",
     scoringTeamId: "red",
     concedingTeamId: "blue",
     scorerPlayerId: "player-red",
@@ -1116,6 +1159,7 @@ test("repository rejects duplicate goal event IDs without double-counting tallie
   await repository.createGoal({
     gameId: "game-1",
     eventId: "goal-idem-duplicate",
+    actorUserId: "scorekeeper@example.com",
     scoringTeamId: "red",
     concedingTeamId: "blue",
     scorerPlayerId: "player-red",
@@ -1127,6 +1171,7 @@ test("repository rejects duplicate goal event IDs without double-counting tallie
     repository.createGoal({
       gameId: "game-1",
       eventId: "goal-idem-duplicate",
+    actorUserId: "scorekeeper@example.com",
       scoringTeamId: "red",
       concedingTeamId: "blue",
       scorerPlayerId: "player-red",
@@ -1150,6 +1195,288 @@ test("repository rejects duplicate goal event IDs without double-counting tallie
   );
   assert.deepEqual((await repository.listGoalEvents("game-1")).map((goal) => goal.eventId), [
     "goal-idem-duplicate",
+  ]);
+});
+
+test("repository updates goals, recomputes tallies, and records audit entries", async () => {
+  const repository = createRepository();
+  await setupScoringGame(repository);
+  await repository.startGameThird({ gameId: "game-1", third: 1 });
+
+  await repository.createGoal({
+    gameId: "game-1",
+    eventId: "goal-correct-own",
+    actorUserId: "scorekeeper@example.com",
+    scoringTeamId: null,
+    concedingTeamId: "blue",
+    scorerPlayerId: "player-blue",
+    assistPlayerIds: [],
+    ownGoal: true,
+  });
+
+  const result = await repository.updateGoal({
+    gameId: "game-1",
+    eventId: "goal-correct-own",
+    actorUserId: "admin@example.com",
+    scoringTeamId: "red",
+    concedingTeamId: "blue",
+    scorerPlayerId: "player-red",
+    assistPlayerIds: ["player-yellow"],
+    ownGoal: false,
+  });
+
+  assert.ok(result);
+  assert.equal(result.goal.eventId, "goal-correct-own");
+  assert.equal(result.goal.displayTime, result.previousGoal.displayTime);
+  assert.equal(result.goal.scoringTeamId, "red");
+  assert.equal(result.goal.ownGoal, false);
+  assert.deepEqual(result.goal.assistPlayerIds, ["player-yellow"]);
+  assert.deepEqual(
+    result.scoreboard.teams.map((team) => ({
+      teamId: team.teamId,
+      scored: team.scored,
+      conceded: team.conceded,
+    })),
+    [
+      { teamId: "red", scored: 1, conceded: 0 },
+      { teamId: "blue", scored: 0, conceded: 1 },
+      { teamId: "yellow", scored: 0, conceded: 0 },
+    ],
+  );
+  assert.equal(result.audit.action, "goal_updated");
+  assert.equal(result.audit.actorUserId, "admin@example.com");
+  assert.equal(result.audit.before?.ownGoal, true);
+  assert.equal(result.audit.after?.scoringTeamId, "red");
+  assert.deepEqual(result.timeline, [result.goal]);
+  assert.deepEqual(
+    (await repository.listGoalAuditEntries("game-1")).map((entry) => entry.action),
+    ["goal_created", "goal_updated"],
+  );
+});
+
+test("repository replays duplicate correction operation IDs without duplicate PATCH side effects", async () => {
+  const repository = createRepository();
+  await setupScoringGame(repository);
+  await repository.startGameThird({ gameId: "game-1", third: 1 });
+
+  await repository.createGoal({
+    gameId: "game-1",
+    eventId: "goal-op-replay",
+    actorUserId: "scorekeeper@example.com",
+    scoringTeamId: "red",
+    concedingTeamId: "blue",
+    scorerPlayerId: "player-red",
+    assistPlayerIds: [],
+    ownGoal: false,
+  });
+
+  const first = await repository.updateGoal({
+    gameId: "game-1",
+    eventId: "goal-op-replay",
+    actorUserId: "scorekeeper@example.com",
+    operationId: "correction-op-1",
+    operationRequestHash: "hash-1",
+    assistPlayerIds: ["player-yellow"],
+  });
+  const second = await repository.updateGoal({
+    gameId: "game-1",
+    eventId: "goal-op-replay",
+    actorUserId: "scorekeeper@example.com",
+    operationId: "correction-op-1",
+    operationRequestHash: "hash-1",
+    assistPlayerIds: ["player-yellow"],
+  });
+
+  assert.deepEqual(second, first);
+  assert.deepEqual(
+    (await repository.listGoalAuditEntries("game-1")).map((entry) => entry.action),
+    ["goal_created", "goal_updated"],
+  );
+  assert.deepEqual((await repository.listGoalEvents("game-1"))[0]?.assistPlayerIds, ["player-yellow"]);
+
+  await assert.rejects(
+    repository.updateGoal({
+      gameId: "game-1",
+      eventId: "goal-op-replay",
+      actorUserId: "scorekeeper@example.com",
+      operationId: "correction-op-1",
+      operationRequestHash: "different-hash",
+      assistPlayerIds: [],
+    }),
+    /different request payload/,
+  );
+});
+
+test("repository deletes goals and recomputes tallies from remaining timeline", async () => {
+  const repository = createRepository();
+  await setupScoringGame(repository);
+  await repository.startGameThird({ gameId: "game-1", third: 1 });
+
+  await repository.createGoal({
+    gameId: "game-1",
+    eventId: "goal-delete-1",
+    actorUserId: "scorekeeper@example.com",
+    scoringTeamId: "red",
+    concedingTeamId: "blue",
+    scorerPlayerId: "player-red",
+    assistPlayerIds: [],
+    ownGoal: false,
+  });
+  await repository.createGoal({
+    gameId: "game-1",
+    eventId: "goal-delete-2",
+    actorUserId: "scorekeeper@example.com",
+    scoringTeamId: "yellow",
+    concedingTeamId: "red",
+    scorerPlayerId: "player-yellow",
+    assistPlayerIds: [],
+    ownGoal: false,
+  });
+
+  const result = await repository.deleteGoal({
+    gameId: "game-1",
+    eventId: "goal-delete-1",
+    actorUserId: "scorekeeper@example.com",
+  });
+
+  assert.ok(result);
+  assert.equal(result.deletedGoal.eventId, "goal-delete-1");
+  assert.deepEqual(result.timeline.map((goal) => goal.eventId), ["goal-delete-2"]);
+  assert.deepEqual(
+    result.scoreboard.teams.map((team) => ({
+      teamId: team.teamId,
+      scored: team.scored,
+      conceded: team.conceded,
+    })),
+    [
+      { teamId: "red", scored: 0, conceded: 1 },
+      { teamId: "blue", scored: 0, conceded: 0 },
+      { teamId: "yellow", scored: 1, conceded: 0 },
+    ],
+  );
+  assert.equal(result.audit.action, "goal_deleted");
+  assert.equal(result.audit.before?.eventId, "goal-delete-1");
+  assert.equal(result.audit.after, null);
+});
+
+test("repository undo-last deletes only the current latest goal and rejects stale expectations", async () => {
+  const repository = createRepository();
+  await setupScoringGame(repository);
+  await repository.startGameThird({ gameId: "game-1", third: 1 });
+
+  await repository.createGoal({
+    gameId: "game-1",
+    eventId: "goal-undo-1",
+    actorUserId: "scorekeeper@example.com",
+    scoringTeamId: "red",
+    concedingTeamId: "blue",
+    scorerPlayerId: "player-red",
+    assistPlayerIds: [],
+    ownGoal: false,
+  });
+  await repository.createGoal({
+    gameId: "game-1",
+    eventId: "goal-undo-2",
+    actorUserId: "scorekeeper@example.com",
+    scoringTeamId: "yellow",
+    concedingTeamId: "red",
+    scorerPlayerId: "player-yellow",
+    assistPlayerIds: [],
+    ownGoal: false,
+  });
+
+  await assert.rejects(
+    repository.undoLastGoal({
+      gameId: "game-1",
+      actorUserId: "scorekeeper@example.com",
+      expectedEventId: "",
+    }),
+    /expectedEventId must be a non-empty string/,
+  );
+
+  await assert.rejects(
+    repository.undoLastGoal({
+      gameId: "game-1",
+      actorUserId: "scorekeeper@example.com",
+      expectedEventId: "goal-undo-1",
+    }),
+    /Latest goal changed/,
+  );
+  assert.deepEqual((await repository.listGoalEvents("game-1")).map((goal) => goal.eventId), [
+    "goal-undo-1",
+    "goal-undo-2",
+  ]);
+
+  const result = await repository.undoLastGoal({
+    gameId: "game-1",
+    actorUserId: "scorekeeper@example.com",
+    expectedEventId: "goal-undo-2",
+  });
+
+  assert.ok(result);
+  assert.equal(result.deletedGoal.eventId, "goal-undo-2");
+  assert.deepEqual(result.timeline.map((goal) => goal.eventId), ["goal-undo-1"]);
+  assert.equal(result.audit.action, "goal_undo_last");
+  assert.deepEqual(
+    result.scoreboard.teams.map((team) => ({
+      teamId: team.teamId,
+      scored: team.scored,
+      conceded: team.conceded,
+    })),
+    [
+      { teamId: "red", scored: 1, conceded: 0 },
+      { teamId: "blue", scored: 0, conceded: 1 },
+      { teamId: "yellow", scored: 0, conceded: 0 },
+    ],
+  );
+});
+
+test("repository undo-last rejects when strongly read goal-state latest is stale", async () => {
+  const { repository, client } = createRepositoryHarness();
+  await setupScoringGame(repository);
+  await repository.startGameThird({ gameId: "game-1", third: 1 });
+
+  await repository.createGoal({
+    gameId: "game-1",
+    eventId: "goal-state-1",
+    actorUserId: "scorekeeper@example.com",
+    scoringTeamId: "red",
+    concedingTeamId: "blue",
+    scorerPlayerId: "player-red",
+    assistPlayerIds: [],
+    ownGoal: false,
+  });
+  await repository.createGoal({
+    gameId: "game-1",
+    eventId: "goal-state-2",
+    actorUserId: "scorekeeper@example.com",
+    scoringTeamId: "yellow",
+    concedingTeamId: "red",
+    scorerPlayerId: "player-yellow",
+    assistPlayerIds: [],
+    ownGoal: false,
+  });
+
+  const stateItem = client.readItem("GAME#game-1", "GOAL_STATE");
+  assert.ok(stateItem?.data?.S);
+  const statePayload = JSON.parse(stateItem.data.S) as {
+    latestEventId: string | null;
+  };
+  statePayload.latestEventId = "goal-state-1";
+  stateItem.data.S = JSON.stringify(statePayload);
+  client.seedItem(stateItem);
+
+  await assert.rejects(
+    repository.undoLastGoal({
+      gameId: "game-1",
+      actorUserId: "scorekeeper@example.com",
+      expectedEventId: "goal-state-2",
+    }),
+    /Latest goal changed/,
+  );
+  assert.deepEqual((await repository.listGoalEvents("game-1")).map((goal) => goal.eventId), [
+    "goal-state-1",
+    "goal-state-2",
   ]);
 });
 
@@ -1177,6 +1504,7 @@ test("repository rejects stale scoreboard writes without creating the goal", asy
     repository.createGoal({
       gameId: "game-1",
       eventId: "goal-stale",
+    actorUserId: "scorekeeper@example.com",
       scoringTeamId: "red",
       concedingTeamId: "blue",
       scorerPlayerId: "player-red",
@@ -1236,6 +1564,7 @@ test("repository own goals increment conceding only and require scorer on conced
   const result = await repository.createGoal({
     gameId: "game-1",
     eventId: "goal-own",
+    actorUserId: "scorekeeper@example.com",
     scoringTeamId: null,
     concedingTeamId: "blue",
     scorerPlayerId: "player-blue",
@@ -1263,6 +1592,7 @@ test("repository own goals increment conceding only and require scorer on conced
     repository.createGoal({
       gameId: "game-1",
       eventId: "goal-own-invalid",
+    actorUserId: "scorekeeper@example.com",
       scoringTeamId: null,
       concedingTeamId: "blue",
       scorerPlayerId: "player-red",
@@ -1281,6 +1611,7 @@ test("repository rejects goal creation unless a third is running", async () => {
     repository.createGoal({
       gameId: "game-1",
       eventId: "goal-no-timer",
+    actorUserId: "scorekeeper@example.com",
       scoringTeamId: "red",
       concedingTeamId: "blue",
       scorerPlayerId: "player-red",
@@ -1300,6 +1631,7 @@ test("repository validates goal roster and team rules", async () => {
     repository.createGoal({
       gameId: "game-1",
       eventId: "goal-unrostered-scorer",
+    actorUserId: "scorekeeper@example.com",
       scoringTeamId: "red",
       concedingTeamId: "blue",
       scorerPlayerId: "player-missing",
@@ -1313,6 +1645,7 @@ test("repository validates goal roster and team rules", async () => {
     repository.createGoal({
       gameId: "game-1",
       eventId: "goal-wrong-team",
+    actorUserId: "scorekeeper@example.com",
       scoringTeamId: "red",
       concedingTeamId: "blue",
       scorerPlayerId: "player-blue",
@@ -1326,6 +1659,7 @@ test("repository validates goal roster and team rules", async () => {
     repository.createGoal({
       gameId: "game-1",
       eventId: "goal-unrostered-assist",
+    actorUserId: "scorekeeper@example.com",
       scoringTeamId: "red",
       concedingTeamId: "blue",
       scorerPlayerId: "player-red",
@@ -1361,6 +1695,7 @@ test("repository enforces goal validation rules", async () => {
     repository.createGoal({
       gameId: "game-1",
       eventId: "goal-invalid",
+    actorUserId: "scorekeeper@example.com",
       scoringTeamId: "red",
       concedingTeamId: "blue",
       scorerPlayerId: "player-1",
@@ -1374,6 +1709,7 @@ test("repository enforces goal validation rules", async () => {
     repository.createGoal({
       gameId: "game-1",
       eventId: "goal-own",
+    actorUserId: "scorekeeper@example.com",
       scoringTeamId: "red",
       concedingTeamId: "blue",
       scorerPlayerId: "player-1",

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -1171,12 +1171,12 @@ test("repository rejects duplicate goal event IDs without double-counting tallie
     repository.createGoal({
       gameId: "game-1",
       eventId: "goal-idem-duplicate",
-    actorUserId: "scorekeeper@example.com",
       scoringTeamId: "red",
       concedingTeamId: "blue",
       scorerPlayerId: "player-red",
       assistPlayerIds: [],
       ownGoal: false,
+      actorUserId: "scorekeeper@example.com",
     }),
     /Goal event has already been created/,
   );
@@ -1504,12 +1504,12 @@ test("repository rejects stale scoreboard writes without creating the goal", asy
     repository.createGoal({
       gameId: "game-1",
       eventId: "goal-stale",
-    actorUserId: "scorekeeper@example.com",
       scoringTeamId: "red",
       concedingTeamId: "blue",
       scorerPlayerId: "player-red",
       assistPlayerIds: [],
       ownGoal: false,
+      actorUserId: "scorekeeper@example.com",
     }),
     /Scoreboard changed while creating this goal/,
   );
@@ -1549,6 +1549,7 @@ test("repository rethrows non-conditional transaction cancellation when creating
       scorerPlayerId: "player-red",
       assistPlayerIds: [],
       ownGoal: false,
+      actorUserId: "scorekeeper@example.com",
     }),
     /Transaction validation failed/,
   );

--- a/api/src/tests/session.test.ts
+++ b/api/src/tests/session.test.ts
@@ -45,6 +45,9 @@ test("isAuthenticatedApiRoute marks protected routes only", () => {
   assert.equal(isAuthenticatedApiRoute("PATCH", "/v1/games/game-1"), true);
   assert.equal(isAuthenticatedApiRoute("DELETE", "/v1/games/game-1"), true);
   assert.equal(isAuthenticatedApiRoute("POST", "/v1/games/game-1/goals"), true);
+  assert.equal(isAuthenticatedApiRoute("PATCH", "/v1/games/game-1/goals/goal-1"), true);
+  assert.equal(isAuthenticatedApiRoute("DELETE", "/v1/games/game-1/goals/goal-1"), true);
+  assert.equal(isAuthenticatedApiRoute("POST", "/v1/games/game-1/goals/undo-last"), true);
   assert.equal(isAuthenticatedApiRoute("GET", "/v1/auth/session"), true);
   assert.equal(isAuthenticatedApiRoute("POST", "/v1/leagues"), true);
   assert.equal(isAuthenticatedApiRoute("POST", "/v1/leagues/league-1/seasons"), true);

--- a/api/src/tests/session.test.ts
+++ b/api/src/tests/session.test.ts
@@ -44,6 +44,8 @@ test("isAuthenticatedApiRoute marks protected routes only", () => {
   assert.equal(isAuthenticatedApiRoute("GET", "/v1/games/game-1"), true);
   assert.equal(isAuthenticatedApiRoute("PATCH", "/v1/games/game-1"), true);
   assert.equal(isAuthenticatedApiRoute("DELETE", "/v1/games/game-1"), true);
+  assert.equal(isAuthenticatedApiRoute("POST", "/v1/games/game-1/thirds/1/start"), true);
+  assert.equal(isAuthenticatedApiRoute("POST", "/v1/games/game-1/thirds/1/finish"), true);
   assert.equal(isAuthenticatedApiRoute("POST", "/v1/games/game-1/goals"), true);
   assert.equal(isAuthenticatedApiRoute("PATCH", "/v1/games/game-1/goals/goal-1"), true);
   assert.equal(isAuthenticatedApiRoute("DELETE", "/v1/games/game-1/goals/goal-1"), true);

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -165,6 +165,21 @@ function isAuthenticated(state: MockApiState): boolean {
   return Boolean(state.session && state.cookieJar.includes(`threefc_session=${state.session.sessionId}`));
 }
 
+function parseMockThirdRouteParam(value: string): 1 | 2 | 3 | null {
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(value);
+  } catch {
+    return null;
+  }
+
+  if (decoded === "1" || decoded === "2" || decoded === "3") {
+    return Number(decoded) as 1 | 2 | 3;
+  }
+
+  return null;
+}
+
 const DEFAULT_MOCK_TEAMS: Array<{ teamId: TeamId; name: string; color: string }> = [
   { teamId: "red", name: "Red", color: "#d83b36" },
   { teamId: "blue", name: "Blue", color: "#2364d2" },
@@ -515,7 +530,11 @@ function createMockFetch(state: MockApiState) {
     const startThirdMatch = path.match(/^\/v1\/games\/([^/]+)\/thirds\/([^/]+)\/start$/);
     if (method === "POST" && startThirdMatch) {
       const gameId = decodeURIComponent(startThirdMatch[1]);
-      const thirdNumber = Number.parseInt(decodeURIComponent(startThirdMatch[2]), 10);
+      const thirdNumber = parseMockThirdRouteParam(startThirdMatch[2]);
+      if (!thirdNumber) {
+        return createJsonResponse(400, { error: "Third must be 1, 2, or 3." });
+      }
+
       const game = state.games.get(gameId);
       if (!game) {
         return createJsonResponse(404, { error: "not_found", message: "Game not found." });
@@ -547,7 +566,11 @@ function createMockFetch(state: MockApiState) {
     const finishThirdMatch = path.match(/^\/v1\/games\/([^/]+)\/thirds\/([^/]+)\/finish$/);
     if (method === "POST" && finishThirdMatch) {
       const gameId = decodeURIComponent(finishThirdMatch[1]);
-      const thirdNumber = Number.parseInt(decodeURIComponent(finishThirdMatch[2]), 10);
+      const thirdNumber = parseMockThirdRouteParam(finishThirdMatch[2]);
+      if (!thirdNumber) {
+        return createJsonResponse(400, { error: "Third must be 1, 2, or 3." });
+      }
+
       const game = state.games.get(gameId);
       if (!game) {
         return createJsonResponse(404, { error: "not_found", message: "Game not found." });
@@ -555,6 +578,10 @@ function createMockFetch(state: MockApiState) {
 
       const thirds = game.thirds.map((third) => ({ ...third }));
       const target = thirds.find((third) => third.third === thirdNumber);
+      if (!target) {
+        return createJsonResponse(400, { error: "Third must be 1, 2, or 3." });
+      }
+
       if (!target?.startedAt) {
         return createJsonResponse(409, {
           error: "conflict",

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -318,7 +318,7 @@
   function formatTimerDisplay(totalSeconds, thirdLengthMinutes) {
     const safeSeconds = Math.max(0, Math.floor(totalSeconds));
     const nominalSeconds = thirdLengthMinutes * 60;
-    if (safeSeconds < nominalSeconds) {
+    if (safeSeconds <= nominalSeconds) {
       const minutes = Math.floor(safeSeconds / 60);
       const seconds = safeSeconds % 60;
       return {

--- a/docs/dynamodb-single-table.md
+++ b/docs/dynamodb-single-table.md
@@ -39,6 +39,15 @@ This document defines the baseline key structure and access patterns for the
 - Goal event id marker:
   - `pk=GAME#{gameId}`
   - `sk=GOAL_EVENT#{eventId}`
+- Goal correction state:
+  - `pk=GAME#{gameId}`
+  - `sk=GOAL_STATE`
+- Goal correction operation marker:
+  - `pk=GAME#{gameId}`
+  - `sk=GOAL_CORRECTION#{operationId}`
+- Goal audit entry:
+  - `pk=GAME#{gameId}`
+  - `sk=AUDIT#GOAL#{createdAt}#{auditId}`
 - Roster assignment:
   - `pk=GAME#{gameId}`
   - `sk=ROSTER#{teamId}#{playerId}`

--- a/docs/openapi/v1-core-write.yaml
+++ b/docs/openapi/v1-core-write.yaml
@@ -233,6 +233,111 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+  /v1/games/{gameId}/goals/undo-last:
+    post:
+      summary: Delete the current most recent goal event
+      operationId: undoLastGoal
+      parameters:
+        - name: gameId
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UndoLastGoalRequest"
+      responses:
+        "200":
+          description: Latest goal deleted with updated scoreboard, timeline, and audit entry
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeleteGoalResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+  /v1/games/{gameId}/goals/{eventId}:
+    patch:
+      summary: Correct an existing goal event without changing its timer stamp
+      operationId: updateGoal
+      parameters:
+        - name: gameId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: eventId
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateGoalRequest"
+      responses:
+        "200":
+          description: Goal updated with recalculated scoreboard, timeline, and audit entry
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UpdateGoalResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+    delete:
+      summary: Delete a goal event and recompute game scoring tallies
+      operationId: deleteGoal
+      parameters:
+        - name: gameId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: eventId
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/IdempotencyKey"
+      responses:
+        "200":
+          description: Goal deleted with recalculated scoreboard, timeline, and audit entry
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeleteGoalResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
   /v1/seasons/{seasonId}/teams:
     get:
       summary: List season default teams
@@ -708,6 +813,47 @@ components:
             minLength: 1
         ownGoal:
           type: boolean
+    UpdateGoalRequest:
+      type: object
+      additionalProperties: false
+      minProperties: 1
+      properties:
+        scoringTeamId:
+          type:
+            - string
+            - "null"
+          enum:
+            - red
+            - blue
+            - yellow
+            - null
+        concedingTeamId:
+          type: string
+          enum:
+            - red
+            - blue
+            - yellow
+        scorerPlayerId:
+          type: string
+          minLength: 1
+        assistPlayerIds:
+          type: array
+          maxItems: 3
+          items:
+            type: string
+            minLength: 1
+          uniqueItems: true
+        ownGoal:
+          type: boolean
+    UndoLastGoalRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - expectedEventId
+      properties:
+        expectedEventId:
+          type: string
+          minLength: 1
     League:
       type: object
       required:
@@ -1118,6 +1264,112 @@ components:
         updatedAt:
           type: string
           format: date-time
+    GoalAuditSnapshot:
+      type: object
+      required:
+        - eventId
+        - third
+        - thirdMinute
+        - gameMinute
+        - elapsedSeconds
+        - stoppageMinute
+        - displayTime
+        - scoringTeamId
+        - concedingTeamId
+        - scorerPlayerId
+        - assistPlayerIds
+        - ownGoal
+      properties:
+        eventId:
+          type: string
+        third:
+          type: integer
+          enum:
+            - 1
+            - 2
+            - 3
+        thirdMinute:
+          type: integer
+          minimum: 1
+        gameMinute:
+          type: integer
+          minimum: 1
+        elapsedSeconds:
+          type: integer
+          minimum: 0
+        stoppageMinute:
+          type:
+            - integer
+            - "null"
+          minimum: 1
+        displayTime:
+          type: string
+        scoringTeamId:
+          type:
+            - string
+            - "null"
+          enum:
+            - red
+            - blue
+            - yellow
+            - null
+        concedingTeamId:
+          type: string
+          enum:
+            - red
+            - blue
+            - yellow
+        scorerPlayerId:
+          type: string
+        assistPlayerIds:
+          type: array
+          maxItems: 3
+          items:
+            type: string
+        ownGoal:
+          type: boolean
+    GoalAuditEntry:
+      type: object
+      required:
+        - auditId
+        - gameId
+        - eventId
+        - actorUserId
+        - action
+        - before
+        - after
+        - createdAt
+        - updatedAt
+      properties:
+        auditId:
+          type: string
+        gameId:
+          type: string
+        eventId:
+          type: string
+        actorUserId:
+          type: string
+        action:
+          type: string
+          enum:
+            - goal_created
+            - goal_updated
+            - goal_deleted
+            - goal_undo_last
+        before:
+          oneOf:
+            - $ref: "#/components/schemas/GoalAuditSnapshot"
+            - type: "null"
+        after:
+          oneOf:
+            - $ref: "#/components/schemas/GoalAuditSnapshot"
+            - type: "null"
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
     GameScoreboard:
       type: object
       required:
@@ -1142,6 +1394,45 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/GoalEvent"
+    UpdateGoalResponse:
+      type: object
+      required:
+        - goal
+        - previousGoal
+        - scoreboard
+        - timeline
+        - audit
+      properties:
+        goal:
+          $ref: "#/components/schemas/GoalEvent"
+        previousGoal:
+          $ref: "#/components/schemas/GoalEvent"
+        scoreboard:
+          $ref: "#/components/schemas/GameScoreboard"
+        timeline:
+          type: array
+          items:
+            $ref: "#/components/schemas/GoalEvent"
+        audit:
+          $ref: "#/components/schemas/GoalAuditEntry"
+    DeleteGoalResponse:
+      type: object
+      required:
+        - deletedGoal
+        - scoreboard
+        - timeline
+        - audit
+      properties:
+        deletedGoal:
+          $ref: "#/components/schemas/GoalEvent"
+        scoreboard:
+          $ref: "#/components/schemas/GameScoreboard"
+        timeline:
+          type: array
+          items:
+            $ref: "#/components/schemas/GoalEvent"
+        audit:
+          $ref: "#/components/schemas/GoalAuditEntry"
     ErrorResponse:
       type: object
       additionalProperties: true

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -56,6 +56,10 @@ gameId.
 - GoalEvent (timeline): PK=GAME#{gameId}
   SK=GOAL#{third}#{gameMinuteSortable}#{elapsedSecondsSortable}#{eventId}
 - GoalEvent id marker: PK=GAME#{gameId} SK=GOAL_EVENT#{eventId}
+- Goal correction state: PK=GAME#{gameId} SK=GOAL_STATE
+- Goal correction operation marker: PK=GAME#{gameId}
+  SK=GOAL_CORRECTION#{operationId}
+- Goal audit entry: PK=GAME#{gameId} SK=AUDIT#GOAL#{createdAt}#{auditId}
 - Roster assignment: PK=GAME#{gameId} SK=ROSTER#{teamId}#{playerId}
 - Session→Game index: PK=SESSION#{sessionId} SK=GAME#{gameStartTs}#{gameId}
 - Player: PK=PLAYER#{playerId} SK=PROFILE

--- a/infra/application/main.tf
+++ b/infra/application/main.tf
@@ -573,6 +573,7 @@ data "aws_iam_policy_document" "lambda_data_access" {
       "dynamodb:PutItem",
       "dynamodb:Query",
       "dynamodb:Scan",
+      "dynamodb:TransactWriteItems",
       "dynamodb:UpdateItem",
     ]
     resources = [

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -80,6 +80,68 @@ export interface CreateGoalResponse {
   timeline: GoalEvent[];
 }
 
+export interface UpdateGoalRequest {
+  scoringTeamId?: TeamId | null;
+  concedingTeamId?: TeamId;
+  scorerPlayerId?: string;
+  assistPlayerIds?: string[];
+  ownGoal?: boolean;
+}
+
+export interface UndoLastGoalRequest {
+  expectedEventId: string;
+}
+
+export type GoalAuditAction =
+  | "goal_created"
+  | "goal_updated"
+  | "goal_deleted"
+  | "goal_undo_last";
+
+export interface GoalAuditSnapshot {
+  eventId: string;
+  third: ThirdNumber;
+  thirdMinute: number;
+  gameMinute: number;
+  elapsedSeconds: number;
+  stoppageMinute: number | null;
+  displayTime: string;
+  scoringTeamId: TeamId | null;
+  concedingTeamId: TeamId;
+  scorerPlayerId: string;
+  assistPlayerIds: string[];
+  ownGoal: boolean;
+}
+
+export interface GoalAuditEntry {
+  auditId: string;
+  gameId: string;
+  eventId: string;
+  actorUserId: string;
+  action: GoalAuditAction;
+  before: GoalAuditSnapshot | null;
+  after: GoalAuditSnapshot | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UpdateGoalResponse {
+  goal: GoalEvent;
+  previousGoal: GoalEvent;
+  scoreboard: GameScoreboard;
+  timeline: GoalEvent[];
+  audit: GoalAuditEntry;
+}
+
+export interface DeleteGoalResponse {
+  deletedGoal: GoalEvent;
+  scoreboard: GameScoreboard;
+  timeline: GoalEvent[];
+  audit: GoalAuditEntry;
+}
+
+export type UndoLastGoalResponse = DeleteGoalResponse;
+
 export interface ThirdTimerSegment {
   third: ThirdNumber;
   startedAt: string | null;

--- a/serverless.api-core.yml
+++ b/serverless.api-core.yml
@@ -179,6 +179,21 @@ functions:
           method: OPTIONS
           path: /v1/games/{gameId}/goals
       - httpApi:
+          method: POST
+          path: /v1/games/{gameId}/goals/undo-last
+      - httpApi:
+          method: OPTIONS
+          path: /v1/games/{gameId}/goals/undo-last
+      - httpApi:
+          method: PATCH
+          path: /v1/games/{gameId}/goals/{eventId}
+      - httpApi:
+          method: DELETE
+          path: /v1/games/{gameId}/goals/{eventId}
+      - httpApi:
+          method: OPTIONS
+          path: /v1/games/{gameId}/goals/{eventId}
+      - httpApi:
           method: GET
           path: /v1/games/{gameId}/teams
       - httpApi:


### PR DESCRIPTION
<!-- review-packet-version:1 -->

## Behavioural claim

Adds M2 goal correction APIs so authenticated scorekeepers can update or undo goal events while preserving audit snapshots, normalized game scoring state, and deployed DynamoDB transaction permissions.

## Specification and acceptance evidence

| Acceptance criterion | Evidence | Result |
| --- | --- | --- |
| Goal correction and undo operations replay game state consistently from normalized goal events and audit snapshots. | `npm run test -w @3fc/api` on branch `codex/m2-04-goal-corrections` | PASS |
| Correction writes enforce scorer, assister, own-goal, authorization, and legacy-field regression cases. | `npm run test -w @3fc/api` on branch `codex/m2-04-goal-corrections` | PASS |
| Runtime IAM grants the DynamoDB transaction permission required by deployed correction writes. | `terraform fmt -check`; `terraform init -backend=false`; `terraform validate` in `infra/application` | PASS |
| Touched TypeScript packages still typecheck. | `npm run lint` on branch `codex/m2-04-goal-corrections` | PASS |

## Scope boundaries

Included: goal correction and undo API behaviour, repository consistency hardening, OpenAPI/contracts updates, serverless route wiring, table-scoped DynamoDB transaction permission for the runtime Lambda role, and API regression tests.

Excluded: live scoring UI controls, finish-game locking/result persistence, Playwright browser smoke, join-code player registration, broader IAM role redesign, and data migration.

## Change classification

- Declared risk: `high`
- [ ] `documentation-only` - Documentation only
- [ ] `tests-only` - Tests only
- [x] `application-behaviour` - Application or API behaviour
- [ ] `backlog-maintenance` - Canonical backlog maintenance
- [ ] `dependency-tooling` - Dependency or tooling
- [x] `public-contract` - Public API or repository contract
- [ ] `data-migration` - Database schema or data migration
- [x] `permission-trust-boundary` - Permission or trust boundary
- [x] `durable-state-ownership` - Durable state or ownership
- [ ] `destructive-behaviour` - Destructive or difficult-to-reverse behaviour
- [ ] `new-production-dependency` - New production dependency
- [ ] `authentication-authorisation` - Authentication or authorisation
- [ ] `privacy-regulated-data` - Privacy or regulated data
- [x] `infrastructure-production-configuration` - Infrastructure or deployment control
- [ ] `review-policy` - Review policy, packet, or workflow

## Architecture and invariants

- [ ] `architecture:none`
- [x] `architecture:documented`
- [ ] `architecture:judgement-required`

### Affected invariants

| Invariant | How this PR affects it | Why it remains valid | Evidence |
| --- | --- | --- | --- |
| INV-002 | Adds protected scorekeeper write routes for goal correction, deletion, and undo, and grants the deployed Lambda role the table-scoped transaction action those writes require. | Each mutation still uses existing session and league-scoped scorekeeper authorization before touching goal state; the IAM addition is scoped to the existing app table resources. | `npm run test -w @3fc/api`; `terraform validate`; `api/src/tests/acl.test.ts`; `api/src/tests/lambda-core.test.ts`; `infra/application/main.tf` |
| INV-003 | Extends idempotent write handling to correction and undo-style goal mutations where the contract marks writes idempotent. | Matching replay returns the stored mutation result and conflicting key reuse is rejected without applying duplicate corrections. | `npm run test -w @3fc/api`; `api/src/tests/lambda-core.test.ts`; `api/src/tests/repository.test.ts` |
| INV-004 | Adds corrected/deleted goal state and audit snapshots to the documented game-owned event storage model. | Corrected events, audit snapshots, recalculated game state, and transaction permissions remain addressed through the documented game-owned table resources. | `npm run test -w @3fc/api`; `terraform validate`; `docs/dynamodb-single-table.md`; `api/src/tests/repository.test.ts` |
| INV-005 | Recomputes team `scored` and `conceded` when goals are edited, deleted, or undone. | Own-goal corrections and undo preserve the distinction between team scored and conceded tallies. | `npm run test -w @3fc/api`; `api/src/tests/lambda-core.test.ts`; `api/src/tests/repository.test.ts` |
| INV-008 | Revalidates scorer and assister combinations during goal edits and preserves those rules after undo/delete. | Corrections still enforce max three unique assisters, scorer exclusion, and rostered-player assist eligibility. | `npm run test -w @3fc/api`; `api/src/tests/lambda-core.test.ts` |

### Architecture or decision record

Correction and undo behaviour follows the existing event/state ownership described in `docs/spec.md`, `docs/dynamodb-single-table.md`, `docs/openapi/v1-core-write.yaml`, and `docs/architecture/invariants.md`. The deployed transaction permission is the existing Terraform-managed Lambda execution role in `infra/application/main.tf` and is scoped to the app DynamoDB table resources already used by the API.

## Failure and rollback

### Failure behaviour

Invalid correction payloads fail validation, unauthorized/cross-league writes fail before persistence, idempotency conflicts are rejected, failed correction transactions do not commit partial state, and deployed correction writes have the table-scoped DynamoDB transaction permission needed to avoid runtime `AccessDeniedException`.

### Rollback approach

Revert the merge commit for this PR and redeploy the previous main release; no data migration or irreversible state transformation is introduced. The IAM permission rolls back with the Terraform application module state.

### Rollback evidence

The PR adds correction/undo code paths and a table-scoped IAM action without schema migration; `npm run test -w @3fc/api`, `npm run lint`, and `terraform validate` pass on the branch.

## Automated and agent review disposition

### Unresolved blocking findings

None.

### Rejected findings and evidence

None.

## Human judgement

- [x] `human-judgement:none`
- [ ] `human-judgement:required`

### Decision requiring judgement

None.

### Options considered

None.

### Reason selected

None.

### Reversal cost

None.

## Review focus

Please inspect the undo/correction ordering, audit snapshot normalization, table-scoped DynamoDB transaction permission, and whether corrected own-goal or assister combinations preserve aggregate scoring invariants.
