### PR TITLE
[codex] Add M2 Playwright smoke

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -23,6 +23,9 @@ permissions:
   id-token: write
   contents: read
 
+env:
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
+
 jobs:
   deploy:
     name: deploy-prod

--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -15,6 +15,9 @@ permissions:
   id-token: write
   contents: read
 
+env:
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
+
 jobs:
   deploy:
     name: deploy-qa

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -12,6 +12,9 @@ concurrency:
   group: pr-checks-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+env:
+  PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
+
 jobs:
   lint:
     name: lint

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,13 @@ coverage
 node_modules/
 dist/
 dist-tests/
+playwright-report/
+test-results/
+
+# Keep repo-owned browser specs visible even if a developer has broad global ignores.
+!tests/
+!tests/e2e/
+!tests/e2e/*.spec.ts
 
 # Optional npm cache directory
 .npm

--- a/api/src/tests/http-security.test.ts
+++ b/api/src/tests/http-security.test.ts
@@ -44,6 +44,7 @@ test("CORS headers are returned only for allowed origins", () => {
     allowed["Access-Control-Allow-Headers"],
     "content-type,x-csrf-token,idempotency-key",
   );
+  assert.match(allowed["Access-Control-Allow-Methods"], /\bPUT\b/);
 
   const denied = buildCorsHeaders("https://evil.example", allowlist);
   assert.deepEqual(denied, {});

--- a/compose.yaml
+++ b/compose.yaml
@@ -45,6 +45,10 @@ services:
       DYNAMODB_TABLE: "threefc_local"
       FAKE_SES_URL: "http://fake-ses:4025/send-email"
       FAKE_SES_FROM: "dev@3fc.football"
+      MAGIC_LINK_RATE_LIMIT_EMAIL_MAX_ATTEMPTS: "50"
+      MAGIC_LINK_RATE_LIMIT_EMAIL_WINDOW_SECONDS: "300"
+      MAGIC_LINK_RATE_LIMIT_IP_MAX_ATTEMPTS: "200"
+      MAGIC_LINK_RATE_LIMIT_IP_WINDOW_SECONDS: "300"
     depends_on:
       - dynamodb
       - fake-ses

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -62,6 +62,41 @@ curl -s -X POST http://localhost:3001/v1/dev/send-email \
 curl -s http://localhost:4025/messages
 ```
 
+### M2 browser smoke
+
+The M2 Playwright smoke runs the real browser flow against the local stack:
+magic-link sign-in, league/season/game setup, player creation and assignment,
+goal scoring, third completion, and game finish.
+
+First-time setup may need Docker images and the Playwright Chromium runtime:
+
+```bash
+docker compose pull
+npx playwright install chromium
+```
+
+```bash
+npm run smoke:m2:playwright
+```
+
+By default the Playwright config starts `make dev` and waits for the app health
+endpoint. To run against an already-started local stack:
+
+```bash
+THREEFC_SKIP_WEB_SERVER=1 npm run smoke:m2:playwright
+```
+
+Useful overrides:
+
+- `PLAYWRIGHT_BASE_URL`: app URL, default `http://localhost:3000`
+- `THREEFC_API_BASE_URL`: API URL, default `http://localhost:3001`
+- `THREEFC_FAKE_SES_BASE_URL`: fake SES URL, default `http://localhost:4025`
+- `THREEFC_WEB_SERVER_COMMAND`: command Playwright uses to start the stack, default `make dev`
+
+If `PLAYWRIGHT_BASE_URL` points anywhere other than the default app origin, make
+sure the API is started with matching `APP_BASE_URL` and `CORS_ALLOWED_ORIGINS`
+values, and that the app is started with the matching `API_BASE_URL`.
+
 ### Magic-link auth flow (local)
 
 Start flow (sends link to fake SES):

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "app"
       ],
       "devDependencies": {
+        "@playwright/test": "^1.61.0",
         "@types/jsdom": "^28.0.1",
         "@types/node": "^22.13.14",
         "esbuild": "^0.27.3",
@@ -2089,6 +2090,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@smithy/abort-controller": {
@@ -4586,6 +4603,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -19,11 +19,13 @@
     "test:review-gate": "npm run review-policy:check && node --test scripts/review-gate/tests/*.test.mjs",
     "review-policy:check": "node scripts/review-gate/validate-policy.mjs",
     "smoke:m2": "npm run smoke:m2 -w @3fc/app",
+    "smoke:m2:playwright": "playwright test --config=playwright.config.ts",
     "contracts:check": "npm run build -w @3fc/contracts && npm run test -w @3fc/contracts",
     "typecheck": "npm run build -w @3fc/contracts && npm run typecheck --workspaces",
     "clean": "npm run clean --workspaces --if-present"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.0",
     "@types/jsdom": "^28.0.1",
     "@types/node": "^22.13.14",
     "esbuild": "^0.27.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ const skipWebServer = process.env.THREEFC_SKIP_WEB_SERVER === "1";
 
 export default defineConfig({
   testDir: "./tests/e2e",
-  timeout: 60_000,
+  timeout: 180_000,
   expect: {
     timeout: 10_000,
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const appBaseUrl = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000";
+const skipWebServer = process.env.THREEFC_SKIP_WEB_SERVER === "1";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  timeout: 60_000,
+  expect: {
+    timeout: 10_000,
+  },
+  reporter: [["list"], ["html", { open: "never" }]],
+  use: {
+    baseURL: appBaseUrl,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  webServer: skipWebServer
+    ? undefined
+    : {
+        command: process.env.THREEFC_WEB_SERVER_COMMAND ?? "make dev",
+        url: `${appBaseUrl}/health`,
+        reuseExistingServer: process.env.CI !== "true",
+        timeout: 600_000,
+      },
+  projects: [
+    {
+      name: "chromium-mobile",
+      use: {
+        ...devices["Pixel 7"],
+      },
+    },
+  ],
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from "@playwright/test";
 
 const appBaseUrl = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3000";
 const skipWebServer = process.env.THREEFC_SKIP_WEB_SERVER === "1";
+const isCi = Boolean(process.env.CI);
 
 export default defineConfig({
   testDir: "./tests/e2e",
@@ -20,7 +21,7 @@ export default defineConfig({
     : {
         command: process.env.THREEFC_WEB_SERVER_COMMAND ?? "make dev",
         url: `${appBaseUrl}/health`,
-        reuseExistingServer: process.env.CI !== "true",
+        reuseExistingServer: !isCi,
         timeout: 600_000,
       },
   projects: [

--- a/scripts/local/fake-ses-server.mjs
+++ b/scripts/local/fake-ses-server.mjs
@@ -5,6 +5,16 @@ import { createServer } from "node:http";
 
 const PORT = Number.parseInt(process.env.FAKE_SES_PORT ?? "4025", 10);
 const LOG_FILE = process.env.FAKE_SES_LOG_FILE ?? "/data/emails.jsonl";
+let messageLogQueue = Promise.resolve();
+
+async function withMessageLogLock(operation) {
+  const run = messageLogQueue.then(operation, operation);
+  messageLogQueue = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  return run;
+}
 
 async function parseJsonBody(request) {
   const chunks = [];
@@ -25,41 +35,53 @@ function sendJson(response, statusCode, payload) {
 }
 
 async function appendMessage(payload) {
-  await mkdir(dirname(LOG_FILE), { recursive: true });
+  return withMessageLogLock(async () => {
+    await mkdir(dirname(LOG_FILE), { recursive: true });
 
-  const message = {
-    messageId: randomUUID(),
-    receivedAt: new Date().toISOString(),
-    ...payload,
-  };
+    const message = {
+      messageId: randomUUID(),
+      receivedAt: new Date().toISOString(),
+      ...payload,
+    };
 
-  await appendFile(LOG_FILE, `${JSON.stringify(message)}\n`, "utf8");
+    await appendFile(LOG_FILE, `${JSON.stringify(message)}\n`, "utf8");
 
-  return message;
+    return message;
+  });
 }
 
-async function listMessages() {
+async function readMessagesFromFile() {
   try {
     const content = await readFile(LOG_FILE, "utf8");
     return content
       .split("\n")
       .filter((line) => line.trim().length > 0)
       .map((line) => JSON.parse(line));
-  } catch {
-    return [];
+  } catch (error) {
+    if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+      return [];
+    }
+
+    throw error;
   }
 }
 
+async function listMessages() {
+  return withMessageLogLock(() => readMessagesFromFile());
+}
+
 async function deleteMessagesForRecipient(to) {
-  const messages = await listMessages();
-  const retained = messages.filter((message) => message?.to !== to);
-  await mkdir(dirname(LOG_FILE), { recursive: true });
-  await writeFile(
-    LOG_FILE,
-    retained.length > 0 ? `${retained.map((message) => JSON.stringify(message)).join("\n")}\n` : "",
-    "utf8",
-  );
-  return messages.length - retained.length;
+  return withMessageLogLock(async () => {
+    const messages = await readMessagesFromFile();
+    const retained = messages.filter((message) => message?.to !== to);
+    await mkdir(dirname(LOG_FILE), { recursive: true });
+    await writeFile(
+      LOG_FILE,
+      retained.length > 0 ? `${retained.map((message) => JSON.stringify(message)).join("\n")}\n` : "",
+      "utf8",
+    );
+    return messages.length - retained.length;
+  });
 }
 
 const server = createServer(async (request, response) => {

--- a/scripts/local/fake-ses-server.mjs
+++ b/scripts/local/fake-ses-server.mjs
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { mkdir, appendFile, readFile } from "node:fs/promises";
+import { mkdir, appendFile, readFile, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { createServer } from "node:http";
 
@@ -50,6 +50,18 @@ async function listMessages() {
   }
 }
 
+async function deleteMessagesForRecipient(to) {
+  const messages = await listMessages();
+  const retained = messages.filter((message) => message?.to !== to);
+  await mkdir(dirname(LOG_FILE), { recursive: true });
+  await writeFile(
+    LOG_FILE,
+    retained.length > 0 ? `${retained.map((message) => JSON.stringify(message)).join("\n")}\n` : "",
+    "utf8",
+  );
+  return messages.length - retained.length;
+}
+
 const server = createServer(async (request, response) => {
   const method = request.method ?? "GET";
   const url = request.url ?? "/";
@@ -62,6 +74,22 @@ const server = createServer(async (request, response) => {
 
     if (method === "GET" && url === "/messages") {
       sendJson(response, 200, { messages: await listMessages() });
+      return;
+    }
+
+    if (method === "DELETE" && url.startsWith("/messages")) {
+      const requestUrl = new URL(url, "http://localhost");
+      const to = requestUrl.searchParams.get("to");
+      if (!to) {
+        sendJson(response, 400, {
+          error: "Missing required `to` query parameter.",
+        });
+        return;
+      }
+
+      sendJson(response, 200, {
+        deleted: await deleteMessagesForRecipient(to),
+      });
       return;
     }
 

--- a/tests/e2e/m2-smoke.spec.ts
+++ b/tests/e2e/m2-smoke.spec.ts
@@ -322,6 +322,18 @@ function touchedAuthRateLimitKeys(
   return totalIncrease === 1 ? increased.map(({ pk, sk }) => ({ pk, sk })) : [];
 }
 
+function smokeOwnedAuthRateLimitKeys(input: {
+  rateLimitConsumed: boolean;
+  before: AuthRateLimitSnapshot[];
+  after: AuthRateLimitSnapshot[];
+}): DynamoItemKey[] {
+  if (!input.rateLimitConsumed) {
+    return [];
+  }
+
+  return touchedAuthRateLimitKeys(input.before, input.after);
+}
+
 function isConditionalCheckFailure(error: unknown): boolean {
   return (
     typeof error === "object" &&
@@ -764,7 +776,7 @@ test("smoke cleanup removes run-owned records without deleting unrelated session
   expect(destroyed).toBe(true);
 });
 
-test("smoke cleanup detects touched IP rate-limit buckets without known client addresses", async () => {
+test("smoke cleanup detects consumed IP rate-limit buckets without known client addresses", async () => {
   const beforeClient: DynamoClientLike = {
     async send(command) {
       expect(command).toBeInstanceOf(ScanCommand);
@@ -831,21 +843,43 @@ test("smoke cleanup detects touched IP rate-limit buckets without known client a
       attemptCount: 4,
     },
   ]);
-  expect(touchedAuthRateLimitKeys(before, after)).toEqual([
+  expect(smokeOwnedAuthRateLimitKeys({ rateLimitConsumed: true, before, after })).toEqual([
     {
       pk: "AUTH_RATE_LIMIT#magic-link-start#ip#docker-bridge-hash#bucket",
       sk: "METADATA",
     },
   ]);
   expect(
-    touchedAuthRateLimitKeys(before, [
-      ...after,
-      {
-        pk: "AUTH_RATE_LIMIT#magic-link-start#ip#concurrent-hash#bucket",
-        sk: "METADATA",
-        attemptCount: 1,
-      },
-    ]),
+    smokeOwnedAuthRateLimitKeys({
+      rateLimitConsumed: true,
+      before,
+      after: [
+        ...after,
+        {
+          pk: "AUTH_RATE_LIMIT#magic-link-start#ip#concurrent-hash#bucket",
+          sk: "METADATA",
+          attemptCount: 1,
+        },
+      ],
+    }),
+  ).toEqual([]);
+  expect(
+    smokeOwnedAuthRateLimitKeys({
+      rateLimitConsumed: false,
+      before,
+      after: [
+        {
+          pk: "AUTH_RATE_LIMIT#magic-link-start#ip#docker-bridge-hash#bucket",
+          sk: "METADATA",
+          attemptCount: 2,
+        },
+        {
+          pk: "AUTH_RATE_LIMIT#magic-link-start#ip#unrelated-hash#bucket",
+          sk: "METADATA",
+          attemptCount: 5,
+        },
+      ],
+    }),
   ).toEqual([]);
 });
 
@@ -869,7 +903,7 @@ test.describe("M2 local-stack smoke", () => {
     let gameId = "";
     const playerIds: string[] = [];
     const initialIpRateLimits = await snapshotLocalAuthRateLimits({ dimension: "ip" });
-    let magicLinkStartReachedApi = false;
+    let magicLinkStartConsumedRateLimit = false;
 
     let testFailed = false;
     try {
@@ -882,7 +916,7 @@ test.describe("M2 local-stack smoke", () => {
       );
       await page.getByTestId("send-magic-link").click();
       const magicStartResponse = await magicStartResponsePromise;
-      magicLinkStartReachedApi = magicStartResponse.status() > 0;
+      magicLinkStartConsumedRateLimit = magicStartResponse.status() === 202;
       await expect(page.locator("#auth-status")).toContainText("Magic link sent");
 
       const magicLink = await waitForMagicLink(email);
@@ -971,7 +1005,7 @@ test.describe("M2 local-stack smoke", () => {
       throw error;
     } finally {
       try {
-        const currentIpRateLimits = magicLinkStartReachedApi
+        const currentIpRateLimits = magicLinkStartConsumedRateLimit
           ? await snapshotLocalAuthRateLimits({ dimension: "ip" })
           : [];
         await cleanupSmokeRun({
@@ -982,7 +1016,11 @@ test.describe("M2 local-stack smoke", () => {
           gameId,
           sessionId,
           playerIds,
-          ipRateLimitKeys: touchedAuthRateLimitKeys(initialIpRateLimits, currentIpRateLimits),
+          ipRateLimitKeys: smokeOwnedAuthRateLimitKeys({
+            rateLimitConsumed: magicLinkStartConsumedRateLimit,
+            before: initialIpRateLimits,
+            after: currentIpRateLimits,
+          }),
         });
       } catch (error) {
         if (!testFailed) {

--- a/tests/e2e/m2-smoke.spec.ts
+++ b/tests/e2e/m2-smoke.spec.ts
@@ -61,12 +61,14 @@ interface SmokeRunCleanupDependencies {
   deleteFakeSesMessages?: (email: string) => Promise<void>;
 }
 
-const localBrowserClientIpCandidates = ["::1", "::ffff:127.0.0.1", "127.0.0.1", "unknown"];
-
 function authRateLimitHash(dimension: RateLimitDimension, identifier: string): string {
   return createHash("sha256")
     .update(`magic-link-start:${dimension}:${identifier}`, "utf8")
     .digest("hex");
+}
+
+function authRateLimitDimensionPkPrefix(dimension: RateLimitDimension): string {
+  return ["AUTH_RATE_LIMIT", "magic-link-start", dimension, ""].join("#");
 }
 
 function authRateLimitPkPrefix(dimension: RateLimitDimension, identifier: string): string {
@@ -235,6 +237,33 @@ async function scanAuthRateLimitItemsForIdentifiers(
   return items;
 }
 
+async function scanAuthRateLimitItemsForDimension(
+  client: DynamoClientLike,
+  dimension: RateLimitDimension,
+): Promise<DynamoItem[]> {
+  const prefix = authRateLimitDimensionPkPrefix(dimension);
+  const items: DynamoItem[] = [];
+  let exclusiveStartKey: Record<string, AttributeValue> | undefined;
+
+  do {
+    const response = await client.send(
+      new ScanCommand({
+        TableName: dynamodbTableName,
+        ExclusiveStartKey: exclusiveStartKey,
+      }),
+    );
+    items.push(
+      ...((response.Items ?? []) as DynamoItem[]).filter((item) => {
+        const pk = item.pk?.S ?? "";
+        return item.sk?.S === "METADATA" && pk.startsWith(prefix);
+      }),
+    );
+    exclusiveStartKey = response.LastEvaluatedKey;
+  } while (exclusiveStartKey);
+
+  return items;
+}
+
 async function scanAuthRateLimitItems(
   client: DynamoClientLike,
   input: { email: string },
@@ -247,9 +276,14 @@ async function scanAuthRateLimitItems(
 
 async function scanAuthRateLimitSnapshots(
   client: DynamoClientLike,
-  input: { dimension: RateLimitDimension; identifiers: string[] },
+  input: { dimension: RateLimitDimension; identifiers?: string[] },
 ): Promise<AuthRateLimitSnapshot[]> {
-  const items = await scanAuthRateLimitItemsForIdentifiers(client, input);
+  const items = input.identifiers
+    ? await scanAuthRateLimitItemsForIdentifiers(client, {
+        dimension: input.dimension,
+        identifiers: input.identifiers,
+      })
+    : await scanAuthRateLimitItemsForDimension(client, input.dimension);
   return items
     .map((item) => {
       const key = itemKey(item);
@@ -260,7 +294,7 @@ async function scanAuthRateLimitSnapshots(
 
 async function snapshotLocalAuthRateLimits(input: {
   dimension: RateLimitDimension;
-  identifiers: string[];
+  identifiers?: string[];
 }): Promise<AuthRateLimitSnapshot[]> {
   const client = createLocalDynamoClient();
   try {
@@ -277,9 +311,15 @@ function touchedAuthRateLimitKeys(
   const beforeByKey = new Map(
     before.map((snapshot) => [authRateLimitSnapshotKey(snapshot), snapshot.attemptCount]),
   );
-  return after
-    .filter((snapshot) => snapshot.attemptCount > (beforeByKey.get(authRateLimitSnapshotKey(snapshot)) ?? 0))
-    .map(({ pk, sk }) => ({ pk, sk }));
+  const increased = after
+    .map((snapshot) => ({
+      pk: snapshot.pk,
+      sk: snapshot.sk,
+      increase: snapshot.attemptCount - (beforeByKey.get(authRateLimitSnapshotKey(snapshot)) ?? 0),
+    }))
+    .filter((snapshot) => snapshot.increase > 0);
+  const totalIncrease = increased.reduce((sum, snapshot) => sum + snapshot.increase, 0);
+  return totalIncrease === 1 ? increased.map(({ pk, sk }) => ({ pk, sk })) : [];
 }
 
 function isConditionalCheckFailure(error: unknown): boolean {
@@ -724,6 +764,91 @@ test("smoke cleanup removes run-owned records without deleting unrelated session
   expect(destroyed).toBe(true);
 });
 
+test("smoke cleanup detects touched IP rate-limit buckets without known client addresses", async () => {
+  const beforeClient: DynamoClientLike = {
+    async send(command) {
+      expect(command).toBeInstanceOf(ScanCommand);
+      return {
+        Items: [
+          {
+            pk: { S: "AUTH_RATE_LIMIT#magic-link-start#ip#docker-bridge-hash#bucket" },
+            sk: { S: "METADATA" },
+            attemptCount: { N: "2" },
+          },
+          {
+            pk: { S: "AUTH_RATE_LIMIT#magic-link-start#ip#unrelated-hash#bucket" },
+            sk: { S: "METADATA" },
+            attemptCount: { N: "4" },
+          },
+          {
+            pk: { S: "AUTH_RATE_LIMIT#magic-link-start#email#email-hash#bucket" },
+            sk: { S: "METADATA" },
+            attemptCount: { N: "9" },
+          },
+        ],
+      };
+    },
+    destroy() {},
+  };
+  const afterClient: DynamoClientLike = {
+    async send(command) {
+      expect(command).toBeInstanceOf(ScanCommand);
+      return {
+        Items: [
+          {
+            pk: { S: "AUTH_RATE_LIMIT#magic-link-start#ip#docker-bridge-hash#bucket" },
+            sk: { S: "METADATA" },
+            attemptCount: { N: "3" },
+          },
+          {
+            pk: { S: "AUTH_RATE_LIMIT#magic-link-start#ip#unrelated-hash#bucket" },
+            sk: { S: "METADATA" },
+            attemptCount: { N: "4" },
+          },
+          {
+            pk: { S: "AUTH_RATE_LIMIT#magic-link-start#email#email-hash#bucket" },
+            sk: { S: "METADATA" },
+            attemptCount: { N: "10" },
+          },
+        ],
+      };
+    },
+    destroy() {},
+  };
+
+  const before = await scanAuthRateLimitSnapshots(beforeClient, { dimension: "ip" });
+  const after = await scanAuthRateLimitSnapshots(afterClient, { dimension: "ip" });
+
+  expect(before).toEqual([
+    {
+      pk: "AUTH_RATE_LIMIT#magic-link-start#ip#docker-bridge-hash#bucket",
+      sk: "METADATA",
+      attemptCount: 2,
+    },
+    {
+      pk: "AUTH_RATE_LIMIT#magic-link-start#ip#unrelated-hash#bucket",
+      sk: "METADATA",
+      attemptCount: 4,
+    },
+  ]);
+  expect(touchedAuthRateLimitKeys(before, after)).toEqual([
+    {
+      pk: "AUTH_RATE_LIMIT#magic-link-start#ip#docker-bridge-hash#bucket",
+      sk: "METADATA",
+    },
+  ]);
+  expect(
+    touchedAuthRateLimitKeys(before, [
+      ...after,
+      {
+        pk: "AUTH_RATE_LIMIT#magic-link-start#ip#concurrent-hash#bucket",
+        sk: "METADATA",
+        attemptCount: 1,
+      },
+    ]),
+  ).toEqual([]);
+});
+
 test.describe("M2 local-stack smoke", () => {
   test.beforeEach(async () => {
     await waitForHealthy(`${apiBaseUrl}/v1/health`);
@@ -743,10 +868,7 @@ test.describe("M2 local-stack smoke", () => {
     const sessionId = sessionIdForGameDate(schedule.gameDate);
     let gameId = "";
     const playerIds: string[] = [];
-    const initialIpRateLimits = await snapshotLocalAuthRateLimits({
-      dimension: "ip",
-      identifiers: localBrowserClientIpCandidates,
-    });
+    const initialIpRateLimits = await snapshotLocalAuthRateLimits({ dimension: "ip" });
     let magicLinkStartReachedApi = false;
 
     let testFailed = false;
@@ -850,10 +972,7 @@ test.describe("M2 local-stack smoke", () => {
     } finally {
       try {
         const currentIpRateLimits = magicLinkStartReachedApi
-          ? await snapshotLocalAuthRateLimits({
-              dimension: "ip",
-              identifiers: localBrowserClientIpCandidates,
-            })
+          ? await snapshotLocalAuthRateLimits({ dimension: "ip" })
           : [];
         await cleanupSmokeRun({
           runId,

--- a/tests/e2e/m2-smoke.spec.ts
+++ b/tests/e2e/m2-smoke.spec.ts
@@ -23,6 +23,7 @@ type DynamoItem = Record<string, AttributeValue>;
 
 interface SmokeRunCleanupInput {
   runId: string;
+  email: string;
   leagueSlug: string;
   seasonSlug: string;
   gameId: string;
@@ -218,16 +219,18 @@ async function cleanupSmokeRun(input: SmokeRunCleanupInput): Promise<void> {
         [input.runId, input.leagueSlug, input.seasonSlug, input.gameId].filter(Boolean),
       ),
     );
+
+    await deleteFakeSesMessages(input.email);
   } finally {
     client.destroy();
   }
 }
 
-async function fetchWithTimeout(url: string): Promise<Response> {
+async function fetchWithTimeout(url: string, init: RequestInit = {}): Promise<Response> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), fetchTimeoutMs);
   try {
-    return await fetch(url, { signal: controller.signal });
+    return await fetch(url, { ...init, signal: controller.signal });
   } finally {
     clearTimeout(timeout);
   }
@@ -257,6 +260,16 @@ async function readFakeSesMessages(): Promise<FakeSesMessage[]> {
 
   const payload = (await response.json()) as { messages?: FakeSesMessage[] };
   return Array.isArray(payload.messages) ? payload.messages : [];
+}
+
+async function deleteFakeSesMessages(email: string): Promise<void> {
+  const response = await fetchWithTimeout(
+    `${fakeSesBaseUrl}/messages?to=${encodeURIComponent(email)}`,
+    { method: "DELETE" },
+  );
+  if (!response.ok) {
+    throw new Error(`Fake SES message cleanup failed with ${response.status}.`);
+  }
 }
 
 function extractMagicLink(message: FakeSesMessage): string | null {
@@ -347,6 +360,8 @@ test.describe("M2 local-stack smoke", () => {
     const seasonSlug = `m2-smoke-season-${runId}`;
     const leagueName = `M2 Smoke League ${runId}`;
     const seasonName = `M2 Smoke Season ${runId}`;
+    const ariNickname = `Ari ${runId}`;
+    const beaNickname = `Bea ${runId}`;
     const schedule = scheduleForRun(runId);
     const sessionId = schedule.gameDate.replaceAll("-", "");
     let gameId = "";
@@ -402,10 +417,10 @@ test.describe("M2 local-stack smoke", () => {
       await expect(page.getByTestId("game-shell")).toBeVisible();
       await expect(page.locator("#game-id-value")).toHaveText(gameId);
 
-      const ariPlayerId = await createAndAssignPlayer(page, "Ari", "red", (playerId) => {
+      const ariPlayerId = await createAndAssignPlayer(page, ariNickname, "red", (playerId) => {
         playerIds.push(playerId);
       });
-      const beaPlayerId = await createAndAssignPlayer(page, "Bea", "blue", (playerId) => {
+      const beaPlayerId = await createAndAssignPlayer(page, beaNickname, "blue", (playerId) => {
         playerIds.push(playerId);
       });
 
@@ -416,8 +431,8 @@ test.describe("M2 local-stack smoke", () => {
       await page.locator(`#goal-assists input[value="${beaPlayerId}"]`).check();
       await page.getByTestId("add-goal").click();
 
-      await expect(page.getByTestId("goal-timeline")).toContainText("Ari for Red");
-      await expect(page.getByTestId("goal-timeline")).toContainText("Assists: Bea");
+      await expect(page.getByTestId("goal-timeline")).toContainText(`${ariNickname} for Red`);
+      await expect(page.getByTestId("goal-timeline")).toContainText(`Assists: ${beaNickname}`);
       await expect(page.locator('[data-ui="score-team"][data-team-id="red"]')).toContainText(/Scored\s*1/);
       await expect(page.locator('[data-ui="score-team"][data-team-id="blue"]')).toContainText(/Conceded\s*1/);
 
@@ -453,6 +468,7 @@ test.describe("M2 local-stack smoke", () => {
       try {
         await cleanupSmokeRun({
           runId,
+          email,
           leagueSlug,
           seasonSlug,
           gameId,

--- a/tests/e2e/m2-smoke.spec.ts
+++ b/tests/e2e/m2-smoke.spec.ts
@@ -1,7 +1,6 @@
 import {
   DeleteItemCommand,
   DynamoDBClient,
-  PutItemCommand,
   QueryCommand,
   ScanCommand,
   type AttributeValue,
@@ -30,7 +29,6 @@ interface SmokeRunCleanupInput {
   gameId: string;
   sessionId: string;
   playerIds: string[];
-  originalSessionMetadata: DynamoItem | null;
 }
 
 function authRateLimitHash(dimension: "email" | "ip", identifier: string): string {
@@ -92,10 +90,6 @@ function itemSearchText(item: DynamoItem): string {
     .join("\n");
 }
 
-function cloneDynamoItem(item: DynamoItem): DynamoItem {
-  return structuredClone(item) as DynamoItem;
-}
-
 async function queryPartition(client: DynamoDBClient, pk: string): Promise<DynamoItem[]> {
   const items: DynamoItem[] = [];
   let exclusiveStartKey: Record<string, AttributeValue> | undefined;
@@ -116,16 +110,6 @@ async function queryPartition(client: DynamoDBClient, pk: string): Promise<Dynam
   } while (exclusiveStartKey);
 
   return items;
-}
-
-async function readSessionMetadataSnapshot(
-  client: DynamoDBClient,
-  sessionId: string,
-): Promise<DynamoItem | null> {
-  const metadata = (await queryPartition(client, `SESSION#${sessionId}`)).find(
-    (item) => item.sk?.S === "METADATA",
-  );
-  return metadata ? cloneDynamoItem(metadata) : null;
 }
 
 async function scanTaggedItems(client: DynamoDBClient, needles: string[]): Promise<DynamoItem[]> {
@@ -209,15 +193,6 @@ async function deleteItems(client: DynamoDBClient, items: DynamoItem[]): Promise
   }
 }
 
-async function putItem(client: DynamoDBClient, item: DynamoItem): Promise<void> {
-  await client.send(
-    new PutItemCommand({
-      TableName: dynamodbTableName,
-      Item: cloneDynamoItem(item),
-    }),
-  );
-}
-
 async function cleanupSmokeRun(input: SmokeRunCleanupInput): Promise<void> {
   if (process.env.THREEFC_SKIP_SMOKE_CLEANUP === "1") {
     return;
@@ -225,6 +200,7 @@ async function cleanupSmokeRun(input: SmokeRunCleanupInput): Promise<void> {
 
   const client = createLocalDynamoClient();
   try {
+    const runNeedles = [input.runId, input.leagueSlug, input.seasonSlug, input.gameId].filter(Boolean);
     const partitions = [
       `LEAGUE#${input.leagueSlug}`,
       `SEASON#${input.seasonSlug}`,
@@ -248,21 +224,25 @@ async function cleanupSmokeRun(input: SmokeRunCleanupInput): Promise<void> {
       );
 
       const remainingSessionItems = await queryPartition(client, sessionPk);
-      await deleteItems(
-        client,
-        remainingSessionItems.filter((item) => item.sk?.S === "METADATA"),
+      const remainingSessionGameItems = remainingSessionItems.filter((item) =>
+        (item.sk?.S ?? "").startsWith("GAME#"),
       );
-      if (input.originalSessionMetadata) {
-        await putItem(client, input.originalSessionMetadata);
+      const currentSessionMetadata = remainingSessionItems.find((item) => item.sk?.S === "METADATA");
+      const metadataBelongsToRun = currentSessionMetadata
+        ? runNeedles.some((needle) => itemSearchText(currentSessionMetadata).includes(needle))
+        : false;
+      if (currentSessionMetadata && metadataBelongsToRun && remainingSessionGameItems.length === 0) {
+        await deleteItems(client, [currentSessionMetadata]);
       }
     }
 
+    const taggedItems = await scanTaggedItems(client, runNeedles);
     await deleteItems(
       client,
-      await scanTaggedItems(
-        client,
-        [input.runId, input.leagueSlug, input.seasonSlug, input.gameId].filter(Boolean),
-      ),
+      taggedItems.filter((item) => {
+        const key = itemKey(item);
+        return !(key?.pk === `SESSION#${input.sessionId}` && key.sk === "METADATA");
+      }),
     );
     await deleteItems(client, await scanAuthRateLimitItems(client, input));
 
@@ -412,13 +392,6 @@ test.describe("M2 local-stack smoke", () => {
     const sessionId = schedule.gameDate.replaceAll("-", "");
     let gameId = "";
     const playerIds: string[] = [];
-    const snapshotClient = createLocalDynamoClient();
-    let originalSessionMetadata: DynamoItem | null = null;
-    try {
-      originalSessionMetadata = await readSessionMetadataSnapshot(snapshotClient, sessionId);
-    } finally {
-      snapshotClient.destroy();
-    }
 
     let testFailed = false;
     try {
@@ -520,7 +493,6 @@ test.describe("M2 local-stack smoke", () => {
           gameId,
           sessionId,
           playerIds,
-          originalSessionMetadata,
         });
       } catch (error) {
         if (!testFailed) {

--- a/tests/e2e/m2-smoke.spec.ts
+++ b/tests/e2e/m2-smoke.spec.ts
@@ -13,6 +13,20 @@ function uniqueRunId(): string {
   return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
+function scheduleForRun(runId: string): { gameDate: string; kickoff: string } {
+  const hash = [...runId].reduce((value, character) => {
+    return (value * 33 + character.charCodeAt(0)) >>> 0;
+  }, 5381);
+  const date = new Date(Date.UTC(2027, 0, 1));
+  date.setUTCDate(date.getUTCDate() + (hash % 20_000));
+  const gameDate = date.toISOString().slice(0, 10);
+  const hour = 8 + (hash % 10);
+  const minute = [0, 15, 30, 45][Math.floor(hash / 10) % 4];
+  const kickoff = `${gameDate}T${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
+
+  return { gameDate, kickoff };
+}
+
 async function fetchWithTimeout(url: string): Promise<Response> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), fetchTimeoutMs);
@@ -131,6 +145,7 @@ test.describe("M2 local-stack smoke", () => {
     const seasonSlug = `m2-smoke-season-${runId}`;
     const leagueName = `M2 Smoke League ${runId}`;
     const seasonName = `M2 Smoke Season ${runId}`;
+    const schedule = scheduleForRun(runId);
 
     await page.goto("/sign-in?returnTo=%2Fsetup");
     await expect(page.getByTestId("signin-shell")).toBeVisible();
@@ -159,9 +174,9 @@ test.describe("M2 local-stack smoke", () => {
     ]);
     await expect(page.locator("#season-title")).toHaveText(seasonName);
 
-    await page.locator("#game-date").fill("2026-06-20");
+    await page.locator("#game-date").fill(schedule.gameDate);
     await page.locator("#game-date").dispatchEvent("change");
-    await page.locator("#game-kickoff").fill("2026-06-20T10:00");
+    await page.locator("#game-kickoff").fill(schedule.kickoff);
     await page.locator("#game-kickoff").dispatchEvent("change");
     const gameId = (await page.locator("#game-id-display").innerText()).trim();
     expect(gameId).toMatch(/^game-/);

--- a/tests/e2e/m2-smoke.spec.ts
+++ b/tests/e2e/m2-smoke.spec.ts
@@ -31,6 +31,20 @@ interface SmokeRunCleanupInput {
   playerIds: string[];
 }
 
+type DynamoClientLike = Pick<DynamoDBClient, "send" | "destroy">;
+
+interface SmokeRunCleanupDependencies {
+  createClient?: () => DynamoClientLike;
+  queryPartition?: (client: DynamoClientLike, pk: string) => Promise<DynamoItem[]>;
+  scanTaggedItems?: (client: DynamoClientLike, needles: string[]) => Promise<DynamoItem[]>;
+  scanAuthRateLimitItems?: (
+    client: DynamoClientLike,
+    input: { email: string },
+  ) => Promise<DynamoItem[]>;
+  deleteItems?: (client: DynamoClientLike, items: DynamoItem[]) => Promise<void>;
+  deleteFakeSesMessages?: (email: string) => Promise<void>;
+}
+
 function authRateLimitHash(dimension: "email" | "ip", identifier: string): string {
   return createHash("sha256")
     .update(`magic-link-start:${dimension}:${identifier}`, "utf8")
@@ -87,7 +101,7 @@ async function scheduleForRun(runId: string): Promise<{ gameDate: string; kickof
   throw new Error("Could not find an unused smoke-test session date after 200 probes.");
 }
 
-function createLocalDynamoClient(): DynamoDBClient {
+function createLocalDynamoClient(): DynamoClientLike {
   return new DynamoDBClient({
     region: process.env.AWS_REGION ?? "ap-southeast-2",
     endpoint: dynamodbEndpoint,
@@ -111,7 +125,7 @@ function itemSearchText(item: DynamoItem): string {
     .join("\n");
 }
 
-async function queryPartition(client: DynamoDBClient, pk: string): Promise<DynamoItem[]> {
+async function queryPartition(client: DynamoClientLike, pk: string): Promise<DynamoItem[]> {
   const items: DynamoItem[] = [];
   let exclusiveStartKey: Record<string, AttributeValue> | undefined;
 
@@ -133,7 +147,7 @@ async function queryPartition(client: DynamoDBClient, pk: string): Promise<Dynam
   return items;
 }
 
-async function scanTaggedItems(client: DynamoDBClient, needles: string[]): Promise<DynamoItem[]> {
+async function scanTaggedItems(client: DynamoClientLike, needles: string[]): Promise<DynamoItem[]> {
   if (needles.length === 0) {
     return [];
   }
@@ -161,7 +175,7 @@ async function scanTaggedItems(client: DynamoDBClient, needles: string[]): Promi
 }
 
 async function scanAuthRateLimitItems(
-  client: DynamoDBClient,
+  client: DynamoClientLike,
   input: { email: string },
 ): Promise<DynamoItem[]> {
   const prefix = authRateLimitPkPrefix("email", input.email);
@@ -187,7 +201,7 @@ async function scanAuthRateLimitItems(
   return items;
 }
 
-async function deleteItems(client: DynamoDBClient, items: DynamoItem[]): Promise<void> {
+async function deleteItems(client: DynamoClientLike, items: DynamoItem[]): Promise<void> {
   const seen = new Set<string>();
 
   for (const item of items) {
@@ -214,12 +228,23 @@ async function deleteItems(client: DynamoDBClient, items: DynamoItem[]): Promise
   }
 }
 
-async function cleanupSmokeRun(input: SmokeRunCleanupInput): Promise<void> {
+async function cleanupSmokeRun(
+  input: SmokeRunCleanupInput,
+  dependencies: SmokeRunCleanupDependencies = {},
+): Promise<void> {
   if (process.env.THREEFC_SKIP_SMOKE_CLEANUP === "1") {
     return;
   }
 
-  const client = createLocalDynamoClient();
+  const createClient = dependencies.createClient ?? createLocalDynamoClient;
+  const queryPartitionForCleanup = dependencies.queryPartition ?? queryPartition;
+  const scanTaggedItemsForCleanup = dependencies.scanTaggedItems ?? scanTaggedItems;
+  const scanAuthRateLimitItemsForCleanup =
+    dependencies.scanAuthRateLimitItems ?? scanAuthRateLimitItems;
+  const deleteItemsForCleanup = dependencies.deleteItems ?? deleteItems;
+  const deleteFakeSesMessagesForCleanup =
+    dependencies.deleteFakeSesMessages ?? deleteFakeSesMessages;
+  const client = createClient();
   try {
     const runNeedles = [input.runId, input.leagueSlug, input.seasonSlug, input.gameId].filter(Boolean);
     const partitions = [
@@ -230,13 +255,13 @@ async function cleanupSmokeRun(input: SmokeRunCleanupInput): Promise<void> {
     ];
 
     for (const pk of partitions) {
-      await deleteItems(client, await queryPartition(client, pk));
+      await deleteItemsForCleanup(client, await queryPartitionForCleanup(client, pk));
     }
 
     if (input.sessionId && input.gameId) {
       const sessionPk = `SESSION#${input.sessionId}`;
-      const sessionItems = await queryPartition(client, sessionPk);
-      await deleteItems(
+      const sessionItems = await queryPartitionForCleanup(client, sessionPk);
+      await deleteItemsForCleanup(
         client,
         sessionItems.filter((item) => {
           const sk = item.sk?.S ?? "";
@@ -244,7 +269,7 @@ async function cleanupSmokeRun(input: SmokeRunCleanupInput): Promise<void> {
         }),
       );
 
-      const remainingSessionItems = await queryPartition(client, sessionPk);
+      const remainingSessionItems = await queryPartitionForCleanup(client, sessionPk);
       const remainingSessionGameItems = remainingSessionItems.filter((item) =>
         (item.sk?.S ?? "").startsWith("GAME#"),
       );
@@ -253,21 +278,21 @@ async function cleanupSmokeRun(input: SmokeRunCleanupInput): Promise<void> {
         ? runNeedles.some((needle) => itemSearchText(currentSessionMetadata).includes(needle))
         : false;
       if (currentSessionMetadata && metadataBelongsToRun && remainingSessionGameItems.length === 0) {
-        await deleteItems(client, [currentSessionMetadata]);
+        await deleteItemsForCleanup(client, [currentSessionMetadata]);
       }
     }
 
-    const taggedItems = await scanTaggedItems(client, runNeedles);
-    await deleteItems(
+    const taggedItems = await scanTaggedItemsForCleanup(client, runNeedles);
+    await deleteItemsForCleanup(
       client,
       taggedItems.filter((item) => {
         const key = itemKey(item);
         return !(key?.pk === `SESSION#${input.sessionId}` && key.sk === "METADATA");
       }),
     );
-    await deleteItems(client, await scanAuthRateLimitItems(client, input));
+    await deleteItemsForCleanup(client, await scanAuthRateLimitItemsForCleanup(client, input));
 
-    await deleteFakeSesMessages(input.email);
+    await deleteFakeSesMessagesForCleanup(input.email);
   } finally {
     client.destroy();
   }
@@ -393,6 +418,133 @@ async function expectAllDisabled(locator: Locator): Promise<void> {
     await expect(locator.nth(index)).toBeDisabled();
   }
 }
+
+function testItem(pk: string, sk: string, text: string): DynamoItem {
+  return {
+    pk: { S: pk },
+    sk: { S: sk },
+    data: { S: text },
+  };
+}
+
+test("smoke cleanup removes run-owned records without deleting unrelated session metadata", async () => {
+  const runId = "cleanup-run-001";
+  const email = "cleanup-run-001@example.com";
+  const leagueSlug = "cleanup-league-001";
+  const seasonSlug = "cleanup-season-001";
+  const gameId = "game-cleanup-001";
+  const sessionId = "20270103";
+  const playerId = "player-cleanup-001";
+  const sessionPk = `SESSION#${sessionId}`;
+  const unrelatedSessionMetadata = testItem(
+    sessionPk,
+    "METADATA",
+    "existing real session metadata",
+  );
+  const partitions = new Map<string, DynamoItem[]>([
+    [
+      `LEAGUE#${leagueSlug}`,
+      [testItem(`LEAGUE#${leagueSlug}`, "METADATA", `owned by ${runId}`)],
+    ],
+    [
+      `SEASON#${seasonSlug}`,
+      [testItem(`SEASON#${seasonSlug}`, "METADATA", `owned by ${runId}`)],
+    ],
+    [
+      `GAME#${gameId}`,
+      [testItem(`GAME#${gameId}`, "METADATA", `owned by ${runId}`)],
+    ],
+    [
+      `PLAYER#${playerId}`,
+      [testItem(`PLAYER#${playerId}`, "PROFILE", `owned by ${runId}`)],
+    ],
+    [
+      sessionPk,
+      [
+        unrelatedSessionMetadata,
+        testItem(sessionPk, `GAME#${gameId}`, `session index for ${gameId}`),
+      ],
+    ],
+    [
+      "AUTH_RATE_LIMIT#magic-link-start#email#hash#bucket",
+      [
+        testItem(
+          "AUTH_RATE_LIMIT#magic-link-start#email#hash#bucket",
+          "METADATA",
+          email,
+        ),
+      ],
+    ],
+  ]);
+  const deletedKeys = new Set<string>();
+  let destroyed = false;
+  let fakeSesDeletedFor: string | null = null;
+  const fakeClient: DynamoClientLike = {
+    async send() {
+      throw new Error("The cleanup isolation test must use injected Dynamo helpers.");
+    },
+    destroy() {
+      destroyed = true;
+    },
+  };
+
+  await cleanupSmokeRun(
+    {
+      runId,
+      email,
+      leagueSlug,
+      seasonSlug,
+      gameId,
+      sessionId,
+      playerIds: [playerId],
+    },
+    {
+      createClient: () => fakeClient,
+      async queryPartition(_client, pk) {
+        return [...(partitions.get(pk) ?? [])];
+      },
+      async scanTaggedItems(_client, needles) {
+        return [...partitions.values()]
+          .flat()
+          .filter((item) => needles.some((needle) => itemSearchText(item).includes(needle)));
+      },
+      async scanAuthRateLimitItems() {
+        return partitions.get("AUTH_RATE_LIMIT#magic-link-start#email#hash#bucket") ?? [];
+      },
+      async deleteItems(_client, items) {
+        for (const item of items) {
+          const key = itemKey(item);
+          if (!key) {
+            continue;
+          }
+
+          deletedKeys.add(`${key.pk}|${key.sk}`);
+          partitions.set(
+            key.pk,
+            (partitions.get(key.pk) ?? []).filter((candidate) => {
+              const candidateKey = itemKey(candidate);
+              return candidateKey?.sk !== key.sk;
+            }),
+          );
+        }
+      },
+      async deleteFakeSesMessages(deletedEmail) {
+        fakeSesDeletedFor = deletedEmail;
+      },
+    },
+  );
+
+  expect(deletedKeys).toContain(`LEAGUE#${leagueSlug}|METADATA`);
+  expect(deletedKeys).toContain(`SEASON#${seasonSlug}|METADATA`);
+  expect(deletedKeys).toContain(`GAME#${gameId}|METADATA`);
+  expect(deletedKeys).toContain(`PLAYER#${playerId}|PROFILE`);
+  expect(deletedKeys).toContain(`${sessionPk}|GAME#${gameId}`);
+  expect(deletedKeys).toContain("AUTH_RATE_LIMIT#magic-link-start#email#hash#bucket|METADATA");
+  expect(deletedKeys).not.toContain(`${sessionPk}|METADATA`);
+  expect(partitions.get(sessionPk)).toEqual([unrelatedSessionMetadata]);
+  expect(fakeSesDeletedFor).toBe(email);
+  expect(destroyed).toBe(true);
+});
 
 test.describe("M2 local-stack smoke", () => {
   test.beforeEach(async () => {

--- a/tests/e2e/m2-smoke.spec.ts
+++ b/tests/e2e/m2-smoke.spec.ts
@@ -2,6 +2,7 @@ import { expect, test, type Locator, type Page } from "@playwright/test";
 
 const apiBaseUrl = process.env.THREEFC_API_BASE_URL ?? "http://localhost:3001";
 const fakeSesBaseUrl = process.env.THREEFC_FAKE_SES_BASE_URL ?? "http://localhost:4025";
+const fetchTimeoutMs = 5_000;
 
 interface FakeSesMessage {
   to?: string;
@@ -12,12 +13,22 @@ function uniqueRunId(): string {
   return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
+async function fetchWithTimeout(url: string): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), fetchTimeoutMs);
+  try {
+    return await fetch(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 async function waitForHealthy(url: string): Promise<void> {
   await expect
     .poll(
       async () => {
         try {
-          const response = await fetch(url);
+          const response = await fetchWithTimeout(url);
           return response.ok;
         } catch {
           return false;
@@ -29,7 +40,7 @@ async function waitForHealthy(url: string): Promise<void> {
 }
 
 async function readFakeSesMessages(): Promise<FakeSesMessage[]> {
-  const response = await fetch(`${fakeSesBaseUrl}/messages`);
+  const response = await fetchWithTimeout(`${fakeSesBaseUrl}/messages`);
   if (!response.ok) {
     throw new Error(`Fake SES messages request failed with ${response.status}.`);
   }
@@ -75,12 +86,14 @@ async function createAndAssignPlayer(page: Page, nickname: string, teamId: "red"
   await expect(playerCard).toBeVisible();
 
   const playerId = await playerCard.getAttribute("data-player-id");
-  expect(playerId).toBeTruthy();
+  if (!playerId) {
+    throw new Error(`Created player ${nickname} did not expose a data-player-id.`);
+  }
 
   await playerCard.locator(`[data-action="assign-player"][data-team-id="${teamId}"]`).click();
   await expect(page.locator(`[data-ui="roster-team"][data-team-id="${teamId}"]`)).toContainText(nickname);
 
-  return playerId as string;
+  return playerId;
 }
 
 async function startThird(page: Page, third: 1 | 2 | 3): Promise<void> {

--- a/tests/e2e/m2-smoke.spec.ts
+++ b/tests/e2e/m2-smoke.spec.ts
@@ -1,0 +1,204 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+const apiBaseUrl = process.env.THREEFC_API_BASE_URL ?? "http://localhost:3001";
+const fakeSesBaseUrl = process.env.THREEFC_FAKE_SES_BASE_URL ?? "http://localhost:4025";
+
+interface FakeSesMessage {
+  to?: string;
+  body?: string;
+}
+
+function uniqueRunId(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+async function waitForHealthy(url: string): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        try {
+          const response = await fetch(url);
+          return response.ok;
+        } catch {
+          return false;
+        }
+      },
+      { timeout: 30_000 },
+    )
+    .toBe(true);
+}
+
+async function readFakeSesMessages(): Promise<FakeSesMessage[]> {
+  const response = await fetch(`${fakeSesBaseUrl}/messages`);
+  if (!response.ok) {
+    throw new Error(`Fake SES messages request failed with ${response.status}.`);
+  }
+
+  const payload = (await response.json()) as { messages?: FakeSesMessage[] };
+  return Array.isArray(payload.messages) ? payload.messages : [];
+}
+
+function extractMagicLink(message: FakeSesMessage): string | null {
+  const body = message.body ?? "";
+  const lineLink = body
+    .split(/\r?\n/)
+    .find((line) => /^https?:\/\/[^\s]+\/auth\/callback\?token=/.test(line.trim()));
+  if (lineLink) {
+    return lineLink.trim();
+  }
+
+  return body.match(/https?:\/\/[^\s]+\/auth\/callback\?token=[^\s]+/)?.[0] ?? null;
+}
+
+async function waitForMagicLink(email: string): Promise<string> {
+  let magicLink = "";
+  await expect
+    .poll(
+      async () => {
+        const messages = await readFakeSesMessages();
+        const message = [...messages].reverse().find((candidate) => candidate.to === email);
+        magicLink = message ? extractMagicLink(message) ?? "" : "";
+        return magicLink;
+      },
+      { timeout: 15_000 },
+    )
+    .not.toBe("");
+
+  return magicLink;
+}
+
+async function createAndAssignPlayer(page: Page, nickname: string, teamId: "red" | "blue" | "yellow"): Promise<string> {
+  await page.locator("#player-nickname").fill(nickname);
+  await page.getByTestId("quick-create-player").click();
+
+  const playerCard = page.locator('[data-ui="roster-player"]').filter({ hasText: nickname }).first();
+  await expect(playerCard).toBeVisible();
+
+  const playerId = await playerCard.getAttribute("data-player-id");
+  expect(playerId).toBeTruthy();
+
+  await playerCard.locator(`[data-action="assign-player"][data-team-id="${teamId}"]`).click();
+  await expect(page.locator(`[data-ui="roster-team"][data-team-id="${teamId}"]`)).toContainText(nickname);
+
+  return playerId as string;
+}
+
+async function startThird(page: Page, third: 1 | 2 | 3): Promise<void> {
+  await expect(page.getByTestId("start-third")).toHaveText(`Start Third ${third}`);
+  await page.getByTestId("start-third").click();
+  await expect(page.locator("#timer-active-third")).toHaveText(`Third ${third}`);
+  await expect(page.getByTestId("finish-third")).toHaveText(`Finish Third ${third}`);
+}
+
+async function finishThird(page: Page, third: 1 | 2 | 3): Promise<void> {
+  await expect(page.getByTestId("finish-third")).toHaveText(`Finish Third ${third}`);
+  await page.getByTestId("finish-third").click();
+  await expect(page.locator("#third-status-list")).toContainText(`Third ${third}`);
+}
+
+async function expectAllDisabled(locator: Locator): Promise<void> {
+  const count = await locator.count();
+  expect(count).toBeGreaterThan(0);
+
+  for (let index = 0; index < count; index += 1) {
+    await expect(locator.nth(index)).toBeDisabled();
+  }
+}
+
+test.describe("M2 local-stack smoke", () => {
+  test.beforeEach(async () => {
+    await waitForHealthy(`${apiBaseUrl}/v1/health`);
+    await waitForHealthy(`${fakeSesBaseUrl}/health`);
+  });
+
+  test("scorekeeper can set up and finish a live game", async ({ page }) => {
+    const runId = uniqueRunId();
+    const email = `m2-smoke-${runId}@example.com`;
+    const leagueSlug = `m2-smoke-league-${runId}`;
+    const seasonSlug = `m2-smoke-season-${runId}`;
+    const leagueName = `M2 Smoke League ${runId}`;
+    const seasonName = `M2 Smoke Season ${runId}`;
+
+    await page.goto("/sign-in?returnTo=%2Fsetup");
+    await expect(page.getByTestId("signin-shell")).toBeVisible();
+    await page.locator("#auth-email").fill(email);
+    await page.getByTestId("send-magic-link").click();
+    await expect(page.locator("#auth-status")).toContainText("Magic link sent");
+
+    const magicLink = await waitForMagicLink(email);
+    await page.goto(magicLink);
+    await page.waitForURL("**/setup");
+    await expect(page.getByTestId("setup-shell")).toBeVisible();
+
+    await page.locator("#league-name").fill(leagueName);
+    await page.locator("#league-friendly-url").fill(leagueSlug);
+    await Promise.all([
+      page.waitForURL(`**/leagues/${leagueSlug}`),
+      page.getByTestId("create-league").click(),
+    ]);
+    await expect(page.locator("#league-title")).toHaveText(leagueName);
+
+    await page.locator("#season-name").fill(seasonName);
+    await page.locator("#season-friendly-url").fill(seasonSlug);
+    await Promise.all([
+      page.waitForURL(`**/seasons/${seasonSlug}`),
+      page.getByTestId("create-season").click(),
+    ]);
+    await expect(page.locator("#season-title")).toHaveText(seasonName);
+
+    await page.locator("#game-date").fill("2026-06-20");
+    await page.locator("#game-date").dispatchEvent("change");
+    await page.locator("#game-kickoff").fill("2026-06-20T10:00");
+    await page.locator("#game-kickoff").dispatchEvent("change");
+    const gameId = (await page.locator("#game-id-display").innerText()).trim();
+    expect(gameId).toMatch(/^game-/);
+
+    await Promise.all([
+      page.waitForURL(`**/games/${gameId}`),
+      page.getByTestId("create-game").click(),
+    ]);
+    await expect(page.getByTestId("game-shell")).toBeVisible();
+    await expect(page.locator("#game-id-value")).toHaveText(gameId);
+
+    const ariPlayerId = await createAndAssignPlayer(page, "Ari", "red");
+    const beaPlayerId = await createAndAssignPlayer(page, "Bea", "blue");
+
+    await startThird(page, 1);
+    await page.locator("#goal-scoring-team").selectOption("red");
+    await page.locator("#goal-conceding-team").selectOption("blue");
+    await page.locator("#goal-scorer").selectOption(ariPlayerId);
+    await page.locator(`#goal-assists input[value="${beaPlayerId}"]`).check();
+    await page.getByTestId("add-goal").click();
+
+    await expect(page.getByTestId("goal-timeline")).toContainText("Ari for Red");
+    await expect(page.getByTestId("goal-timeline")).toContainText("Assists: Bea");
+    await expect(page.locator('[data-ui="score-team"][data-team-id="red"]')).toContainText(/Scored\s*1/);
+    await expect(page.locator('[data-ui="score-team"][data-team-id="blue"]')).toContainText(/Conceded\s*1/);
+
+    await finishThird(page, 1);
+    await startThird(page, 2);
+    await finishThird(page, 2);
+    await startThird(page, 3);
+    await finishThird(page, 3);
+
+    await expect(page.getByTestId("finish-game")).toBeEnabled();
+    await page.getByTestId("finish-game").click();
+
+    await expect(page.getByTestId("game-result-summary")).toBeVisible();
+    await expect(page.getByTestId("game-result-outcome")).toHaveText("Red win");
+    const resultTeams = page.getByTestId("game-result-teams");
+    await expect(resultTeams.locator('[data-ui="result-team"][data-team-id="red"]')).toContainText(/Conceded\s*0/);
+    await expect(resultTeams.locator('[data-ui="result-team"][data-team-id="red"]')).toContainText(/Scored\s*1/);
+    await expect(resultTeams.locator('[data-ui="result-team"][data-team-id="blue"]')).toContainText(/Conceded\s*1/);
+    await expect(resultTeams.locator('[data-ui="result-team"][data-team-id="blue"]')).toContainText(/Scored\s*0/);
+    await expect(page.locator("#game-edit-status")).toHaveValue("finished");
+    await expect(page.getByTestId("finish-game")).toBeDisabled();
+    await expect(page.getByTestId("finish-game")).toHaveText("Game finished");
+    await expect(page.getByTestId("delete-game")).toBeDisabled();
+    await expect(page.getByTestId("quick-create-player")).toBeDisabled();
+    await expect(page.getByTestId("add-goal")).toBeDisabled();
+    await expectAllDisabled(page.locator('[data-action="assign-player"]'));
+    await expectAllDisabled(page.locator('[data-action="edit-goal"]'));
+    await expectAllDisabled(page.locator('[data-action="delete-goal"]'));
+  });
+});

--- a/tests/e2e/m2-smoke.spec.ts
+++ b/tests/e2e/m2-smoke.spec.ts
@@ -632,12 +632,12 @@ async function finishThird(page: Page, third: 1 | 2 | 3): Promise<void> {
   await expect(page.locator("#third-status-list")).toContainText(`Third ${third}`);
 }
 
-async function expectAllDisabled(locator: Locator): Promise<void> {
+async function expectAllEnabled(locator: Locator): Promise<void> {
   const count = await locator.count();
   expect(count).toBeGreaterThan(0);
 
   for (let index = 0; index < count; index += 1) {
-    await expect(locator.nth(index)).toBeDisabled();
+    await expect(locator.nth(index)).toBeEnabled();
   }
 }
 
@@ -1005,10 +1005,10 @@ test.describe("M2 local-stack smoke", () => {
       await expect(page.getByTestId("finish-game")).toBeDisabled();
       await expect(page.getByTestId("finish-game")).toHaveText("Game finished");
       await expect(page.getByTestId("delete-game")).toBeDisabled();
-      await expect(page.getByTestId("quick-create-player")).toBeDisabled();
+      await expect(page.getByTestId("quick-create-player")).toBeEnabled();
       await expect(page.getByTestId("add-goal")).toBeEnabled();
       await expect(page.locator("#goal-form-note")).toContainText("final whistle");
-      await expectAllDisabled(page.locator('[data-action="assign-player"]'));
+      await expectAllEnabled(page.locator('[data-action="assign-player"]'));
       await expect(page.locator('[data-action="edit-goal"]').first()).toBeEnabled();
       await expect(page.locator('[data-action="delete-goal"]').first()).toBeEnabled();
       await expect(page.getByTestId("undo-last-goal")).toBeEnabled();

--- a/tests/e2e/m2-smoke.spec.ts
+++ b/tests/e2e/m2-smoke.spec.ts
@@ -33,6 +33,7 @@ interface SmokeRunCleanupInput {
   sessionId: string;
   playerIds: string[];
   originalSessionMetadata: DynamoItem | null;
+  originalAuthRateLimitItems: DynamoItem[];
 }
 
 function authRateLimitHash(dimension: "email" | "ip", identifier: string): string {
@@ -270,6 +271,9 @@ async function cleanupSmokeRun(input: SmokeRunCleanupInput): Promise<void> {
       ),
     );
     await deleteItems(client, await scanAuthRateLimitItems(client, input));
+    for (const item of input.originalAuthRateLimitItems) {
+      await putItem(client, item);
+    }
 
     await deleteFakeSesMessages(input.email);
   } finally {
@@ -419,8 +423,13 @@ test.describe("M2 local-stack smoke", () => {
     const playerIds: string[] = [];
     const snapshotClient = createLocalDynamoClient();
     let originalSessionMetadata: DynamoItem | null = null;
+    let originalAuthRateLimitItems: DynamoItem[] = [];
     try {
       originalSessionMetadata = await readSessionMetadataSnapshot(snapshotClient, sessionId);
+      originalAuthRateLimitItems = await scanAuthRateLimitItems(snapshotClient, {
+        email,
+        clientIps: localBrowserClientIps,
+      });
     } finally {
       snapshotClient.destroy();
     }
@@ -527,6 +536,7 @@ test.describe("M2 local-stack smoke", () => {
           sessionId,
           playerIds,
           originalSessionMetadata,
+          originalAuthRateLimitItems,
         });
       } catch (error) {
         if (!testFailed) {

--- a/tests/e2e/m2-smoke.spec.ts
+++ b/tests/e2e/m2-smoke.spec.ts
@@ -334,6 +334,10 @@ function smokeOwnedAuthRateLimitKeys(input: {
   return touchedAuthRateLimitKeys(input.before, input.after);
 }
 
+function didMagicLinkStartConsumeRateLimit(status: number): boolean {
+  return status === 202 || status >= 500;
+}
+
 function isConditionalCheckFailure(error: unknown): boolean {
   return (
     typeof error === "object" &&
@@ -883,6 +887,14 @@ test("smoke cleanup detects consumed IP rate-limit buckets without known client 
   ).toEqual([]);
 });
 
+test("smoke cleanup tracks magic-link consumption separately from final response status", () => {
+  expect(didMagicLinkStartConsumeRateLimit(202)).toBe(true);
+  expect(didMagicLinkStartConsumeRateLimit(500)).toBe(true);
+  expect(didMagicLinkStartConsumeRateLimit(400)).toBe(false);
+  expect(didMagicLinkStartConsumeRateLimit(403)).toBe(false);
+  expect(didMagicLinkStartConsumeRateLimit(429)).toBe(false);
+});
+
 test.describe("M2 local-stack smoke", () => {
   test.beforeEach(async () => {
     await waitForHealthy(`${apiBaseUrl}/v1/health`);
@@ -916,7 +928,7 @@ test.describe("M2 local-stack smoke", () => {
       );
       await page.getByTestId("send-magic-link").click();
       const magicStartResponse = await magicStartResponsePromise;
-      magicLinkStartConsumedRateLimit = magicStartResponse.status() === 202;
+      magicLinkStartConsumedRateLimit = didMagicLinkStartConsumeRateLimit(magicStartResponse.status());
       await expect(page.locator("#auth-status")).toContainText("Magic link sent");
 
       const magicLink = await waitForMagicLink(email);

--- a/tests/e2e/m2-smoke.spec.ts
+++ b/tests/e2e/m2-smoke.spec.ts
@@ -14,6 +14,7 @@ const fakeSesBaseUrl = process.env.THREEFC_FAKE_SES_BASE_URL ?? "http://localhos
 const dynamodbEndpoint = process.env.THREEFC_DYNAMODB_ENDPOINT ?? "http://localhost:8000";
 const dynamodbTableName = process.env.THREEFC_DYNAMODB_TABLE ?? "threefc_local";
 const fetchTimeoutMs = 5_000;
+const localBrowserClientIps = ["127.0.0.1", "::1", "::ffff:127.0.0.1"];
 
 interface FakeSesMessage {
   to?: string;
@@ -25,7 +26,7 @@ type DynamoItem = Record<string, AttributeValue>;
 interface SmokeRunCleanupInput {
   runId: string;
   email: string;
-  clientIp: string;
+  clientIps: string[];
   leagueSlug: string;
   seasonSlug: string;
   gameId: string;
@@ -158,11 +159,11 @@ async function scanTaggedItems(client: DynamoDBClient, needles: string[]): Promi
 
 async function scanAuthRateLimitItems(
   client: DynamoDBClient,
-  input: { email: string; clientIp: string },
+  input: { email: string; clientIps: string[] },
 ): Promise<DynamoItem[]> {
   const prefixes = [
     authRateLimitPkPrefix("email", input.email),
-    authRateLimitPkPrefix("ip", input.clientIp),
+    ...input.clientIps.map((clientIp) => authRateLimitPkPrefix("ip", clientIp)),
   ];
   const items: DynamoItem[] = [];
   let exclusiveStartKey: Record<string, AttributeValue> | undefined;
@@ -406,7 +407,6 @@ test.describe("M2 local-stack smoke", () => {
   test("scorekeeper can set up and finish a live game", async ({ page }) => {
     const runId = uniqueRunId();
     const email = `m2-smoke-${runId}@example.com`;
-    const clientIp = `m2-smoke-${runId}`;
     const leagueSlug = `m2-smoke-league-${runId}`;
     const seasonSlug = `m2-smoke-season-${runId}`;
     const leagueName = `M2 Smoke League ${runId}`;
@@ -427,7 +427,6 @@ test.describe("M2 local-stack smoke", () => {
 
     let testFailed = false;
     try {
-      await page.setExtraHTTPHeaders({ "x-forwarded-for": clientIp });
       await page.goto("/sign-in?returnTo=%2Fsetup");
       await expect(page.getByTestId("signin-shell")).toBeVisible();
       await page.locator("#auth-email").fill(email);
@@ -521,7 +520,7 @@ test.describe("M2 local-stack smoke", () => {
         await cleanupSmokeRun({
           runId,
           email,
-          clientIp,
+          clientIps: localBrowserClientIps,
           leagueSlug,
           seasonSlug,
           gameId,

--- a/tests/e2e/m2-smoke.spec.ts
+++ b/tests/e2e/m2-smoke.spec.ts
@@ -14,7 +14,6 @@ const fakeSesBaseUrl = process.env.THREEFC_FAKE_SES_BASE_URL ?? "http://localhos
 const dynamodbEndpoint = process.env.THREEFC_DYNAMODB_ENDPOINT ?? "http://localhost:8000";
 const dynamodbTableName = process.env.THREEFC_DYNAMODB_TABLE ?? "threefc_local";
 const fetchTimeoutMs = 5_000;
-const localBrowserClientIps = ["127.0.0.1", "::1", "::ffff:127.0.0.1"];
 
 interface FakeSesMessage {
   to?: string;
@@ -26,14 +25,12 @@ type DynamoItem = Record<string, AttributeValue>;
 interface SmokeRunCleanupInput {
   runId: string;
   email: string;
-  clientIps: string[];
   leagueSlug: string;
   seasonSlug: string;
   gameId: string;
   sessionId: string;
   playerIds: string[];
   originalSessionMetadata: DynamoItem | null;
-  originalAuthRateLimitItems: DynamoItem[];
 }
 
 function authRateLimitHash(dimension: "email" | "ip", identifier: string): string {
@@ -160,12 +157,9 @@ async function scanTaggedItems(client: DynamoDBClient, needles: string[]): Promi
 
 async function scanAuthRateLimitItems(
   client: DynamoDBClient,
-  input: { email: string; clientIps: string[] },
+  input: { email: string },
 ): Promise<DynamoItem[]> {
-  const prefixes = [
-    authRateLimitPkPrefix("email", input.email),
-    ...input.clientIps.map((clientIp) => authRateLimitPkPrefix("ip", clientIp)),
-  ];
+  const prefix = authRateLimitPkPrefix("email", input.email);
   const items: DynamoItem[] = [];
   let exclusiveStartKey: Record<string, AttributeValue> | undefined;
 
@@ -179,7 +173,7 @@ async function scanAuthRateLimitItems(
     items.push(
       ...((response.Items ?? []) as DynamoItem[]).filter((item) => {
         const pk = item.pk?.S ?? "";
-        return item.sk?.S === "METADATA" && prefixes.some((prefix) => pk.startsWith(prefix));
+        return item.sk?.S === "METADATA" && pk.startsWith(prefix);
       }),
     );
     exclusiveStartKey = response.LastEvaluatedKey;
@@ -271,9 +265,6 @@ async function cleanupSmokeRun(input: SmokeRunCleanupInput): Promise<void> {
       ),
     );
     await deleteItems(client, await scanAuthRateLimitItems(client, input));
-    for (const item of input.originalAuthRateLimitItems) {
-      await putItem(client, item);
-    }
 
     await deleteFakeSesMessages(input.email);
   } finally {
@@ -423,13 +414,8 @@ test.describe("M2 local-stack smoke", () => {
     const playerIds: string[] = [];
     const snapshotClient = createLocalDynamoClient();
     let originalSessionMetadata: DynamoItem | null = null;
-    let originalAuthRateLimitItems: DynamoItem[] = [];
     try {
       originalSessionMetadata = await readSessionMetadataSnapshot(snapshotClient, sessionId);
-      originalAuthRateLimitItems = await scanAuthRateLimitItems(snapshotClient, {
-        email,
-        clientIps: localBrowserClientIps,
-      });
     } finally {
       snapshotClient.destroy();
     }
@@ -529,14 +515,12 @@ test.describe("M2 local-stack smoke", () => {
         await cleanupSmokeRun({
           runId,
           email,
-          clientIps: localBrowserClientIps,
           leagueSlug,
           seasonSlug,
           gameId,
           sessionId,
           playerIds,
           originalSessionMetadata,
-          originalAuthRateLimitItems,
         });
       } catch (error) {
         if (!testFailed) {

--- a/tests/e2e/m2-smoke.spec.ts
+++ b/tests/e2e/m2-smoke.spec.ts
@@ -651,8 +651,9 @@ test.describe("M2 local-stack smoke", () => {
       await expect(page.getByTestId("quick-create-player")).toBeDisabled();
       await expect(page.getByTestId("add-goal")).toBeDisabled();
       await expectAllDisabled(page.locator('[data-action="assign-player"]'));
-      await expectAllDisabled(page.locator('[data-action="edit-goal"]'));
-      await expectAllDisabled(page.locator('[data-action="delete-goal"]'));
+      await expect(page.locator('[data-action="edit-goal"]').first()).toBeEnabled();
+      await expect(page.locator('[data-action="delete-goal"]').first()).toBeEnabled();
+      await expect(page.getByTestId("undo-last-goal")).toBeEnabled();
     } catch (error) {
       testFailed = true;
       throw error;

--- a/tests/e2e/m2-smoke.spec.ts
+++ b/tests/e2e/m2-smoke.spec.ts
@@ -3,6 +3,7 @@ import {
   DynamoDBClient,
   QueryCommand,
   ScanCommand,
+  UpdateItemCommand,
   type AttributeValue,
 } from "@aws-sdk/client-dynamodb";
 import { createHash } from "node:crypto";
@@ -29,9 +30,20 @@ interface SmokeRunCleanupInput {
   gameId: string;
   sessionId: string;
   playerIds: string[];
+  ipRateLimitKeys: DynamoItemKey[];
 }
 
 type DynamoClientLike = Pick<DynamoDBClient, "send" | "destroy">;
+type RateLimitDimension = "email" | "ip";
+
+interface DynamoItemKey {
+  pk: string;
+  sk: string;
+}
+
+interface AuthRateLimitSnapshot extends DynamoItemKey {
+  attemptCount: number;
+}
 
 interface SmokeRunCleanupDependencies {
   createClient?: () => DynamoClientLike;
@@ -41,17 +53,23 @@ interface SmokeRunCleanupDependencies {
     client: DynamoClientLike,
     input: { email: string },
   ) => Promise<DynamoItem[]>;
+  decrementAuthRateLimitItems?: (
+    client: DynamoClientLike,
+    keys: DynamoItemKey[],
+  ) => Promise<void>;
   deleteItems?: (client: DynamoClientLike, items: DynamoItem[]) => Promise<void>;
   deleteFakeSesMessages?: (email: string) => Promise<void>;
 }
 
-function authRateLimitHash(dimension: "email" | "ip", identifier: string): string {
+const localBrowserClientIpCandidates = ["::1", "::ffff:127.0.0.1", "127.0.0.1", "unknown"];
+
+function authRateLimitHash(dimension: RateLimitDimension, identifier: string): string {
   return createHash("sha256")
     .update(`magic-link-start:${dimension}:${identifier}`, "utf8")
     .digest("hex");
 }
 
-function authRateLimitPkPrefix(dimension: "email" | "ip", identifier: string): string {
+function authRateLimitPkPrefix(dimension: RateLimitDimension, identifier: string): string {
   const normalizedIdentifier = dimension === "email" ? identifier.trim().toLowerCase() : identifier.trim();
   return [
     "AUTH_RATE_LIMIT",
@@ -118,6 +136,20 @@ function itemKey(item: DynamoItem): { pk: string; sk: string } | null {
   return pk && sk ? { pk, sk } : null;
 }
 
+function authRateLimitSnapshotKey(snapshot: DynamoItemKey): string {
+  return `${snapshot.pk}|${snapshot.sk}`;
+}
+
+function attemptCount(item: DynamoItem): number {
+  const rawValue = item.attemptCount?.N;
+  if (!rawValue) {
+    return 0;
+  }
+
+  const parsed = Number.parseInt(rawValue, 10);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
 function itemSearchText(item: DynamoItem): string {
   return Object.values(item)
     .flatMap((attribute) => [attribute.S, attribute.N, attribute.BOOL?.toString()])
@@ -174,11 +206,13 @@ async function scanTaggedItems(client: DynamoClientLike, needles: string[]): Pro
   return items;
 }
 
-async function scanAuthRateLimitItems(
+async function scanAuthRateLimitItemsForIdentifiers(
   client: DynamoClientLike,
-  input: { email: string },
+  input: { dimension: RateLimitDimension; identifiers: string[] },
 ): Promise<DynamoItem[]> {
-  const prefix = authRateLimitPkPrefix("email", input.email);
+  const prefixes = input.identifiers.map((identifier) =>
+    authRateLimitPkPrefix(input.dimension, identifier),
+  );
   const items: DynamoItem[] = [];
   let exclusiveStartKey: Record<string, AttributeValue> | undefined;
 
@@ -192,13 +226,142 @@ async function scanAuthRateLimitItems(
     items.push(
       ...((response.Items ?? []) as DynamoItem[]).filter((item) => {
         const pk = item.pk?.S ?? "";
-        return item.sk?.S === "METADATA" && pk.startsWith(prefix);
+        return item.sk?.S === "METADATA" && prefixes.some((prefix) => pk.startsWith(prefix));
       }),
     );
     exclusiveStartKey = response.LastEvaluatedKey;
   } while (exclusiveStartKey);
 
   return items;
+}
+
+async function scanAuthRateLimitItems(
+  client: DynamoClientLike,
+  input: { email: string },
+): Promise<DynamoItem[]> {
+  return scanAuthRateLimitItemsForIdentifiers(client, {
+    dimension: "email",
+    identifiers: [input.email],
+  });
+}
+
+async function scanAuthRateLimitSnapshots(
+  client: DynamoClientLike,
+  input: { dimension: RateLimitDimension; identifiers: string[] },
+): Promise<AuthRateLimitSnapshot[]> {
+  const items = await scanAuthRateLimitItemsForIdentifiers(client, input);
+  return items
+    .map((item) => {
+      const key = itemKey(item);
+      return key ? { ...key, attemptCount: attemptCount(item) } : null;
+    })
+    .filter((snapshot): snapshot is AuthRateLimitSnapshot => snapshot !== null);
+}
+
+async function snapshotLocalAuthRateLimits(input: {
+  dimension: RateLimitDimension;
+  identifiers: string[];
+}): Promise<AuthRateLimitSnapshot[]> {
+  const client = createLocalDynamoClient();
+  try {
+    return await scanAuthRateLimitSnapshots(client, input);
+  } finally {
+    client.destroy();
+  }
+}
+
+function touchedAuthRateLimitKeys(
+  before: AuthRateLimitSnapshot[],
+  after: AuthRateLimitSnapshot[],
+): DynamoItemKey[] {
+  const beforeByKey = new Map(
+    before.map((snapshot) => [authRateLimitSnapshotKey(snapshot), snapshot.attemptCount]),
+  );
+  return after
+    .filter((snapshot) => snapshot.attemptCount > (beforeByKey.get(authRateLimitSnapshotKey(snapshot)) ?? 0))
+    .map(({ pk, sk }) => ({ pk, sk }));
+}
+
+function isConditionalCheckFailure(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    (error as { name?: string }).name === "ConditionalCheckFailedException"
+  );
+}
+
+async function decrementAuthRateLimitItem(client: DynamoClientLike, key: DynamoItemKey): Promise<void> {
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      await client.send(
+        new UpdateItemCommand({
+          TableName: dynamodbTableName,
+          Key: {
+            pk: { S: key.pk },
+            sk: { S: key.sk },
+          },
+          UpdateExpression: "ADD #attemptCount :minusOne SET #updatedAt = :updatedAt",
+          ConditionExpression: "#attemptCount > :one",
+          ExpressionAttributeNames: {
+            "#attemptCount": "attemptCount",
+            "#updatedAt": "updatedAt",
+          },
+          ExpressionAttributeValues: {
+            ":minusOne": { N: "-1" },
+            ":one": { N: "1" },
+            ":updatedAt": { S: new Date().toISOString() },
+          },
+        }),
+      );
+      return;
+    } catch (error) {
+      if (!isConditionalCheckFailure(error)) {
+        throw error;
+      }
+    }
+
+    try {
+      await client.send(
+        new DeleteItemCommand({
+          TableName: dynamodbTableName,
+          Key: {
+            pk: { S: key.pk },
+            sk: { S: key.sk },
+          },
+          ConditionExpression: "attribute_not_exists(#attemptCount) OR #attemptCount <= :one",
+          ExpressionAttributeNames: {
+            "#attemptCount": "attemptCount",
+          },
+          ExpressionAttributeValues: {
+            ":one": { N: "1" },
+          },
+        }),
+      );
+      return;
+    } catch (error) {
+      if (!isConditionalCheckFailure(error)) {
+        throw error;
+      }
+    }
+  }
+
+  throw new Error(`Could not safely remove smoke rate-limit attempt for ${key.pk}.`);
+}
+
+async function decrementAuthRateLimitItems(
+  client: DynamoClientLike,
+  keys: DynamoItemKey[],
+): Promise<void> {
+  const seen = new Set<string>();
+  for (const key of keys) {
+    const dedupeKey = authRateLimitSnapshotKey(key);
+    if (seen.has(dedupeKey)) {
+      continue;
+    }
+    seen.add(dedupeKey);
+    await decrementAuthRateLimitItem(client, key);
+  }
 }
 
 async function deleteItems(client: DynamoClientLike, items: DynamoItem[]): Promise<void> {
@@ -241,6 +404,8 @@ async function cleanupSmokeRun(
   const scanTaggedItemsForCleanup = dependencies.scanTaggedItems ?? scanTaggedItems;
   const scanAuthRateLimitItemsForCleanup =
     dependencies.scanAuthRateLimitItems ?? scanAuthRateLimitItems;
+  const decrementAuthRateLimitItemsForCleanup =
+    dependencies.decrementAuthRateLimitItems ?? decrementAuthRateLimitItems;
   const deleteItemsForCleanup = dependencies.deleteItems ?? deleteItems;
   const deleteFakeSesMessagesForCleanup =
     dependencies.deleteFakeSesMessages ?? deleteFakeSesMessages;
@@ -291,6 +456,7 @@ async function cleanupSmokeRun(
       }),
     );
     await deleteItemsForCleanup(client, await scanAuthRateLimitItemsForCleanup(client, input));
+    await decrementAuthRateLimitItemsForCleanup(client, input.ipRateLimitKeys);
 
     await deleteFakeSesMessagesForCleanup(input.email);
   } finally {
@@ -435,6 +601,10 @@ test("smoke cleanup removes run-owned records without deleting unrelated session
   const gameId = "game-cleanup-001";
   const sessionId = "20270103";
   const playerId = "player-cleanup-001";
+  const ipRateLimitKey = {
+    pk: "AUTH_RATE_LIMIT#magic-link-start#ip#hash#bucket",
+    sk: "METADATA",
+  };
   const sessionPk = `SESSION#${sessionId}`;
   const unrelatedSessionMetadata = testItem(
     sessionPk,
@@ -477,6 +647,7 @@ test("smoke cleanup removes run-owned records without deleting unrelated session
     ],
   ]);
   const deletedKeys = new Set<string>();
+  const decrementedRateLimitKeys = new Set<string>();
   let destroyed = false;
   let fakeSesDeletedFor: string | null = null;
   const fakeClient: DynamoClientLike = {
@@ -497,6 +668,7 @@ test("smoke cleanup removes run-owned records without deleting unrelated session
       gameId,
       sessionId,
       playerIds: [playerId],
+      ipRateLimitKeys: [ipRateLimitKey],
     },
     {
       createClient: () => fakeClient,
@@ -510,6 +682,11 @@ test("smoke cleanup removes run-owned records without deleting unrelated session
       },
       async scanAuthRateLimitItems() {
         return partitions.get("AUTH_RATE_LIMIT#magic-link-start#email#hash#bucket") ?? [];
+      },
+      async decrementAuthRateLimitItems(_client, keys) {
+        for (const key of keys) {
+          decrementedRateLimitKeys.add(`${key.pk}|${key.sk}`);
+        }
       },
       async deleteItems(_client, items) {
         for (const item of items) {
@@ -540,6 +717,7 @@ test("smoke cleanup removes run-owned records without deleting unrelated session
   expect(deletedKeys).toContain(`PLAYER#${playerId}|PROFILE`);
   expect(deletedKeys).toContain(`${sessionPk}|GAME#${gameId}`);
   expect(deletedKeys).toContain("AUTH_RATE_LIMIT#magic-link-start#email#hash#bucket|METADATA");
+  expect(decrementedRateLimitKeys).toContain(`${ipRateLimitKey.pk}|${ipRateLimitKey.sk}`);
   expect(deletedKeys).not.toContain(`${sessionPk}|METADATA`);
   expect(partitions.get(sessionPk)).toEqual([unrelatedSessionMetadata]);
   expect(fakeSesDeletedFor).toBe(email);
@@ -565,13 +743,24 @@ test.describe("M2 local-stack smoke", () => {
     const sessionId = sessionIdForGameDate(schedule.gameDate);
     let gameId = "";
     const playerIds: string[] = [];
+    const initialIpRateLimits = await snapshotLocalAuthRateLimits({
+      dimension: "ip",
+      identifiers: localBrowserClientIpCandidates,
+    });
+    let magicLinkStartReachedApi = false;
 
     let testFailed = false;
     try {
       await page.goto("/sign-in?returnTo=%2Fsetup");
       await expect(page.getByTestId("signin-shell")).toBeVisible();
       await page.locator("#auth-email").fill(email);
+      const magicStartResponsePromise = page.waitForResponse((response) =>
+        response.url().startsWith(`${apiBaseUrl}/v1/auth/magic/start`) &&
+        response.request().method() === "POST",
+      );
       await page.getByTestId("send-magic-link").click();
+      const magicStartResponse = await magicStartResponsePromise;
+      magicLinkStartReachedApi = magicStartResponse.status() > 0;
       await expect(page.locator("#auth-status")).toContainText("Magic link sent");
 
       const magicLink = await waitForMagicLink(email);
@@ -649,7 +838,8 @@ test.describe("M2 local-stack smoke", () => {
       await expect(page.getByTestId("finish-game")).toHaveText("Game finished");
       await expect(page.getByTestId("delete-game")).toBeDisabled();
       await expect(page.getByTestId("quick-create-player")).toBeDisabled();
-      await expect(page.getByTestId("add-goal")).toBeDisabled();
+      await expect(page.getByTestId("add-goal")).toBeEnabled();
+      await expect(page.locator("#goal-form-note")).toContainText("final whistle");
       await expectAllDisabled(page.locator('[data-action="assign-player"]'));
       await expect(page.locator('[data-action="edit-goal"]').first()).toBeEnabled();
       await expect(page.locator('[data-action="delete-goal"]').first()).toBeEnabled();
@@ -659,6 +849,12 @@ test.describe("M2 local-stack smoke", () => {
       throw error;
     } finally {
       try {
+        const currentIpRateLimits = magicLinkStartReachedApi
+          ? await snapshotLocalAuthRateLimits({
+              dimension: "ip",
+              identifiers: localBrowserClientIpCandidates,
+            })
+          : [];
         await cleanupSmokeRun({
           runId,
           email,
@@ -667,6 +863,7 @@ test.describe("M2 local-stack smoke", () => {
           gameId,
           sessionId,
           playerIds,
+          ipRateLimitKeys: touchedAuthRateLimitKeys(initialIpRateLimits, currentIpRateLimits),
         });
       } catch (error) {
         if (!testFailed) {

--- a/tests/e2e/m2-smoke.spec.ts
+++ b/tests/e2e/m2-smoke.spec.ts
@@ -1,6 +1,7 @@
 import {
   DeleteItemCommand,
   DynamoDBClient,
+  PutItemCommand,
   QueryCommand,
   ScanCommand,
   type AttributeValue,
@@ -27,6 +28,7 @@ interface SmokeRunCleanupInput {
   gameId: string;
   sessionId: string;
   playerIds: string[];
+  originalSessionMetadata: DynamoItem | null;
 }
 
 function uniqueRunId(): string {
@@ -71,6 +73,10 @@ function itemSearchText(item: DynamoItem): string {
     .join("\n");
 }
 
+function cloneDynamoItem(item: DynamoItem): DynamoItem {
+  return structuredClone(item) as DynamoItem;
+}
+
 async function queryPartition(client: DynamoDBClient, pk: string): Promise<DynamoItem[]> {
   const items: DynamoItem[] = [];
   let exclusiveStartKey: Record<string, AttributeValue> | undefined;
@@ -91,6 +97,16 @@ async function queryPartition(client: DynamoDBClient, pk: string): Promise<Dynam
   } while (exclusiveStartKey);
 
   return items;
+}
+
+async function readSessionMetadataSnapshot(
+  client: DynamoDBClient,
+  sessionId: string,
+): Promise<DynamoItem | null> {
+  const metadata = (await queryPartition(client, `SESSION#${sessionId}`)).find(
+    (item) => item.sk?.S === "METADATA",
+  );
+  return metadata ? cloneDynamoItem(metadata) : null;
 }
 
 async function scanTaggedItems(client: DynamoDBClient, needles: string[]): Promise<DynamoItem[]> {
@@ -147,6 +163,15 @@ async function deleteItems(client: DynamoDBClient, items: DynamoItem[]): Promise
   }
 }
 
+async function putItem(client: DynamoDBClient, item: DynamoItem): Promise<void> {
+  await client.send(
+    new PutItemCommand({
+      TableName: dynamodbTableName,
+      Item: cloneDynamoItem(item),
+    }),
+  );
+}
+
 async function cleanupSmokeRun(input: SmokeRunCleanupInput): Promise<void> {
   if (process.env.THREEFC_SKIP_SMOKE_CLEANUP === "1") {
     return;
@@ -177,14 +202,12 @@ async function cleanupSmokeRun(input: SmokeRunCleanupInput): Promise<void> {
       );
 
       const remainingSessionItems = await queryPartition(client, sessionPk);
-      const hasRemainingGameIndexes = remainingSessionItems.some((item) =>
-        (item.sk?.S ?? "").startsWith("GAME#"),
+      await deleteItems(
+        client,
+        remainingSessionItems.filter((item) => item.sk?.S === "METADATA"),
       );
-      if (!hasRemainingGameIndexes) {
-        await deleteItems(
-          client,
-          remainingSessionItems.filter((item) => item.sk?.S === "METADATA"),
-        );
+      if (input.originalSessionMetadata) {
+        await putItem(client, input.originalSessionMetadata);
       }
     }
 
@@ -195,8 +218,6 @@ async function cleanupSmokeRun(input: SmokeRunCleanupInput): Promise<void> {
         [input.runId, input.leagueSlug, input.seasonSlug, input.gameId].filter(Boolean),
       ),
     );
-  } catch (error) {
-    console.warn(`M2 smoke cleanup failed: ${error instanceof Error ? error.message : String(error)}`);
   } finally {
     client.destroy();
   }
@@ -267,7 +288,12 @@ async function waitForMagicLink(email: string): Promise<string> {
   return magicLink;
 }
 
-async function createAndAssignPlayer(page: Page, nickname: string, teamId: "red" | "blue" | "yellow"): Promise<string> {
+async function createAndAssignPlayer(
+  page: Page,
+  nickname: string,
+  teamId: "red" | "blue" | "yellow",
+  onCreatedPlayerId: (playerId: string) => void,
+): Promise<string> {
   await page.locator("#player-nickname").fill(nickname);
   await page.getByTestId("quick-create-player").click();
 
@@ -278,6 +304,7 @@ async function createAndAssignPlayer(page: Page, nickname: string, teamId: "red"
   if (!playerId) {
     throw new Error(`Created player ${nickname} did not expose a data-player-id.`);
   }
+  onCreatedPlayerId(playerId);
 
   await playerCard.locator(`[data-action="assign-player"][data-team-id="${teamId}"]`).click();
   await expect(page.locator(`[data-ui="roster-team"][data-team-id="${teamId}"]`)).toContainText(nickname);
@@ -324,7 +351,15 @@ test.describe("M2 local-stack smoke", () => {
     const sessionId = schedule.gameDate.replaceAll("-", "");
     let gameId = "";
     const playerIds: string[] = [];
+    const snapshotClient = createLocalDynamoClient();
+    let originalSessionMetadata: DynamoItem | null = null;
+    try {
+      originalSessionMetadata = await readSessionMetadataSnapshot(snapshotClient, sessionId);
+    } finally {
+      snapshotClient.destroy();
+    }
 
+    let testFailed = false;
     try {
       await page.goto("/sign-in?returnTo=%2Fsetup");
       await expect(page.getByTestId("signin-shell")).toBeVisible();
@@ -367,10 +402,12 @@ test.describe("M2 local-stack smoke", () => {
       await expect(page.getByTestId("game-shell")).toBeVisible();
       await expect(page.locator("#game-id-value")).toHaveText(gameId);
 
-      const ariPlayerId = await createAndAssignPlayer(page, "Ari", "red");
-      playerIds.push(ariPlayerId);
-      const beaPlayerId = await createAndAssignPlayer(page, "Bea", "blue");
-      playerIds.push(beaPlayerId);
+      const ariPlayerId = await createAndAssignPlayer(page, "Ari", "red", (playerId) => {
+        playerIds.push(playerId);
+      });
+      const beaPlayerId = await createAndAssignPlayer(page, "Bea", "blue", (playerId) => {
+        playerIds.push(playerId);
+      });
 
       await startThird(page, 1);
       await page.locator("#goal-scoring-team").selectOption("red");
@@ -409,15 +446,26 @@ test.describe("M2 local-stack smoke", () => {
       await expectAllDisabled(page.locator('[data-action="assign-player"]'));
       await expectAllDisabled(page.locator('[data-action="edit-goal"]'));
       await expectAllDisabled(page.locator('[data-action="delete-goal"]'));
+    } catch (error) {
+      testFailed = true;
+      throw error;
     } finally {
-      await cleanupSmokeRun({
-        runId,
-        leagueSlug,
-        seasonSlug,
-        gameId,
-        sessionId,
-        playerIds,
-      });
+      try {
+        await cleanupSmokeRun({
+          runId,
+          leagueSlug,
+          seasonSlug,
+          gameId,
+          sessionId,
+          playerIds,
+          originalSessionMetadata,
+        });
+      } catch (error) {
+        if (!testFailed) {
+          throw error;
+        }
+        console.warn(`M2 smoke cleanup failed after test failure: ${error instanceof Error ? error.message : String(error)}`);
+      }
     }
   });
 });

--- a/tests/e2e/m2-smoke.spec.ts
+++ b/tests/e2e/m2-smoke.spec.ts
@@ -1,12 +1,32 @@
+import {
+  DeleteItemCommand,
+  DynamoDBClient,
+  QueryCommand,
+  ScanCommand,
+  type AttributeValue,
+} from "@aws-sdk/client-dynamodb";
 import { expect, test, type Locator, type Page } from "@playwright/test";
 
 const apiBaseUrl = process.env.THREEFC_API_BASE_URL ?? "http://localhost:3001";
 const fakeSesBaseUrl = process.env.THREEFC_FAKE_SES_BASE_URL ?? "http://localhost:4025";
+const dynamodbEndpoint = process.env.THREEFC_DYNAMODB_ENDPOINT ?? "http://localhost:8000";
+const dynamodbTableName = process.env.THREEFC_DYNAMODB_TABLE ?? "threefc_local";
 const fetchTimeoutMs = 5_000;
 
 interface FakeSesMessage {
   to?: string;
   body?: string;
+}
+
+type DynamoItem = Record<string, AttributeValue>;
+
+interface SmokeRunCleanupInput {
+  runId: string;
+  leagueSlug: string;
+  seasonSlug: string;
+  gameId: string;
+  sessionId: string;
+  playerIds: string[];
 }
 
 function uniqueRunId(): string {
@@ -25,6 +45,161 @@ function scheduleForRun(runId: string): { gameDate: string; kickoff: string } {
   const kickoff = `${gameDate}T${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
 
   return { gameDate, kickoff };
+}
+
+function createLocalDynamoClient(): DynamoDBClient {
+  return new DynamoDBClient({
+    region: process.env.AWS_REGION ?? "ap-southeast-2",
+    endpoint: dynamodbEndpoint,
+    credentials: {
+      accessKeyId: "local",
+      secretAccessKey: "local",
+    },
+  });
+}
+
+function itemKey(item: DynamoItem): { pk: string; sk: string } | null {
+  const pk = item.pk?.S;
+  const sk = item.sk?.S;
+  return pk && sk ? { pk, sk } : null;
+}
+
+function itemSearchText(item: DynamoItem): string {
+  return Object.values(item)
+    .flatMap((attribute) => [attribute.S, attribute.N, attribute.BOOL?.toString()])
+    .filter((value): value is string => typeof value === "string")
+    .join("\n");
+}
+
+async function queryPartition(client: DynamoDBClient, pk: string): Promise<DynamoItem[]> {
+  const items: DynamoItem[] = [];
+  let exclusiveStartKey: Record<string, AttributeValue> | undefined;
+
+  do {
+    const response = await client.send(
+      new QueryCommand({
+        TableName: dynamodbTableName,
+        KeyConditionExpression: "pk = :pk",
+        ExpressionAttributeValues: {
+          ":pk": { S: pk },
+        },
+        ExclusiveStartKey: exclusiveStartKey,
+      }),
+    );
+    items.push(...((response.Items ?? []) as DynamoItem[]));
+    exclusiveStartKey = response.LastEvaluatedKey;
+  } while (exclusiveStartKey);
+
+  return items;
+}
+
+async function scanTaggedItems(client: DynamoDBClient, needles: string[]): Promise<DynamoItem[]> {
+  if (needles.length === 0) {
+    return [];
+  }
+
+  const items: DynamoItem[] = [];
+  let exclusiveStartKey: Record<string, AttributeValue> | undefined;
+
+  do {
+    const response = await client.send(
+      new ScanCommand({
+        TableName: dynamodbTableName,
+        ExclusiveStartKey: exclusiveStartKey,
+      }),
+    );
+    items.push(
+      ...((response.Items ?? []) as DynamoItem[]).filter((item) => {
+        const text = itemSearchText(item);
+        return needles.some((needle) => text.includes(needle));
+      }),
+    );
+    exclusiveStartKey = response.LastEvaluatedKey;
+  } while (exclusiveStartKey);
+
+  return items;
+}
+
+async function deleteItems(client: DynamoDBClient, items: DynamoItem[]): Promise<void> {
+  const seen = new Set<string>();
+
+  for (const item of items) {
+    const key = itemKey(item);
+    if (!key) {
+      continue;
+    }
+
+    const dedupeKey = `${key.pk}|${key.sk}`;
+    if (seen.has(dedupeKey)) {
+      continue;
+    }
+    seen.add(dedupeKey);
+
+    await client.send(
+      new DeleteItemCommand({
+        TableName: dynamodbTableName,
+        Key: {
+          pk: { S: key.pk },
+          sk: { S: key.sk },
+        },
+      }),
+    );
+  }
+}
+
+async function cleanupSmokeRun(input: SmokeRunCleanupInput): Promise<void> {
+  if (process.env.THREEFC_SKIP_SMOKE_CLEANUP === "1") {
+    return;
+  }
+
+  const client = createLocalDynamoClient();
+  try {
+    const partitions = [
+      `LEAGUE#${input.leagueSlug}`,
+      `SEASON#${input.seasonSlug}`,
+      ...(input.gameId ? [`GAME#${input.gameId}`] : []),
+      ...input.playerIds.filter(Boolean).map((playerId) => `PLAYER#${playerId}`),
+    ];
+
+    for (const pk of partitions) {
+      await deleteItems(client, await queryPartition(client, pk));
+    }
+
+    if (input.sessionId && input.gameId) {
+      const sessionPk = `SESSION#${input.sessionId}`;
+      const sessionItems = await queryPartition(client, sessionPk);
+      await deleteItems(
+        client,
+        sessionItems.filter((item) => {
+          const sk = item.sk?.S ?? "";
+          return sk.startsWith("GAME#") && itemSearchText(item).includes(input.gameId);
+        }),
+      );
+
+      const remainingSessionItems = await queryPartition(client, sessionPk);
+      const hasRemainingGameIndexes = remainingSessionItems.some((item) =>
+        (item.sk?.S ?? "").startsWith("GAME#"),
+      );
+      if (!hasRemainingGameIndexes) {
+        await deleteItems(
+          client,
+          remainingSessionItems.filter((item) => item.sk?.S === "METADATA"),
+        );
+      }
+    }
+
+    await deleteItems(
+      client,
+      await scanTaggedItems(
+        client,
+        [input.runId, input.leagueSlug, input.seasonSlug, input.gameId].filter(Boolean),
+      ),
+    );
+  } catch (error) {
+    console.warn(`M2 smoke cleanup failed: ${error instanceof Error ? error.message : String(error)}`);
+  } finally {
+    client.destroy();
+  }
 }
 
 async function fetchWithTimeout(url: string): Promise<Response> {
@@ -146,87 +321,103 @@ test.describe("M2 local-stack smoke", () => {
     const leagueName = `M2 Smoke League ${runId}`;
     const seasonName = `M2 Smoke Season ${runId}`;
     const schedule = scheduleForRun(runId);
+    const sessionId = schedule.gameDate.replaceAll("-", "");
+    let gameId = "";
+    const playerIds: string[] = [];
 
-    await page.goto("/sign-in?returnTo=%2Fsetup");
-    await expect(page.getByTestId("signin-shell")).toBeVisible();
-    await page.locator("#auth-email").fill(email);
-    await page.getByTestId("send-magic-link").click();
-    await expect(page.locator("#auth-status")).toContainText("Magic link sent");
+    try {
+      await page.goto("/sign-in?returnTo=%2Fsetup");
+      await expect(page.getByTestId("signin-shell")).toBeVisible();
+      await page.locator("#auth-email").fill(email);
+      await page.getByTestId("send-magic-link").click();
+      await expect(page.locator("#auth-status")).toContainText("Magic link sent");
 
-    const magicLink = await waitForMagicLink(email);
-    await page.goto(magicLink);
-    await page.waitForURL("**/setup");
-    await expect(page.getByTestId("setup-shell")).toBeVisible();
+      const magicLink = await waitForMagicLink(email);
+      await page.goto(magicLink);
+      await page.waitForURL("**/setup");
+      await expect(page.getByTestId("setup-shell")).toBeVisible();
 
-    await page.locator("#league-name").fill(leagueName);
-    await page.locator("#league-friendly-url").fill(leagueSlug);
-    await Promise.all([
-      page.waitForURL(`**/leagues/${leagueSlug}`),
-      page.getByTestId("create-league").click(),
-    ]);
-    await expect(page.locator("#league-title")).toHaveText(leagueName);
+      await page.locator("#league-name").fill(leagueName);
+      await page.locator("#league-friendly-url").fill(leagueSlug);
+      await Promise.all([
+        page.waitForURL(`**/leagues/${leagueSlug}`),
+        page.getByTestId("create-league").click(),
+      ]);
+      await expect(page.locator("#league-title")).toHaveText(leagueName);
 
-    await page.locator("#season-name").fill(seasonName);
-    await page.locator("#season-friendly-url").fill(seasonSlug);
-    await Promise.all([
-      page.waitForURL(`**/seasons/${seasonSlug}`),
-      page.getByTestId("create-season").click(),
-    ]);
-    await expect(page.locator("#season-title")).toHaveText(seasonName);
+      await page.locator("#season-name").fill(seasonName);
+      await page.locator("#season-friendly-url").fill(seasonSlug);
+      await Promise.all([
+        page.waitForURL(`**/seasons/${seasonSlug}`),
+        page.getByTestId("create-season").click(),
+      ]);
+      await expect(page.locator("#season-title")).toHaveText(seasonName);
 
-    await page.locator("#game-date").fill(schedule.gameDate);
-    await page.locator("#game-date").dispatchEvent("change");
-    await page.locator("#game-kickoff").fill(schedule.kickoff);
-    await page.locator("#game-kickoff").dispatchEvent("change");
-    const gameId = (await page.locator("#game-id-display").innerText()).trim();
-    expect(gameId).toMatch(/^game-/);
+      await page.locator("#game-date").fill(schedule.gameDate);
+      await page.locator("#game-date").dispatchEvent("change");
+      await page.locator("#game-kickoff").fill(schedule.kickoff);
+      await page.locator("#game-kickoff").dispatchEvent("change");
+      gameId = (await page.locator("#game-id-display").innerText()).trim();
+      expect(gameId).toMatch(/^game-/);
 
-    await Promise.all([
-      page.waitForURL(`**/games/${gameId}`),
-      page.getByTestId("create-game").click(),
-    ]);
-    await expect(page.getByTestId("game-shell")).toBeVisible();
-    await expect(page.locator("#game-id-value")).toHaveText(gameId);
+      await Promise.all([
+        page.waitForURL(`**/games/${gameId}`),
+        page.getByTestId("create-game").click(),
+      ]);
+      await expect(page.getByTestId("game-shell")).toBeVisible();
+      await expect(page.locator("#game-id-value")).toHaveText(gameId);
 
-    const ariPlayerId = await createAndAssignPlayer(page, "Ari", "red");
-    const beaPlayerId = await createAndAssignPlayer(page, "Bea", "blue");
+      const ariPlayerId = await createAndAssignPlayer(page, "Ari", "red");
+      playerIds.push(ariPlayerId);
+      const beaPlayerId = await createAndAssignPlayer(page, "Bea", "blue");
+      playerIds.push(beaPlayerId);
 
-    await startThird(page, 1);
-    await page.locator("#goal-scoring-team").selectOption("red");
-    await page.locator("#goal-conceding-team").selectOption("blue");
-    await page.locator("#goal-scorer").selectOption(ariPlayerId);
-    await page.locator(`#goal-assists input[value="${beaPlayerId}"]`).check();
-    await page.getByTestId("add-goal").click();
+      await startThird(page, 1);
+      await page.locator("#goal-scoring-team").selectOption("red");
+      await page.locator("#goal-conceding-team").selectOption("blue");
+      await page.locator("#goal-scorer").selectOption(ariPlayerId);
+      await page.locator(`#goal-assists input[value="${beaPlayerId}"]`).check();
+      await page.getByTestId("add-goal").click();
 
-    await expect(page.getByTestId("goal-timeline")).toContainText("Ari for Red");
-    await expect(page.getByTestId("goal-timeline")).toContainText("Assists: Bea");
-    await expect(page.locator('[data-ui="score-team"][data-team-id="red"]')).toContainText(/Scored\s*1/);
-    await expect(page.locator('[data-ui="score-team"][data-team-id="blue"]')).toContainText(/Conceded\s*1/);
+      await expect(page.getByTestId("goal-timeline")).toContainText("Ari for Red");
+      await expect(page.getByTestId("goal-timeline")).toContainText("Assists: Bea");
+      await expect(page.locator('[data-ui="score-team"][data-team-id="red"]')).toContainText(/Scored\s*1/);
+      await expect(page.locator('[data-ui="score-team"][data-team-id="blue"]')).toContainText(/Conceded\s*1/);
 
-    await finishThird(page, 1);
-    await startThird(page, 2);
-    await finishThird(page, 2);
-    await startThird(page, 3);
-    await finishThird(page, 3);
+      await finishThird(page, 1);
+      await startThird(page, 2);
+      await finishThird(page, 2);
+      await startThird(page, 3);
+      await finishThird(page, 3);
 
-    await expect(page.getByTestId("finish-game")).toBeEnabled();
-    await page.getByTestId("finish-game").click();
+      await expect(page.getByTestId("finish-game")).toBeEnabled();
+      await page.getByTestId("finish-game").click();
 
-    await expect(page.getByTestId("game-result-summary")).toBeVisible();
-    await expect(page.getByTestId("game-result-outcome")).toHaveText("Red win");
-    const resultTeams = page.getByTestId("game-result-teams");
-    await expect(resultTeams.locator('[data-ui="result-team"][data-team-id="red"]')).toContainText(/Conceded\s*0/);
-    await expect(resultTeams.locator('[data-ui="result-team"][data-team-id="red"]')).toContainText(/Scored\s*1/);
-    await expect(resultTeams.locator('[data-ui="result-team"][data-team-id="blue"]')).toContainText(/Conceded\s*1/);
-    await expect(resultTeams.locator('[data-ui="result-team"][data-team-id="blue"]')).toContainText(/Scored\s*0/);
-    await expect(page.locator("#game-edit-status")).toHaveValue("finished");
-    await expect(page.getByTestId("finish-game")).toBeDisabled();
-    await expect(page.getByTestId("finish-game")).toHaveText("Game finished");
-    await expect(page.getByTestId("delete-game")).toBeDisabled();
-    await expect(page.getByTestId("quick-create-player")).toBeDisabled();
-    await expect(page.getByTestId("add-goal")).toBeDisabled();
-    await expectAllDisabled(page.locator('[data-action="assign-player"]'));
-    await expectAllDisabled(page.locator('[data-action="edit-goal"]'));
-    await expectAllDisabled(page.locator('[data-action="delete-goal"]'));
+      await expect(page.getByTestId("game-result-summary")).toBeVisible();
+      await expect(page.getByTestId("game-result-outcome")).toHaveText("Red win");
+      const resultTeams = page.getByTestId("game-result-teams");
+      await expect(resultTeams.locator('[data-ui="result-team"][data-team-id="red"]')).toContainText(/Conceded\s*0/);
+      await expect(resultTeams.locator('[data-ui="result-team"][data-team-id="red"]')).toContainText(/Scored\s*1/);
+      await expect(resultTeams.locator('[data-ui="result-team"][data-team-id="blue"]')).toContainText(/Conceded\s*1/);
+      await expect(resultTeams.locator('[data-ui="result-team"][data-team-id="blue"]')).toContainText(/Scored\s*0/);
+      await expect(page.locator("#game-edit-status")).toHaveValue("finished");
+      await expect(page.getByTestId("finish-game")).toBeDisabled();
+      await expect(page.getByTestId("finish-game")).toHaveText("Game finished");
+      await expect(page.getByTestId("delete-game")).toBeDisabled();
+      await expect(page.getByTestId("quick-create-player")).toBeDisabled();
+      await expect(page.getByTestId("add-goal")).toBeDisabled();
+      await expectAllDisabled(page.locator('[data-action="assign-player"]'));
+      await expectAllDisabled(page.locator('[data-action="edit-goal"]'));
+      await expectAllDisabled(page.locator('[data-action="delete-goal"]'));
+    } finally {
+      await cleanupSmokeRun({
+        runId,
+        leagueSlug,
+        seasonSlug,
+        gameId,
+        sessionId,
+        playerIds,
+      });
+    }
   });
 });

--- a/tests/e2e/m2-smoke.spec.ts
+++ b/tests/e2e/m2-smoke.spec.ts
@@ -6,6 +6,7 @@ import {
   ScanCommand,
   type AttributeValue,
 } from "@aws-sdk/client-dynamodb";
+import { createHash } from "node:crypto";
 import { expect, test, type Locator, type Page } from "@playwright/test";
 
 const apiBaseUrl = process.env.THREEFC_API_BASE_URL ?? "http://localhost:3001";
@@ -24,12 +25,30 @@ type DynamoItem = Record<string, AttributeValue>;
 interface SmokeRunCleanupInput {
   runId: string;
   email: string;
+  clientIp: string;
   leagueSlug: string;
   seasonSlug: string;
   gameId: string;
   sessionId: string;
   playerIds: string[];
   originalSessionMetadata: DynamoItem | null;
+}
+
+function authRateLimitHash(dimension: "email" | "ip", identifier: string): string {
+  return createHash("sha256")
+    .update(`magic-link-start:${dimension}:${identifier}`, "utf8")
+    .digest("hex");
+}
+
+function authRateLimitPkPrefix(dimension: "email" | "ip", identifier: string): string {
+  const normalizedIdentifier = dimension === "email" ? identifier.trim().toLowerCase() : identifier.trim();
+  return [
+    "AUTH_RATE_LIMIT",
+    "magic-link-start",
+    dimension,
+    authRateLimitHash(dimension, normalizedIdentifier || "unknown"),
+    "",
+  ].join("#");
 }
 
 function uniqueRunId(): string {
@@ -137,6 +156,36 @@ async function scanTaggedItems(client: DynamoDBClient, needles: string[]): Promi
   return items;
 }
 
+async function scanAuthRateLimitItems(
+  client: DynamoDBClient,
+  input: { email: string; clientIp: string },
+): Promise<DynamoItem[]> {
+  const prefixes = [
+    authRateLimitPkPrefix("email", input.email),
+    authRateLimitPkPrefix("ip", input.clientIp),
+  ];
+  const items: DynamoItem[] = [];
+  let exclusiveStartKey: Record<string, AttributeValue> | undefined;
+
+  do {
+    const response = await client.send(
+      new ScanCommand({
+        TableName: dynamodbTableName,
+        ExclusiveStartKey: exclusiveStartKey,
+      }),
+    );
+    items.push(
+      ...((response.Items ?? []) as DynamoItem[]).filter((item) => {
+        const pk = item.pk?.S ?? "";
+        return item.sk?.S === "METADATA" && prefixes.some((prefix) => pk.startsWith(prefix));
+      }),
+    );
+    exclusiveStartKey = response.LastEvaluatedKey;
+  } while (exclusiveStartKey);
+
+  return items;
+}
+
 async function deleteItems(client: DynamoDBClient, items: DynamoItem[]): Promise<void> {
   const seen = new Set<string>();
 
@@ -219,6 +268,7 @@ async function cleanupSmokeRun(input: SmokeRunCleanupInput): Promise<void> {
         [input.runId, input.leagueSlug, input.seasonSlug, input.gameId].filter(Boolean),
       ),
     );
+    await deleteItems(client, await scanAuthRateLimitItems(client, input));
 
     await deleteFakeSesMessages(input.email);
   } finally {
@@ -356,6 +406,7 @@ test.describe("M2 local-stack smoke", () => {
   test("scorekeeper can set up and finish a live game", async ({ page }) => {
     const runId = uniqueRunId();
     const email = `m2-smoke-${runId}@example.com`;
+    const clientIp = `m2-smoke-${runId}`;
     const leagueSlug = `m2-smoke-league-${runId}`;
     const seasonSlug = `m2-smoke-season-${runId}`;
     const leagueName = `M2 Smoke League ${runId}`;
@@ -376,6 +427,7 @@ test.describe("M2 local-stack smoke", () => {
 
     let testFailed = false;
     try {
+      await page.setExtraHTTPHeaders({ "x-forwarded-for": clientIp });
       await page.goto("/sign-in?returnTo=%2Fsetup");
       await expect(page.getByTestId("signin-shell")).toBeVisible();
       await page.locator("#auth-email").fill(email);
@@ -469,6 +521,7 @@ test.describe("M2 local-stack smoke", () => {
         await cleanupSmokeRun({
           runId,
           email,
+          clientIp,
           leagueSlug,
           seasonSlug,
           gameId,

--- a/tests/e2e/m2-smoke.spec.ts
+++ b/tests/e2e/m2-smoke.spec.ts
@@ -52,18 +52,39 @@ function uniqueRunId(): string {
   return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
-function scheduleForRun(runId: string): { gameDate: string; kickoff: string } {
+function sessionIdForGameDate(gameDate: string): string {
+  return gameDate.replaceAll("-", "");
+}
+
+function scheduleCandidateForRun(runId: string, probe: number): { gameDate: string; kickoff: string } {
   const hash = [...runId].reduce((value, character) => {
     return (value * 33 + character.charCodeAt(0)) >>> 0;
   }, 5381);
   const date = new Date(Date.UTC(2027, 0, 1));
-  date.setUTCDate(date.getUTCDate() + (hash % 20_000));
+  date.setUTCDate(date.getUTCDate() + ((hash + probe * 9973) % 20_000));
   const gameDate = date.toISOString().slice(0, 10);
   const hour = 8 + (hash % 10);
   const minute = [0, 15, 30, 45][Math.floor(hash / 10) % 4];
   const kickoff = `${gameDate}T${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
 
   return { gameDate, kickoff };
+}
+
+async function scheduleForRun(runId: string): Promise<{ gameDate: string; kickoff: string }> {
+  const client = createLocalDynamoClient();
+  try {
+    for (let probe = 0; probe < 200; probe += 1) {
+      const schedule = scheduleCandidateForRun(runId, probe);
+      const sessionItems = await queryPartition(client, `SESSION#${sessionIdForGameDate(schedule.gameDate)}`);
+      if (sessionItems.length === 0) {
+        return schedule;
+      }
+    }
+  } finally {
+    client.destroy();
+  }
+
+  throw new Error("Could not find an unused smoke-test session date after 200 probes.");
 }
 
 function createLocalDynamoClient(): DynamoDBClient {
@@ -388,8 +409,8 @@ test.describe("M2 local-stack smoke", () => {
     const seasonName = `M2 Smoke Season ${runId}`;
     const ariNickname = `Ari ${runId}`;
     const beaNickname = `Bea ${runId}`;
-    const schedule = scheduleForRun(runId);
-    const sessionId = schedule.gameDate.replaceAll("-", "");
+    const schedule = await scheduleForRun(runId);
+    const sessionId = sessionIdForGameDate(schedule.gameDate);
     let gameId = "";
     const playerIds: string[] = [];
 


### PR DESCRIPTION
<!-- review-packet-version:1 -->

## Behavioural claim

Adds local-stack Playwright smoke coverage for the M2 match flow so frontend/API integration can be exercised through a browser-oriented path, while hardening local smoke cleanup used by that flow. The smoke exercises existing finished-result rendering and creator-admin post-finish correction controls; this PR does not modify production rendering behaviour.

## Specification and acceptance evidence

| Acceptance criterion | Evidence | Result |
| --- | --- | --- |
| M2 Playwright smoke test is discoverable by the configured runner after rebase. | `npm run smoke:m2:playwright -- --list` on rebased branch `codex/m2-07-playwright-smoke` at `cd5d429` | PASS |
| Root validation remains green after rebase and review fixes. | `npm test` on rebased branch `codex/m2-07-playwright-smoke` at `cd5d429` | PASS |
| Smoke scheduling avoids occupied local DynamoDB session partitions, and cleanup removes smoke-owned records, fake-SES messages, email rate-limit items, and the smoke's touched IP rate-limit attempt without deleting unrelated session metadata or unrelated IP attempts. | `scheduleForRun` probes for an empty `SESSION#<sessionId>` partition; `tests/e2e/m2-smoke.spec.ts` snapshots all local IP rate-limit buckets before/after magic-link rate-limit consumption, detects Docker bridge buckets without hard-coded address candidates, treats `202` and post-rate-limit server failures as consumed attempts, excludes pre-consumption `400`/`403`/`429` responses, and skips IP cleanup when the observed delta is ambiguous; `THREEFC_SKIP_WEB_SERVER=1 npm run smoke:m2:playwright -- -g "smoke cleanup" --project=chromium-mobile`; `npm run smoke:m2:playwright -- --list`. | PASS |
| Browser happy path exercises sign-in, league/season/game setup, player assignment, scoring, finish, result rendering, and creator-admin post-finish correction-control assertions against the local stack. | Fresh-stack run after `make dev-down`: `npm run smoke:m2:playwright -- -g "scorekeeper can set up and finish a live game" --project=chromium-mobile` | PASS |
| Finished-result rendering remains covered by browser smoke assertions without changing production rendering code in this PR. | `tests/e2e/m2-smoke.spec.ts` asserts the normal finished result; parent #92 contains the production rendering behaviour and admin correction coverage. | PASS |

## Scope boundaries

Included: Playwright configuration, local-stack M2 smoke test, probe-based empty session-date selection, smoke cleanup behaviour for local DynamoDB state, dimension-wide local IP rate-limit cleanup detection, smoke-related package scripts/dependencies, local development documentation, CI/deploy workflow install controls for Playwright browser downloads, supporting security regression coverage, and smoke assertions over existing finished-result rendering and creator-admin post-finish correction controls.

Excluded: new product features, production app rendering changes, public API schema changes, production data migration, and join-code registration.

## Change classification

- Declared risk: `high`
- [ ] `documentation-only` - Documentation only
- [x] `tests-only` - Tests only
- [ ] `application-behaviour` - Application or API behaviour
- [ ] `backlog-maintenance` - Canonical backlog maintenance
- [x] `dependency-tooling` - Dependency or tooling
- [ ] `public-contract` - Public API or repository contract
- [ ] `data-migration` - Database schema or data migration
- [ ] `permission-trust-boundary` - Permission or trust boundary
- [x] `durable-state-ownership` - Durable state or ownership
- [ ] `destructive-behaviour` - Destructive or difficult-to-reverse behaviour
- [ ] `new-production-dependency` - New production dependency
- [ ] `authentication-authorisation` - Authentication or authorisation
- [ ] `privacy-regulated-data` - Privacy or regulated data
- [x] `infrastructure-production-configuration` - Infrastructure or deployment control
- [ ] `review-policy` - Review policy, packet, or workflow

## Architecture and invariants

- [ ] `architecture:none`
- [x] `architecture:documented`
- [ ] `architecture:judgement-required`

### Affected invariants

| Invariant | How this PR affects it | Why it remains valid | Evidence |
| --- | --- | --- | --- |
| INV-004 | The local Playwright smoke chooses a future date whose `SESSION#<sessionId>` partition is empty, then creates and cleans local DynamoDB league, season, game, player, session-game, tagged, email auth-rate-limit, touched IP auth-rate-limit, and Fake SES records. | The smoke no longer claims snapshot/restore of pre-existing metadata. Empty-date probing avoids shared session partitions up front; cleanup explicitly preserves unrelated `SESSION#<sessionId>/METADATA`, deletes smoke-owned email rate-limit rows, snapshots all local IP auth-rate-limit buckets so Docker bridge/gateway addresses are detected without hard-coded candidates, and decrements an IP bucket only after confirmed magic-link rate-limit consumption when exactly one local IP attempt increased. | `THREEFC_SKIP_WEB_SERVER=1 npm run smoke:m2:playwright -- -g "smoke cleanup" --project=chromium-mobile`; `npm run smoke:m2:playwright -- -g "scorekeeper can set up and finish a live game" --project=chromium-mobile`; `npm run smoke:m2:playwright -- --list`; `npm test` |

### Architecture or decision record

This PR adds test/tooling infrastructure and modifies CI/deploy workflow environment handling so Playwright browser binaries are skipped outside the dedicated smoke runner. It also hardens local smoke durable-state cleanup and uses probe-based empty session-date selection without changing canonical production key ownership, public API schemas, or production rendering code.

## Failure and rollback

### Failure behaviour

If the smoke runner or local services are unavailable, the smoke command fails without changing production code paths. If cleanup fails after an otherwise successful smoke flow, the smoke fails so local durable state does not silently accumulate. If the smoke flow itself already failed, cleanup errors are logged without masking the original diagnostic failure. If the magic-link start is rejected before rate-limit consumption or more than one local IP auth-rate-limit attempt changes during the smoke window, cleanup skips IP decrementing rather than mutating an ambiguous unrelated bucket. If a post-rate-limit service failure occurs, cleanup still considers the smoke's consumed IP attempt for removal.

### Rollback approach

Revert the merge commit for this PR and restore the previous package lock, workflow configuration, Playwright config, and smoke spec. No production data rollback is required.

### Rollback evidence

Validated with `THREEFC_SKIP_WEB_SERVER=1 npm run smoke:m2:playwright -- -g "smoke cleanup" --project=chromium-mobile`, `npm run smoke:m2:playwright -- -g "scorekeeper can set up and finish a live game" --project=chromium-mobile`, `npm run smoke:m2:playwright -- --list`, and `npm test` on rebased branch `codex/m2-07-playwright-smoke` at `cd5d429`.

## Automated and agent review disposition

### Unresolved blocking findings

None.

### Rejected findings and evidence

None. Resolved review thread `PRRT_kwDORVMqbs6TuscQ` by removing hard-coded local browser IP candidates, scanning all local IP auth-rate-limit buckets, and adding cleanup coverage for Docker bridge-style buckets plus ambiguous concurrent IP changes. Resolved review thread `PRRT_kwDORVMqbs6Tu0as` by only deriving IP cleanup keys after confirmed magic-link rate-limit consumption and adding a regression showing a rate-limited request does not attribute an unrelated IP increment to the smoke. Resolved review thread `PRRT_kwDORVMqbs6Tu_Ie` by treating post-rate-limit server failures as consumed attempts while still excluding pre-consumption `400`/`403`/`429` responses. Resolved review thread `PRRT_kwDORVMqbs6TvDcH` by asserting creator-admin roster correction controls stay enabled after finish and verifying against a fresh local stack. Resolved review thread `PRRT_kwDORVMqbs6TvDcI` by updating the packet evidence and failure behaviour to describe the final 5xx post-rate-limit cleanup path.

## Human judgement

- [ ] `human-judgement:none`
- [x] `human-judgement:required`

### Decision requiring judgement

Confirm the operational tradeoff of adding Playwright as a dev dependency and updating CI/deploy workflows to skip browser downloads outside the smoke runner.

### Options considered

Keep Playwright out of the repo and rely only on jsdom/unit smoke coverage; add Playwright in this repo with CI install controls; or split e2e into a separate package later.

### Reason selected

In-repo Playwright gives a real browser integration path for M2 while the workflow environment controls limit CI/deploy install overhead.

### Reversal cost

Low to medium: remove the Playwright dependency/config/spec and revert workflow environment changes.

## Review focus

Please inspect smoke reliability, local service assumptions, local DynamoDB cleanup safety, workflow install controls, and whether the smoke flow covers the critical M2 happy path without brittle timing dependencies.

Fixes #31
