### PR TITLE
[codex] Add M2 join-code registration

### DIFF
--- a/api/src/contracts/core-write.ts
+++ b/api/src/contracts/core-write.ts
@@ -5,6 +5,7 @@ const nonEmptyTrimmedString = z.string().trim().min(1, "must be a non-empty stri
 const optionalNullableString = z.string().nullable().optional();
 const teamIdSchema = z.enum(TEAM_IDS);
 const joinCodePathPattern = /^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{8}$/;
+export const PUBLIC_JOIN_NICKNAME_MAX_LENGTH = 80;
 const thirdLengthMinutesSchema = z.union([
   z.literal(THIRD_LENGTH_MINUTES[0]),
   z.literal(THIRD_LENGTH_MINUTES[1]),
@@ -67,7 +68,10 @@ export const quickCreateGamePlayerRequestSchema = z
 
 export const joinGameRequestSchema = z
   .object({
-    nickname: nonEmptyTrimmedString,
+    nickname: nonEmptyTrimmedString.max(
+      PUBLIC_JOIN_NICKNAME_MAX_LENGTH,
+      `must be ${PUBLIC_JOIN_NICKNAME_MAX_LENGTH} characters or fewer`,
+    ),
   })
   .strict();
 

--- a/api/src/contracts/core-write.ts
+++ b/api/src/contracts/core-write.ts
@@ -4,6 +4,7 @@ import { MAX_ASSISTS, TEAM_IDS, THIRD_LENGTH_MINUTES } from "@3fc/contracts";
 const nonEmptyTrimmedString = z.string().trim().min(1, "must be a non-empty string");
 const optionalNullableString = z.string().nullable().optional();
 const teamIdSchema = z.enum(TEAM_IDS);
+const joinCodePathPattern = /^[A-Z0-9]{8}$/;
 const thirdLengthMinutesSchema = z.union([
   z.literal(THIRD_LENGTH_MINUTES[0]),
   z.literal(THIRD_LENGTH_MINUTES[1]),
@@ -69,6 +70,14 @@ export const joinGameRequestSchema = z
     nickname: nonEmptyTrimmedString,
   })
   .strict();
+
+export function normalizeJoinCodePathParam(joinCode: string): string {
+  return joinCode.trim().toUpperCase();
+}
+
+export function isJoinCodePathParamValid(joinCode: string): boolean {
+  return joinCodePathPattern.test(joinCode);
+}
 
 export const assignRosterPlayerRequestSchema = z
   .object({

--- a/api/src/contracts/core-write.ts
+++ b/api/src/contracts/core-write.ts
@@ -64,6 +64,12 @@ export const quickCreateGamePlayerRequestSchema = z
   })
   .strict();
 
+export const joinGameRequestSchema = z
+  .object({
+    nickname: nonEmptyTrimmedString,
+  })
+  .strict();
+
 export const assignRosterPlayerRequestSchema = z
   .object({
     teamId: teamIdSchema,
@@ -190,6 +196,7 @@ export type CreateSessionRequest = z.infer<typeof createSessionRequestSchema>;
 export type CreateGameRequest = z.infer<typeof createGameRequestSchema>;
 export type UpsertTeamRequest = z.infer<typeof upsertTeamRequestSchema>;
 export type QuickCreateGamePlayerRequest = z.infer<typeof quickCreateGamePlayerRequestSchema>;
+export type JoinGameRequest = z.infer<typeof joinGameRequestSchema>;
 export type AssignRosterPlayerRequest = z.infer<typeof assignRosterPlayerRequestSchema>;
 export type CreateGoalRequest = z.infer<typeof createGoalRequestSchema>;
 export type UpdateGoalRequest = z.infer<typeof updateGoalRequestSchema>;

--- a/api/src/contracts/core-write.ts
+++ b/api/src/contracts/core-write.ts
@@ -4,7 +4,7 @@ import { MAX_ASSISTS, TEAM_IDS, THIRD_LENGTH_MINUTES } from "@3fc/contracts";
 const nonEmptyTrimmedString = z.string().trim().min(1, "must be a non-empty string");
 const optionalNullableString = z.string().nullable().optional();
 const teamIdSchema = z.enum(TEAM_IDS);
-const joinCodePathPattern = /^[A-Z0-9]{8}$/;
+const joinCodePathPattern = /^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{8}$/;
 const thirdLengthMinutesSchema = z.union([
   z.literal(THIRD_LENGTH_MINUTES[0]),
   z.literal(THIRD_LENGTH_MINUTES[1]),

--- a/api/src/data/keys.ts
+++ b/api/src/data/keys.ts
@@ -4,6 +4,7 @@ export const ENTITY_PK_PREFIX = {
   game: "GAME#",
   session: "SESSION#",
   player: "PLAYER#",
+  joinCode: "JOIN_CODE#",
   idempotency: "IDEMPOTENCY#",
 } as const;
 
@@ -37,6 +38,10 @@ export function gamePk(gameId: string): string {
 
 export function playerPk(playerId: string): string {
   return `${ENTITY_PK_PREFIX.player}${playerId}`;
+}
+
+export function joinCodePk(joinCode: string): string {
+  return `${ENTITY_PK_PREFIX.joinCode}${joinCode}`;
 }
 
 export function idempotencyPk(scope: string, key: string): string {

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -309,6 +309,7 @@ function isValidTimestamp(value: unknown): value is string {
 
 const JOIN_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
 const JOIN_CODE_LENGTH = 8;
+const JOIN_CODE_PATTERN = /^[A-Z0-9]{8}$/;
 
 export function buildJoinCodeForGameId(gameId: string): string {
   const digest = createHash("sha256").update(`3fc:join:${gameId}`).digest();
@@ -323,6 +324,15 @@ export function buildJoinCodeForGameId(gameId: string): string {
 
 function normalizeJoinCode(joinCode: string): string {
   return joinCode.trim().toUpperCase();
+}
+
+function normalizeCustomJoinCode(joinCode: string): string {
+  const normalizedJoinCode = normalizeJoinCode(joinCode);
+  if (!JOIN_CODE_PATTERN.test(normalizedJoinCode)) {
+    throw new Error("joinCode must be 8 letters or digits.");
+  }
+
+  return normalizedJoinCode;
 }
 
 function normalizeGameResultPayload(value: unknown): GameResult | null {
@@ -1289,9 +1299,9 @@ export class ThreeFcRepository {
     }
 
     const now = this.clock.now();
-    const joinCode = normalizeJoinCode(
-      input.joinCode?.trim() ? input.joinCode : buildJoinCodeForGameId(input.gameId),
-    );
+    const joinCode = input.joinCode?.trim()
+      ? normalizeCustomJoinCode(input.joinCode)
+      : buildJoinCodeForGameId(input.gameId);
     const payload = {
       gameId: input.gameId,
       joinCode,

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -309,6 +309,8 @@ function isValidTimestamp(value: unknown): value is string {
 
 const JOIN_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
 const JOIN_CODE_LENGTH = 8;
+const LEGACY_JOIN_CODE_REPAIR_ATTEMPTS = 16;
+const LEGACY_JOIN_CODE_REPAIR_RACE_RETRIES = 3;
 const JOIN_CODE_PATTERN = /^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{8}$/;
 
 export function buildJoinCodeForGameId(gameId: string): string {
@@ -324,6 +326,10 @@ export function buildJoinCodeForGameId(gameId: string): string {
 
 function normalizeJoinCode(joinCode: string): string {
   return joinCode.trim().toUpperCase();
+}
+
+function buildLegacyJoinCodeRepairCandidate(gameId: string, attempt: number): string {
+  return attempt === 0 ? buildJoinCodeForGameId(gameId) : buildJoinCodeForGameId(`${gameId}:${attempt}`);
 }
 
 function normalizeCustomJoinCode(joinCode: string): string {
@@ -1396,7 +1402,7 @@ export class ThreeFcRepository {
     const rawGame = item.data as Partial<Omit<GameRecord, "createdAt" | "updatedAt">>;
     const game = withTimestamps(normalizeGamePayload(item.data), item.createdAt, item.updatedAt);
     if (typeof rawGame.joinCode !== "string" || rawGame.joinCode.trim().length === 0) {
-      await this.ensureGameJoinCodeLookup(game);
+      return this.repairLegacyGameJoinCode(item);
     }
 
     return game;
@@ -4043,51 +4049,139 @@ export class ThreeFcRepository {
     );
   }
 
-  private async ensureGameJoinCodeLookup(game: Pick<GameRecord, "gameId" | "joinCode">): Promise<void> {
-    if (game.gameId.trim().length === 0) {
-      return;
-    }
+  private async repairLegacyGameJoinCode(stored: StoredEntity<unknown>): Promise<GameRecord> {
+    let currentStored = stored;
 
-    const joinCode = normalizeJoinCode(game.joinCode);
-    if (joinCode.length === 0) {
-      return;
-    }
-
-    const existing = await this.getEntity(joinCodePk(joinCode), metadataSk(), { consistentRead: true });
-    if (existing?.entityType === ENTITY_TYPE.gameJoinCode) {
-      const existingRecord = existing.data as Partial<GameJoinCodeRecord>;
-      if (existingRecord.gameId === game.gameId) {
-        return;
+    for (let raceAttempt = 0; raceAttempt < LEGACY_JOIN_CODE_REPAIR_RACE_RETRIES; raceAttempt += 1) {
+      const rawGame = currentStored.data as Partial<Omit<GameRecord, "createdAt" | "updatedAt">>;
+      const currentGame = normalizeGamePayload(currentStored.data);
+      if (typeof rawGame.joinCode === "string" && rawGame.joinCode.trim().length > 0) {
+        return withTimestamps(currentGame, currentStored.createdAt, currentStored.updatedAt);
       }
 
-      return;
+      const seenCandidates = new Set<string>();
+      for (
+        let candidateAttempt = 0;
+        candidateAttempt < LEGACY_JOIN_CODE_REPAIR_ATTEMPTS;
+        candidateAttempt += 1
+      ) {
+        const joinCode = buildLegacyJoinCodeRepairCandidate(currentGame.gameId, candidateAttempt);
+        if (seenCandidates.has(joinCode)) {
+          continue;
+        }
+        seenCandidates.add(joinCode);
+
+        const joinCodeItem = await this.getEntity(joinCodePk(joinCode), metadataSk(), {
+          consistentRead: true,
+        });
+        if (joinCodeItem?.entityType === ENTITY_TYPE.gameJoinCode) {
+          const joinCodeRecord = joinCodeItem.data as Partial<GameJoinCodeRecord>;
+          if (joinCodeRecord.gameId !== currentGame.gameId) {
+            continue;
+          }
+        } else if (joinCodeItem) {
+          continue;
+        }
+
+        const repairedGame = await this.writeLegacyGameJoinCodeRepair({
+          stored: currentStored,
+          game: currentGame,
+          joinCode,
+          joinCodeItem: joinCodeItem?.entityType === ENTITY_TYPE.gameJoinCode ? joinCodeItem : null,
+        });
+        if (repairedGame) {
+          return repairedGame;
+        }
+
+        break;
+      }
+
+      const latest = await this.getEntity(gamePk(currentGame.gameId), metadataSk(), {
+        consistentRead: true,
+      });
+      if (!latest || latest.entityType !== ENTITY_TYPE.game) {
+        return withTimestamps(currentGame, currentStored.createdAt, currentStored.updatedAt);
+      }
+      currentStored = latest;
     }
 
+    throw new GameJoinCodeCollisionError(
+      "Could not repair legacy game join code without a collision.",
+    );
+  }
+
+  private async writeLegacyGameJoinCodeRepair(input: {
+    stored: StoredEntity<unknown>;
+    game: Omit<GameRecord, "createdAt" | "updatedAt">;
+    joinCode: string;
+    joinCodeItem: StoredEntity<unknown> | null;
+  }): Promise<GameRecord | null> {
     const now = this.clock.now();
-    try {
-      await this.client.send(
-        new PutItemCommand({
+    const repairedGame = {
+      ...input.game,
+      joinCode: input.joinCode,
+    };
+    const transactionItems: TransactWriteItem[] = [
+      this.buildGamePutTransactionItem({
+        game: repairedGame,
+        stored: input.stored,
+        now,
+      }),
+    ];
+
+    if (input.joinCodeItem) {
+      transactionItems.push({
+        ConditionCheck: {
+          TableName: this.tableName,
+          Key: {
+            pk: { S: joinCodePk(input.joinCode) },
+            sk: { S: metadataSk() },
+          },
+          ConditionExpression: "#updatedAt = :expectedJoinCodeUpdatedAt AND #data = :expectedJoinCodeData",
+          ExpressionAttributeNames: {
+            "#updatedAt": "updatedAt",
+            "#data": "data",
+          },
+          ExpressionAttributeValues: {
+            ":expectedJoinCodeUpdatedAt": { S: input.joinCodeItem.updatedAt },
+            ":expectedJoinCodeData": { S: input.joinCodeItem.rawData },
+          },
+        },
+      });
+    } else {
+      transactionItems.push({
+        Put: {
           TableName: this.tableName,
           Item: buildItem(
-            joinCodePk(joinCode),
+            joinCodePk(input.joinCode),
             metadataSk(),
             ENTITY_TYPE.gameJoinCode,
             {
-              joinCode,
-              gameId: game.gameId,
+              joinCode: input.joinCode,
+              gameId: input.game.gameId,
             },
             now,
           ),
           ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
+        },
+      });
+    }
+
+    try {
+      await this.client.send(
+        new TransactWriteItemsCommand({
+          TransactItems: transactionItems,
         }),
       );
     } catch (error) {
       if (isConditionalWriteFailure(error)) {
-        return;
+        return null;
       }
 
       throw error;
     }
+
+    return withTimestamps(repairedGame, input.stored.createdAt, now);
   }
 
   private async putEntityWithTimestampsIfUnchanged<T>(

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -200,6 +200,13 @@ export class GameJoinCodeCollisionError extends Error {
   }
 }
 
+export class GameAlreadyExistsError extends Error {
+  constructor(gameId: string) {
+    super(`Game ${gameId} already exists.`);
+    this.name = "GameAlreadyExistsError";
+  }
+}
+
 export class GameJoinRegistrationError extends Error {
   constructor(
     readonly code: "game_finished" | "join_state_changed",
@@ -710,6 +717,11 @@ function isConditionalWriteFailure(error: unknown): boolean {
       reason.Code === "ConditionalCheckFailed" ||
       reason.Code === "ConditionalCheckFailedException",
   );
+}
+
+function transactionCancellationCode(error: unknown, index: number): string | null {
+  const reason = (error as { CancellationReasons?: Array<{ Code?: string }> }).CancellationReasons?.[index];
+  return typeof reason?.Code === "string" ? reason.Code : null;
 }
 
 function readString(value: AttributeValue | undefined, field: string): string {
@@ -1317,7 +1329,25 @@ export class ThreeFcRepository {
       );
     } catch (error) {
       if (isConditionalWriteFailure(error)) {
-        throw new GameJoinCodeCollisionError();
+        const gameCancellationCode = transactionCancellationCode(error, 0);
+        const joinCodeCancellationCode = transactionCancellationCode(error, 1);
+        if (gameCancellationCode === "ConditionalCheckFailed") {
+          throw new GameAlreadyExistsError(input.gameId);
+        }
+        if (joinCodeCancellationCode === "ConditionalCheckFailed") {
+          throw new GameJoinCodeCollisionError();
+        }
+
+        const [existingGameItem, existingJoinCodeItem] = await Promise.all([
+          this.getEntity(gamePk(input.gameId), metadataSk(), { consistentRead: true }),
+          this.getEntity(joinCodePk(joinCode), metadataSk(), { consistentRead: true }),
+        ]);
+        if (existingGameItem?.entityType === ENTITY_TYPE.game) {
+          throw new GameAlreadyExistsError(input.gameId);
+        }
+        if (existingJoinCodeItem?.entityType === ENTITY_TYPE.gameJoinCode) {
+          throw new GameJoinCodeCollisionError();
+        }
       }
 
       throw error;
@@ -1340,14 +1370,27 @@ export class ThreeFcRepository {
     const normalizedJoinCode = normalizeJoinCode(joinCode);
     requireNonEmpty("joinCode", normalizedJoinCode);
 
-    const joinCodeItem = await this.getEntity(joinCodePk(normalizedJoinCode), metadataSk());
+    const joinCodeItem = await this.getEntity(joinCodePk(normalizedJoinCode), metadataSk(), {
+      consistentRead: true,
+    });
     if (joinCodeItem?.entityType === ENTITY_TYPE.gameJoinCode) {
       const joinCodeRecord = withTimestamps(
         joinCodeItem.data as Omit<GameJoinCodeRecord, "createdAt" | "updatedAt">,
         joinCodeItem.createdAt,
         joinCodeItem.updatedAt,
       );
-      const game = await this.getGame(joinCodeRecord.gameId);
+      const gameItem = await this.getEntity(gamePk(joinCodeRecord.gameId), metadataSk(), {
+        consistentRead: true,
+      });
+      if (!gameItem || gameItem.entityType !== ENTITY_TYPE.game) {
+        return null;
+      }
+
+      const game = withTimestamps(
+        normalizeGamePayload(gameItem.data),
+        gameItem.createdAt,
+        gameItem.updatedAt,
+      );
 
       if (game && normalizeJoinCode(game.joinCode) === normalizedJoinCode) {
         return game;

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -1430,12 +1430,8 @@ export class ThreeFcRepository {
       return null;
     }
 
-    const rawGame = item.data as Partial<Omit<GameRecord, "createdAt" | "updatedAt">>;
     const game = withTimestamps(normalizeGamePayload(item.data), item.createdAt, item.updatedAt);
-    if (
-      options.repairLegacyJoinCode &&
-      (typeof rawGame.joinCode !== "string" || rawGame.joinCode.trim().length === 0)
-    ) {
+    if (options.repairLegacyJoinCode) {
       return this.repairLegacyGameJoinCode(item);
     }
 
@@ -1508,6 +1504,15 @@ export class ThreeFcRepository {
     );
     if (normalizeJoinCode(game.joinCode) !== normalizedJoinCode) {
       return null;
+    }
+
+    const existingReplay = await this.readExistingJoinRegistration({
+      game,
+      playerId: input.playerId,
+      nickname: input.nickname,
+    });
+    if (existingReplay) {
+      return existingReplay;
     }
 
     if (game.status === "finished") {
@@ -1594,6 +1599,15 @@ export class ThreeFcRepository {
       );
     } catch (error) {
       if (isConditionalWriteFailure(error)) {
+        const replayedJoin = await this.readExistingJoinRegistration({
+          game,
+          playerId: input.playerId,
+          nickname: input.nickname,
+        });
+        if (replayedJoin) {
+          return replayedJoin;
+        }
+
         throw new GameJoinRegistrationError(
           "join_state_changed",
           409,
@@ -1608,6 +1622,49 @@ export class ThreeFcRepository {
       game,
       player: withTimestamps(playerPayload, now, now),
       link: withTimestamps(linkPayload, now, now),
+    };
+  }
+
+  private async readExistingJoinRegistration(input: {
+    game: GameRecord;
+    playerId: string;
+    nickname: string;
+  }): Promise<JoinGameByCodeResult | null> {
+    const [playerItem, linkItem] = await Promise.all([
+      this.getEntity(playerPk(input.playerId), profileSk(), { consistentRead: true }),
+      this.getEntity(gamePk(input.game.gameId), gamePlayerSk(input.playerId), {
+        consistentRead: true,
+      }),
+    ]);
+    if (playerItem?.entityType !== ENTITY_TYPE.player || linkItem?.entityType !== ENTITY_TYPE.gamePlayer) {
+      return null;
+    }
+
+    const player = withTimestamps(
+      playerItem.data as Omit<PlayerRecord, "createdAt" | "updatedAt">,
+      playerItem.createdAt,
+      playerItem.updatedAt,
+    );
+    const link = withTimestamps(
+      linkItem.data as Omit<GamePlayerRecord, "createdAt" | "updatedAt">,
+      linkItem.createdAt,
+      linkItem.updatedAt,
+    );
+
+    if (
+      player.playerId !== input.playerId ||
+      player.nickname !== input.nickname ||
+      player.claimedByUserId !== null ||
+      link.gameId !== input.game.gameId ||
+      link.playerId !== input.playerId
+    ) {
+      return null;
+    }
+
+    return {
+      game: input.game,
+      player,
+      link,
     };
   }
 
@@ -1695,7 +1752,7 @@ export class ThreeFcRepository {
       throw new Error("At least one game field must be updated.");
     }
 
-    const gameItem = await this.getEntity(gamePk(input.gameId), metadataSk());
+    const gameItem = await this.readMutableGameEntity(input.gameId);
     if (!gameItem || gameItem.entityType !== ENTITY_TYPE.game) {
       return null;
     }
@@ -1813,7 +1870,7 @@ export class ThreeFcRepository {
     requireNonEmpty("gameId", input.gameId);
     requireThirdNumber(input.third);
 
-    const gameItem = await this.getEntity(gamePk(input.gameId), metadataSk());
+    const gameItem = await this.readMutableGameEntity(input.gameId);
     if (!gameItem || gameItem.entityType !== ENTITY_TYPE.game) {
       return null;
     }
@@ -1890,7 +1947,7 @@ export class ThreeFcRepository {
     requireNonEmpty("gameId", input.gameId);
     requireThirdNumber(input.third);
 
-    const gameItem = await this.getEntity(gamePk(input.gameId), metadataSk());
+    const gameItem = await this.readMutableGameEntity(input.gameId);
     if (!gameItem || gameItem.entityType !== ENTITY_TYPE.game) {
       return null;
     }
@@ -1956,9 +2013,7 @@ export class ThreeFcRepository {
   async finishGame(input: FinishGameInput): Promise<GameRecord | null> {
     requireNonEmpty("gameId", input.gameId);
 
-    const gameItem = await this.getEntity(gamePk(input.gameId), metadataSk(), {
-      consistentRead: true,
-    });
+    const gameItem = await this.readMutableGameEntity(input.gameId);
     if (!gameItem || gameItem.entityType !== ENTITY_TYPE.game) {
       return null;
     }
@@ -2074,7 +2129,7 @@ export class ThreeFcRepository {
   async deleteGame(gameId: string): Promise<boolean> {
     requireNonEmpty("gameId", gameId);
 
-    const gameItem = await this.getEntity(gamePk(gameId), metadataSk(), { consistentRead: true });
+    const gameItem = await this.readMutableGameEntity(gameId);
     if (!gameItem || gameItem.entityType !== ENTITY_TYPE.game) {
       return false;
     }
@@ -2941,7 +2996,7 @@ export class ThreeFcRepository {
     finishedMessage: string;
     changedMessage: string;
   }): Promise<{ item: StoredEntity<unknown>; game: Omit<GameRecord, "createdAt" | "updatedAt"> }> {
-    const gameItem = await this.getEntity(gamePk(input.gameId), metadataSk(), { consistentRead: true });
+    const gameItem = await this.readMutableGameEntity(input.gameId);
     if (!gameItem || gameItem.entityType !== ENTITY_TYPE.game) {
       throw new GameMutationStateError("game_state_changed", input.changedMessage);
     }
@@ -2952,6 +3007,25 @@ export class ThreeFcRepository {
     }
 
     return { item: gameItem, game };
+  }
+
+  private async readMutableGameEntity(gameId: string): Promise<StoredEntity<unknown> | null> {
+    const gameItem = await this.getEntity(gamePk(gameId), metadataSk(), { consistentRead: true });
+    if (!gameItem || gameItem.entityType !== ENTITY_TYPE.game) {
+      return null;
+    }
+
+    const originalGame = normalizeGamePayload(gameItem.data);
+    const repairedGame = await this.repairLegacyGameJoinCode(gameItem);
+    if (
+      repairedGame.updatedAt === gameItem.updatedAt &&
+      normalizeJoinCode(repairedGame.joinCode) === normalizeJoinCode(originalGame.joinCode)
+    ) {
+      return gameItem;
+    }
+
+    const repairedItem = await this.getEntity(gamePk(gameId), metadataSk(), { consistentRead: true });
+    return repairedItem?.entityType === ENTITY_TYPE.game ? repairedItem : null;
   }
 
   private buildTeamConditionChecks(
@@ -3585,11 +3659,7 @@ export class ThreeFcRepository {
       return replayed;
     }
 
-    const gameItem = await this.getEntity(
-      gamePk(input.gameId),
-      metadataSk(),
-      { consistentRead: true },
-    );
+    const gameItem = await this.readMutableGameEntity(input.gameId);
     if (!gameItem || gameItem.entityType !== ENTITY_TYPE.game) {
       return null;
     }
@@ -3772,11 +3842,7 @@ export class ThreeFcRepository {
       return replayed;
     }
 
-    const gameItem = await this.getEntity(
-      gamePk(input.gameId),
-      metadataSk(),
-      { consistentRead: true },
-    );
+    const gameItem = await this.readMutableGameEntity(input.gameId);
     if (!gameItem || gameItem.entityType !== ENTITY_TYPE.game) {
       return null;
     }
@@ -4089,8 +4155,53 @@ export class ThreeFcRepository {
     for (let raceAttempt = 0; raceAttempt < LEGACY_JOIN_CODE_REPAIR_RACE_RETRIES; raceAttempt += 1) {
       const rawGame = currentStored.data as Partial<Omit<GameRecord, "createdAt" | "updatedAt">>;
       const currentGame = normalizeGamePayload(currentStored.data);
-      if (typeof rawGame.joinCode === "string" && rawGame.joinCode.trim().length > 0) {
-        return withTimestamps(currentGame, currentStored.createdAt, currentStored.updatedAt);
+      const storedJoinCode =
+        typeof rawGame.joinCode === "string" && rawGame.joinCode.trim().length > 0
+          ? normalizeJoinCode(rawGame.joinCode)
+          : null;
+      if (storedJoinCode && JOIN_CODE_PATTERN.test(storedJoinCode)) {
+        const joinCodeItem = await this.getEntity(joinCodePk(storedJoinCode), metadataSk(), {
+          consistentRead: true,
+        });
+        if (joinCodeItem?.entityType === ENTITY_TYPE.gameJoinCode) {
+          const joinCodeRecord = joinCodeItem.data as Partial<GameJoinCodeRecord>;
+          const lookupHasSameGame = joinCodeRecord.gameId === currentGame.gameId;
+          const lookupHasSameCode =
+            typeof joinCodeRecord.joinCode === "string" &&
+            normalizeJoinCode(joinCodeRecord.joinCode) === storedJoinCode;
+          if (lookupHasSameGame && lookupHasSameCode) {
+            return withTimestamps(
+              { ...currentGame, joinCode: storedJoinCode },
+              currentStored.createdAt,
+              currentStored.updatedAt,
+            );
+          }
+          if (lookupHasSameGame) {
+            const repairedGame = await this.writeLegacyGameJoinCodeRepair({
+              stored: currentStored,
+              game: currentGame,
+              joinCode: storedJoinCode,
+              joinCodeItem,
+            });
+            if (repairedGame) {
+              return repairedGame;
+            }
+
+            break;
+          }
+        } else if (!joinCodeItem) {
+          const repairedGame = await this.writeLegacyGameJoinCodeRepair({
+            stored: currentStored,
+            game: currentGame,
+            joinCode: storedJoinCode,
+            joinCodeItem: null,
+          });
+          if (repairedGame) {
+            return repairedGame;
+          }
+
+          break;
+        }
       }
 
       const seenCandidates = new Set<string>();
@@ -4165,12 +4276,19 @@ export class ThreeFcRepository {
 
     if (input.joinCodeItem) {
       transactionItems.push({
-        ConditionCheck: {
+        Put: {
           TableName: this.tableName,
-          Key: {
-            pk: { S: joinCodePk(input.joinCode) },
-            sk: { S: metadataSk() },
-          },
+          Item: buildItemWithTimestamps(
+            joinCodePk(input.joinCode),
+            metadataSk(),
+            ENTITY_TYPE.gameJoinCode,
+            {
+              joinCode: input.joinCode,
+              gameId: input.game.gameId,
+            },
+            input.joinCodeItem.createdAt,
+            now,
+          ),
           ConditionExpression: "#updatedAt = :expectedJoinCodeUpdatedAt AND #data = :expectedJoinCodeData",
           ExpressionAttributeNames: {
             "#updatedAt": "updatedAt",

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -406,8 +406,12 @@ function normalizeGameResultPayload(value: unknown): GameResult | null {
 
 function normalizeGamePayload(data: unknown): Omit<GameRecord, "createdAt" | "updatedAt"> {
   const raw = data as Partial<Omit<GameRecord, "createdAt" | "updatedAt">>;
+  const createRequestHash =
+    typeof raw.createRequestHash === "string" && raw.createRequestHash.trim().length > 0
+      ? raw.createRequestHash.trim()
+      : null;
 
-  return {
+  const game = {
     gameId: raw.gameId ?? "",
     joinCode:
       typeof raw.joinCode === "string" && raw.joinCode.trim().length > 0
@@ -423,6 +427,8 @@ function normalizeGamePayload(data: unknown): Omit<GameRecord, "createdAt" | "up
     finishedAt: isValidTimestamp(raw.finishedAt) ? raw.finishedAt : null,
     result: normalizeGameResultPayload(raw.result),
   };
+
+  return createRequestHash ? { ...game, createRequestHash } : game;
 }
 
 function normalizeNonNegativeInteger(value: unknown): number {
@@ -1334,9 +1340,11 @@ export class ThreeFcRepository {
 
     for (let attempt = 0; attempt < (customJoinCode ? 1 : JOIN_CODE_GENERATION_ATTEMPTS); attempt += 1) {
       const joinCode = customJoinCode ?? generateJoinCode();
+      const createRequestHash = input.createRequestHash?.trim() || null;
       const payload = {
         gameId: input.gameId,
         joinCode,
+        ...(createRequestHash ? { createRequestHash } : {}),
         leagueId: input.leagueId,
         seasonId: input.seasonId,
         sessionId: input.sessionId,

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -11,7 +11,7 @@ import {
   type AttributeValue,
   type TransactWriteItem,
 } from "@aws-sdk/client-dynamodb";
-import { createHash, randomUUID } from "node:crypto";
+import { createHash, randomBytes, randomUUID } from "node:crypto";
 import {
   createDefaultThirdTimerSegments,
   DEFAULT_THIRD_LENGTH_MINUTES,
@@ -309,6 +309,7 @@ function isValidTimestamp(value: unknown): value is string {
 
 const JOIN_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
 const JOIN_CODE_LENGTH = 8;
+const JOIN_CODE_GENERATION_ATTEMPTS = 8;
 const LEGACY_JOIN_CODE_REPAIR_ATTEMPTS = 16;
 const LEGACY_JOIN_CODE_REPAIR_RACE_RETRIES = 3;
 const JOIN_CODE_PATTERN = /^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{8}$/;
@@ -319,6 +320,17 @@ export function buildJoinCodeForGameId(gameId: string): string {
 
   for (let index = 0; index < JOIN_CODE_LENGTH; index += 1) {
     joinCode += JOIN_CODE_ALPHABET[digest[index] % JOIN_CODE_ALPHABET.length];
+  }
+
+  return joinCode;
+}
+
+function generateJoinCode(): string {
+  const bytes = randomBytes(JOIN_CODE_LENGTH);
+  let joinCode = "";
+
+  for (const byte of bytes) {
+    joinCode += JOIN_CODE_ALPHABET[byte % JOIN_CODE_ALPHABET.length];
   }
 
   return joinCode;
@@ -1316,79 +1328,91 @@ export class ThreeFcRepository {
     }
 
     const now = this.clock.now();
-    const joinCode = input.joinCode?.trim()
+    const customJoinCode = input.joinCode?.trim()
       ? normalizeCustomJoinCode(input.joinCode)
-      : buildJoinCodeForGameId(input.gameId);
-    const payload = {
-      gameId: input.gameId,
-      joinCode,
-      leagueId: input.leagueId,
-      seasonId: input.seasonId,
-      sessionId: input.sessionId,
-      status: input.status ?? "scheduled",
-      gameStartTs: input.gameStartTs,
-      thirdLengthMinutes: input.thirdLengthMinutes ?? DEFAULT_THIRD_LENGTH_MINUTES,
-      thirds: createDefaultThirdTimerSegments(),
-      finishedAt: null,
-      result: null,
-    };
+      : null;
 
-    try {
-      await this.client.send(
-        new TransactWriteItemsCommand({
-          TransactItems: [
-            {
-              Put: {
-                TableName: this.tableName,
-                Item: buildItem(gamePk(input.gameId), metadataSk(), ENTITY_TYPE.game, payload, now),
-                ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
+    for (let attempt = 0; attempt < (customJoinCode ? 1 : JOIN_CODE_GENERATION_ATTEMPTS); attempt += 1) {
+      const joinCode = customJoinCode ?? generateJoinCode();
+      const payload = {
+        gameId: input.gameId,
+        joinCode,
+        leagueId: input.leagueId,
+        seasonId: input.seasonId,
+        sessionId: input.sessionId,
+        status: input.status ?? "scheduled",
+        gameStartTs: input.gameStartTs,
+        thirdLengthMinutes: input.thirdLengthMinutes ?? DEFAULT_THIRD_LENGTH_MINUTES,
+        thirds: createDefaultThirdTimerSegments(),
+        finishedAt: null,
+        result: null,
+      };
+
+      try {
+        await this.client.send(
+          new TransactWriteItemsCommand({
+            TransactItems: [
+              {
+                Put: {
+                  TableName: this.tableName,
+                  Item: buildItem(gamePk(input.gameId), metadataSk(), ENTITY_TYPE.game, payload, now),
+                  ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
+                },
               },
-            },
-            {
-              Put: {
-                TableName: this.tableName,
-                Item: buildItem(
-                  joinCodePk(joinCode),
-                  metadataSk(),
-                  ENTITY_TYPE.gameJoinCode,
-                  {
-                    joinCode,
-                    gameId: input.gameId,
-                  },
-                  now,
-                ),
-                ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
+              {
+                Put: {
+                  TableName: this.tableName,
+                  Item: buildItem(
+                    joinCodePk(joinCode),
+                    metadataSk(),
+                    ENTITY_TYPE.gameJoinCode,
+                    {
+                      joinCode,
+                      gameId: input.gameId,
+                    },
+                    now,
+                  ),
+                  ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
+                },
               },
-            },
-          ],
-        }),
-      );
-    } catch (error) {
-      if (isConditionalWriteFailure(error)) {
-        const gameCancellationCode = transactionCancellationCode(error, 0);
-        const joinCodeCancellationCode = transactionCancellationCode(error, 1);
-        if (isConditionalCancellationCode(gameCancellationCode ?? undefined)) {
-          throw new GameAlreadyExistsError(input.gameId);
-        }
-        if (isConditionalCancellationCode(joinCodeCancellationCode ?? undefined)) {
-          throw new GameJoinCodeCollisionError();
+            ],
+          }),
+        );
+        return withTimestamps(payload, now, now);
+      } catch (error) {
+        if (isConditionalWriteFailure(error)) {
+          const gameCancellationCode = transactionCancellationCode(error, 0);
+          const joinCodeCancellationCode = transactionCancellationCode(error, 1);
+          if (isConditionalCancellationCode(gameCancellationCode ?? undefined)) {
+            throw new GameAlreadyExistsError(input.gameId);
+          }
+          if (isConditionalCancellationCode(joinCodeCancellationCode ?? undefined)) {
+            if (customJoinCode) {
+              throw new GameJoinCodeCollisionError();
+            }
+            continue;
+          }
+
+          const [existingGameItem, existingJoinCodeItem] = await Promise.all([
+            this.getEntity(gamePk(input.gameId), metadataSk(), { consistentRead: true }),
+            this.getEntity(joinCodePk(joinCode), metadataSk(), { consistentRead: true }),
+          ]);
+          if (existingGameItem?.entityType === ENTITY_TYPE.game) {
+            throw new GameAlreadyExistsError(input.gameId);
+          }
+          if (existingJoinCodeItem?.entityType === ENTITY_TYPE.gameJoinCode) {
+            if (customJoinCode) {
+              throw new GameJoinCodeCollisionError();
+            }
+            continue;
+          }
         }
 
-        const [existingGameItem, existingJoinCodeItem] = await Promise.all([
-          this.getEntity(gamePk(input.gameId), metadataSk(), { consistentRead: true }),
-          this.getEntity(joinCodePk(joinCode), metadataSk(), { consistentRead: true }),
-        ]);
-        if (existingGameItem?.entityType === ENTITY_TYPE.game) {
-          throw new GameAlreadyExistsError(input.gameId);
-        }
-        if (existingJoinCodeItem?.entityType === ENTITY_TYPE.gameJoinCode) {
-          throw new GameJoinCodeCollisionError();
-        }
+        throw error;
       }
-
-      throw error;
     }
-    return withTimestamps(payload, now, now);
+
+    throw new GameJoinCodeCollisionError();
   }
 
   async getGame(gameId: string, options: { consistentRead?: boolean } = {}): Promise<GameRecord | null> {

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -1480,6 +1480,24 @@ export class ThreeFcRepository {
               ConditionCheck: {
                 TableName: this.tableName,
                 Key: {
+                  pk: { S: joinCodePk(normalizedJoinCode) },
+                  sk: { S: metadataSk() },
+                },
+                ConditionExpression: "#updatedAt = :expectedJoinCodeUpdatedAt AND #data = :expectedJoinCodeData",
+                ExpressionAttributeNames: {
+                  "#updatedAt": "updatedAt",
+                  "#data": "data",
+                },
+                ExpressionAttributeValues: {
+                  ":expectedJoinCodeUpdatedAt": { S: joinCodeItem.updatedAt },
+                  ":expectedJoinCodeData": { S: joinCodeItem.rawData },
+                },
+              },
+            },
+            {
+              ConditionCheck: {
+                TableName: this.tableName,
+                Key: {
                   pk: { S: gamePk(game.gameId) },
                   sk: { S: metadataSk() },
                 },

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -711,16 +711,25 @@ function isConditionalWriteFailure(error: unknown): boolean {
     return false;
   }
 
-  const cancellationReasons = awsError.CancellationReasons ?? awsError.cancellationReasons ?? [];
-  return cancellationReasons.some(
-    (reason) =>
-      reason.Code === "ConditionalCheckFailed" ||
-      reason.Code === "ConditionalCheckFailedException",
+  return transactionCancellationReasons(error).some((reason) =>
+    isConditionalCancellationCode(reason.Code),
   );
 }
 
+function transactionCancellationReasons(error: unknown): Array<{ Code?: string }> {
+  const awsError = error as {
+    CancellationReasons?: Array<{ Code?: string }>;
+    cancellationReasons?: Array<{ Code?: string }>;
+  };
+  return awsError.CancellationReasons ?? awsError.cancellationReasons ?? [];
+}
+
+function isConditionalCancellationCode(code: string | undefined): boolean {
+  return code === "ConditionalCheckFailed" || code === "ConditionalCheckFailedException";
+}
+
 function transactionCancellationCode(error: unknown, index: number): string | null {
-  const reason = (error as { CancellationReasons?: Array<{ Code?: string }> }).CancellationReasons?.[index];
+  const reason = transactionCancellationReasons(error)[index];
   return typeof reason?.Code === "string" ? reason.Code : null;
 }
 
@@ -1331,10 +1340,10 @@ export class ThreeFcRepository {
       if (isConditionalWriteFailure(error)) {
         const gameCancellationCode = transactionCancellationCode(error, 0);
         const joinCodeCancellationCode = transactionCancellationCode(error, 1);
-        if (gameCancellationCode === "ConditionalCheckFailed") {
+        if (isConditionalCancellationCode(gameCancellationCode ?? undefined)) {
           throw new GameAlreadyExistsError(input.gameId);
         }
-        if (joinCodeCancellationCode === "ConditionalCheckFailed") {
+        if (isConditionalCancellationCode(joinCodeCancellationCode ?? undefined)) {
           throw new GameJoinCodeCollisionError();
         }
 

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -11,7 +11,7 @@ import {
   type AttributeValue,
   type TransactWriteItem,
 } from "@aws-sdk/client-dynamodb";
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import {
   createDefaultThirdTimerSegments,
   DEFAULT_THIRD_LENGTH_MINUTES,
@@ -39,6 +39,7 @@ import {
   goalStateSk,
   goalSk,
   idempotencyPk,
+  joinCodePk,
   leaguePk,
   metadataSk,
   playerPk,
@@ -67,6 +68,7 @@ import type {
   DeleteGoalInput,
   DeleteGoalResult,
   FinishGameInput,
+  GameJoinCodeRecord,
   GameTeamRecord,
   GamePlayerRecord,
   GameRecord,
@@ -77,6 +79,8 @@ import type {
   GoalEventRecord,
   GoalStateRecord,
   IdempotencyRecord,
+  JoinGameByCodeInput,
+  JoinGameByCodeResult,
   LeagueAclRecord,
   LeagueRecord,
   ListPlayersInput,
@@ -102,6 +106,7 @@ const ENTITY_TYPE = {
   game: "game",
   gameTeam: "gameTeam",
   gamePlayer: "gamePlayer",
+  gameJoinCode: "gameJoinCode",
   sessionGame: "sessionGame",
   player: "player",
   acl: "acl",
@@ -185,6 +190,24 @@ export class GameMutationStateError extends Error {
   ) {
     super(message);
     this.name = "GameMutationStateError";
+  }
+}
+
+export class GameJoinCodeCollisionError extends Error {
+  constructor(message = "Join code is already assigned to another game.") {
+    super(message);
+    this.name = "GameJoinCodeCollisionError";
+  }
+}
+
+export class GameJoinRegistrationError extends Error {
+  constructor(
+    readonly code: "game_finished" | "join_state_changed",
+    readonly statusCode: 409,
+    message: string,
+  ) {
+    super(message);
+    this.name = "GameJoinRegistrationError";
   }
 }
 
@@ -277,6 +300,24 @@ function isValidTimestamp(value: unknown): value is string {
   return typeof value === "string" && !Number.isNaN(Date.parse(value));
 }
 
+const JOIN_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+const JOIN_CODE_LENGTH = 8;
+
+export function buildJoinCodeForGameId(gameId: string): string {
+  const digest = createHash("sha256").update(`3fc:join:${gameId}`).digest();
+  let joinCode = "";
+
+  for (let index = 0; index < JOIN_CODE_LENGTH; index += 1) {
+    joinCode += JOIN_CODE_ALPHABET[digest[index] % JOIN_CODE_ALPHABET.length];
+  }
+
+  return joinCode;
+}
+
+function normalizeJoinCode(joinCode: string): string {
+  return joinCode.trim().toUpperCase();
+}
+
 function normalizeGameResultPayload(value: unknown): GameResult | null {
   if (!value || typeof value !== "object") {
     return null;
@@ -333,6 +374,10 @@ function normalizeGamePayload(data: unknown): Omit<GameRecord, "createdAt" | "up
 
   return {
     gameId: raw.gameId ?? "",
+    joinCode:
+      typeof raw.joinCode === "string" && raw.joinCode.trim().length > 0
+        ? normalizeJoinCode(raw.joinCode)
+        : buildJoinCodeForGameId(raw.gameId ?? ""),
     leagueId: raw.leagueId ?? "",
     seasonId: raw.seasonId ?? "",
     sessionId: raw.sessionId ?? "",
@@ -1223,8 +1268,12 @@ export class ThreeFcRepository {
     }
 
     const now = this.clock.now();
+    const joinCode = normalizeJoinCode(
+      input.joinCode?.trim() ? input.joinCode : buildJoinCodeForGameId(input.gameId),
+    );
     const payload = {
       gameId: input.gameId,
+      joinCode,
       leagueId: input.leagueId,
       seasonId: input.seasonId,
       sessionId: input.sessionId,
@@ -1236,7 +1285,43 @@ export class ThreeFcRepository {
       result: null,
     };
 
-    await this.putEntity(gamePk(input.gameId), metadataSk(), ENTITY_TYPE.game, payload, now);
+    try {
+      await this.client.send(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            {
+              Put: {
+                TableName: this.tableName,
+                Item: buildItem(gamePk(input.gameId), metadataSk(), ENTITY_TYPE.game, payload, now),
+                ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
+              },
+            },
+            {
+              Put: {
+                TableName: this.tableName,
+                Item: buildItem(
+                  joinCodePk(joinCode),
+                  metadataSk(),
+                  ENTITY_TYPE.gameJoinCode,
+                  {
+                    joinCode,
+                    gameId: input.gameId,
+                  },
+                  now,
+                ),
+                ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
+              },
+            },
+          ],
+        }),
+      );
+    } catch (error) {
+      if (isConditionalWriteFailure(error)) {
+        throw new GameJoinCodeCollisionError();
+      }
+
+      throw error;
+    }
     return withTimestamps(payload, now, now);
   }
 
@@ -1249,6 +1334,144 @@ export class ThreeFcRepository {
     }
 
     return withTimestamps(normalizeGamePayload(item.data), item.createdAt, item.updatedAt);
+  }
+
+  async getGameByJoinCode(joinCode: string): Promise<GameRecord | null> {
+    const normalizedJoinCode = normalizeJoinCode(joinCode);
+    requireNonEmpty("joinCode", normalizedJoinCode);
+
+    const joinCodeItem = await this.getEntity(joinCodePk(normalizedJoinCode), metadataSk());
+    if (joinCodeItem?.entityType === ENTITY_TYPE.gameJoinCode) {
+      const joinCodeRecord = withTimestamps(
+        joinCodeItem.data as Omit<GameJoinCodeRecord, "createdAt" | "updatedAt">,
+        joinCodeItem.createdAt,
+        joinCodeItem.updatedAt,
+      );
+      const game = await this.getGame(joinCodeRecord.gameId);
+
+      if (game && normalizeJoinCode(game.joinCode) === normalizedJoinCode) {
+        return game;
+      }
+    }
+
+    return null;
+  }
+
+  async joinGameByCode(input: JoinGameByCodeInput): Promise<JoinGameByCodeResult | null> {
+    const normalizedJoinCode = normalizeJoinCode(input.joinCode);
+    requireNonEmpty("joinCode", normalizedJoinCode);
+    requireNonEmpty("playerId", input.playerId);
+    requireNonEmpty("nickname", input.nickname);
+
+    const joinCodeItem = await this.getEntity(joinCodePk(normalizedJoinCode), metadataSk(), {
+      consistentRead: true,
+    });
+    if (!joinCodeItem || joinCodeItem.entityType !== ENTITY_TYPE.gameJoinCode) {
+      return null;
+    }
+
+    const joinCodeRecord = withTimestamps(
+      joinCodeItem.data as Omit<GameJoinCodeRecord, "createdAt" | "updatedAt">,
+      joinCodeItem.createdAt,
+      joinCodeItem.updatedAt,
+    );
+    const gameItem = await this.getEntity(gamePk(joinCodeRecord.gameId), metadataSk(), {
+      consistentRead: true,
+    });
+    if (!gameItem || gameItem.entityType !== ENTITY_TYPE.game) {
+      return null;
+    }
+
+    const game = withTimestamps(
+      normalizeGamePayload(gameItem.data),
+      gameItem.createdAt,
+      gameItem.updatedAt,
+    );
+    if (normalizeJoinCode(game.joinCode) !== normalizedJoinCode) {
+      return null;
+    }
+
+    if (game.status === "finished") {
+      throw new GameJoinRegistrationError(
+        "game_finished",
+        409,
+        `Game ${game.gameId} is finished. Join registration is closed.`,
+      );
+    }
+
+    const now = this.clock.now();
+    const playerPayload = {
+      playerId: input.playerId,
+      nickname: input.nickname,
+      claimedByUserId: null,
+    };
+    const linkPayload = {
+      gameId: game.gameId,
+      playerId: input.playerId,
+    };
+
+    try {
+      await this.client.send(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            {
+              ConditionCheck: {
+                TableName: this.tableName,
+                Key: {
+                  pk: { S: gamePk(game.gameId) },
+                  sk: { S: metadataSk() },
+                },
+                ConditionExpression: "#updatedAt = :expectedGameUpdatedAt AND #data = :expectedGameData",
+                ExpressionAttributeNames: {
+                  "#updatedAt": "updatedAt",
+                  "#data": "data",
+                },
+                ExpressionAttributeValues: {
+                  ":expectedGameUpdatedAt": { S: game.updatedAt },
+                  ":expectedGameData": { S: gameItem.rawData },
+                },
+              },
+            },
+            {
+              Put: {
+                TableName: this.tableName,
+                Item: buildItem(playerPk(input.playerId), profileSk(), ENTITY_TYPE.player, playerPayload, now),
+                ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
+              },
+            },
+            {
+              Put: {
+                TableName: this.tableName,
+                Item: buildItem(
+                  gamePk(game.gameId),
+                  gamePlayerSk(input.playerId),
+                  ENTITY_TYPE.gamePlayer,
+                  linkPayload,
+                  now,
+                ),
+                ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
+              },
+            },
+          ],
+        }),
+      );
+    } catch (error) {
+      if (isConditionalWriteFailure(error)) {
+        throw new GameJoinRegistrationError(
+          "join_state_changed",
+          409,
+          "Game join state changed while registering this player. Reload and try again.",
+        );
+      }
+
+      throw error;
+    }
+
+    return {
+      game,
+      player: withTimestamps(playerPayload, now, now),
+      link: withTimestamps(linkPayload, now, now),
+    };
   }
 
   async createSessionGame(input: CreateSessionGameInput): Promise<SessionGameRecord> {
@@ -1724,38 +1947,75 @@ export class ThreeFcRepository {
       return false;
     }
 
+    const joinCodeItem = await this.getEntity(joinCodePk(game.joinCode), metadataSk(), {
+      consistentRead: true,
+    });
+    const joinCodeRecord =
+      joinCodeItem?.entityType === ENTITY_TYPE.gameJoinCode
+        ? withTimestamps(
+            joinCodeItem.data as Omit<GameJoinCodeRecord, "createdAt" | "updatedAt">,
+            joinCodeItem.createdAt,
+            joinCodeItem.updatedAt,
+          )
+        : null;
+    const deletesJoinCodeLookup =
+      joinCodeItem !== null &&
+      joinCodeRecord?.gameId === gameId &&
+      normalizeJoinCode(joinCodeRecord.joinCode) === normalizeJoinCode(game.joinCode);
+    const transactionItems: TransactWriteItem[] = [
+      {
+        Delete: {
+          TableName: this.tableName,
+          Key: {
+            pk: { S: gamePk(gameId) },
+            sk: { S: metadataSk() },
+          },
+          ConditionExpression: "#updatedAt = :expectedGameUpdatedAt AND #data = :expectedGameData",
+          ExpressionAttributeNames: {
+            "#updatedAt": "updatedAt",
+            "#data": "data",
+          },
+          ExpressionAttributeValues: {
+            ":expectedGameUpdatedAt": { S: gameItem.updatedAt },
+            ":expectedGameData": { S: gameItem.rawData },
+          },
+        },
+      },
+      {
+        Delete: {
+          TableName: this.tableName,
+          Key: {
+            pk: { S: gameSessionIndexPk(game.sessionId) },
+            sk: { S: gameSessionIndexSk(game.gameStartTs, game.gameId) },
+          },
+        },
+      },
+    ];
+    if (deletesJoinCodeLookup && joinCodeItem) {
+      transactionItems.push({
+        Delete: {
+          TableName: this.tableName,
+          Key: {
+            pk: { S: joinCodePk(game.joinCode) },
+            sk: { S: metadataSk() },
+          },
+          ConditionExpression: "#updatedAt = :expectedJoinCodeUpdatedAt AND #data = :expectedJoinCodeData",
+          ExpressionAttributeNames: {
+            "#updatedAt": "updatedAt",
+            "#data": "data",
+          },
+          ExpressionAttributeValues: {
+            ":expectedJoinCodeUpdatedAt": { S: joinCodeItem.updatedAt },
+            ":expectedJoinCodeData": { S: joinCodeItem.rawData },
+          },
+        },
+      });
+    }
+
     try {
       await this.client.send(
         new TransactWriteItemsCommand({
-          TransactItems: [
-            {
-              Delete: {
-                TableName: this.tableName,
-                Key: {
-                  pk: { S: gamePk(gameId) },
-                  sk: { S: metadataSk() },
-                },
-                ConditionExpression: "#updatedAt = :expectedGameUpdatedAt AND #data = :expectedGameData",
-                ExpressionAttributeNames: {
-                  "#updatedAt": "updatedAt",
-                  "#data": "data",
-                },
-                ExpressionAttributeValues: {
-                  ":expectedGameUpdatedAt": { S: gameItem.updatedAt },
-                  ":expectedGameData": { S: gameItem.rawData },
-                },
-              },
-            },
-            {
-              Delete: {
-                TableName: this.tableName,
-                Key: {
-                  pk: { S: gameSessionIndexPk(game.sessionId) },
-                  sk: { S: gameSessionIndexSk(game.gameStartTs, game.gameId) },
-                },
-              },
-            },
-          ],
+          TransactItems: transactionItems,
         }),
       );
     } catch (error) {

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -1393,7 +1393,13 @@ export class ThreeFcRepository {
       return null;
     }
 
-    return withTimestamps(normalizeGamePayload(item.data), item.createdAt, item.updatedAt);
+    const rawGame = item.data as Partial<Omit<GameRecord, "createdAt" | "updatedAt">>;
+    const game = withTimestamps(normalizeGamePayload(item.data), item.createdAt, item.updatedAt);
+    if (typeof rawGame.joinCode !== "string" || rawGame.joinCode.trim().length === 0) {
+      await this.ensureGameJoinCodeLookup(game);
+    }
+
+    return game;
   }
 
   async getGameByJoinCode(joinCode: string): Promise<GameRecord | null> {
@@ -4035,6 +4041,53 @@ export class ThreeFcRepository {
         Item: buildItemWithTimestamps(pk, sk, entityType, payload, createdAt, updatedAt),
       }),
     );
+  }
+
+  private async ensureGameJoinCodeLookup(game: Pick<GameRecord, "gameId" | "joinCode">): Promise<void> {
+    if (game.gameId.trim().length === 0) {
+      return;
+    }
+
+    const joinCode = normalizeJoinCode(game.joinCode);
+    if (joinCode.length === 0) {
+      return;
+    }
+
+    const existing = await this.getEntity(joinCodePk(joinCode), metadataSk(), { consistentRead: true });
+    if (existing?.entityType === ENTITY_TYPE.gameJoinCode) {
+      const existingRecord = existing.data as Partial<GameJoinCodeRecord>;
+      if (existingRecord.gameId === game.gameId) {
+        return;
+      }
+
+      return;
+    }
+
+    const now = this.clock.now();
+    try {
+      await this.client.send(
+        new PutItemCommand({
+          TableName: this.tableName,
+          Item: buildItem(
+            joinCodePk(joinCode),
+            metadataSk(),
+            ENTITY_TYPE.gameJoinCode,
+            {
+              joinCode,
+              gameId: game.gameId,
+            },
+            now,
+          ),
+          ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
+        }),
+      );
+    } catch (error) {
+      if (isConditionalWriteFailure(error)) {
+        return;
+      }
+
+      throw error;
+    }
   }
 
   private async putEntityWithTimestampsIfUnchanged<T>(

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -340,10 +340,6 @@ function normalizeJoinCode(joinCode: string): string {
   return joinCode.trim().toUpperCase();
 }
 
-function buildLegacyJoinCodeRepairCandidate(gameId: string, attempt: number): string {
-  return attempt === 0 ? buildJoinCodeForGameId(gameId) : buildJoinCodeForGameId(`${gameId}:${attempt}`);
-}
-
 function normalizeCustomJoinCode(joinCode: string): string {
   const normalizedJoinCode = normalizeJoinCode(joinCode);
   if (!JOIN_CODE_PATTERN.test(normalizedJoinCode)) {
@@ -1423,7 +1419,10 @@ export class ThreeFcRepository {
     throw new GameJoinCodeCollisionError();
   }
 
-  async getGame(gameId: string, options: { consistentRead?: boolean } = {}): Promise<GameRecord | null> {
+  async getGame(
+    gameId: string,
+    options: { consistentRead?: boolean; repairLegacyJoinCode?: boolean } = {},
+  ): Promise<GameRecord | null> {
     requireNonEmpty("gameId", gameId);
     const item = await this.getEntity(gamePk(gameId), metadataSk(), options);
 
@@ -1433,7 +1432,10 @@ export class ThreeFcRepository {
 
     const rawGame = item.data as Partial<Omit<GameRecord, "createdAt" | "updatedAt">>;
     const game = withTimestamps(normalizeGamePayload(item.data), item.createdAt, item.updatedAt);
-    if (typeof rawGame.joinCode !== "string" || rawGame.joinCode.trim().length === 0) {
+    if (
+      options.repairLegacyJoinCode &&
+      (typeof rawGame.joinCode !== "string" || rawGame.joinCode.trim().length === 0)
+    ) {
       return this.repairLegacyGameJoinCode(item);
     }
 
@@ -4097,7 +4099,7 @@ export class ThreeFcRepository {
         candidateAttempt < LEGACY_JOIN_CODE_REPAIR_ATTEMPTS;
         candidateAttempt += 1
       ) {
-        const joinCode = buildLegacyJoinCodeRepairCandidate(currentGame.gameId, candidateAttempt);
+        const joinCode = generateJoinCode();
         if (seenCandidates.has(joinCode)) {
           continue;
         }

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -309,7 +309,7 @@ function isValidTimestamp(value: unknown): value is string {
 
 const JOIN_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
 const JOIN_CODE_LENGTH = 8;
-const JOIN_CODE_PATTERN = /^[A-Z0-9]{8}$/;
+const JOIN_CODE_PATTERN = /^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{8}$/;
 
 export function buildJoinCodeForGameId(gameId: string): string {
   const digest = createHash("sha256").update(`3fc:join:${gameId}`).digest();
@@ -329,7 +329,7 @@ function normalizeJoinCode(joinCode: string): string {
 function normalizeCustomJoinCode(joinCode: string): string {
   const normalizedJoinCode = normalizeJoinCode(joinCode);
   if (!JOIN_CODE_PATTERN.test(normalizedJoinCode)) {
-    throw new Error("joinCode must be 8 letters or digits.");
+    throw new Error("joinCode must be 8 uppercase non-ambiguous letters or digits.");
   }
 
   return normalizedJoinCode;
@@ -721,9 +721,20 @@ function isConditionalWriteFailure(error: unknown): boolean {
     return false;
   }
 
-  return transactionCancellationReasons(error).some((reason) =>
-    isConditionalCancellationCode(reason.Code),
-  );
+  const reasons = transactionCancellationReasons(error);
+  let hasConditionalFailure = false;
+  for (const reason of reasons) {
+    if (!reason.Code || reason.Code === "None") {
+      continue;
+    }
+    if (isConditionalCancellationCode(reason.Code)) {
+      hasConditionalFailure = true;
+      continue;
+    }
+    return false;
+  }
+
+  return hasConditionalFailure;
 }
 
 function transactionCancellationReasons(error: unknown): Array<{ Code?: string }> {
@@ -3937,7 +3948,9 @@ export class ThreeFcRepository {
   async getIdempotencyRecord(scope: string, key: string): Promise<IdempotencyRecord | null> {
     requireNonEmpty("scope", scope);
     requireNonEmpty("key", key);
-    const item = await this.getEntity(idempotencyPk(scope, key), metadataSk());
+    const item = await this.getEntity(idempotencyPk(scope, key), metadataSk(), {
+      consistentRead: true,
+    });
 
     if (!item || item.entityType !== ENTITY_TYPE.idempotency) {
       return null;

--- a/api/src/data/types.ts
+++ b/api/src/data/types.ts
@@ -60,6 +60,7 @@ export interface SessionRecord {
 export interface GameRecord {
   gameId: string;
   joinCode: string;
+  createRequestHash?: string;
   leagueId: string;
   seasonId: string;
   sessionId: string;
@@ -245,6 +246,7 @@ export interface CreateSessionInput {
 export interface CreateGameInput {
   gameId: string;
   joinCode?: string | null;
+  createRequestHash?: string | null;
   leagueId: string;
   seasonId: string;
   sessionId: string;

--- a/api/src/data/types.ts
+++ b/api/src/data/types.ts
@@ -59,6 +59,7 @@ export interface SessionRecord {
 
 export interface GameRecord {
   gameId: string;
+  joinCode: string;
   leagueId: string;
   seasonId: string;
   sessionId: string;
@@ -78,6 +79,13 @@ export interface SessionGameRecord {
   gameStartTs: string;
   leagueId: string;
   seasonId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GameJoinCodeRecord {
+  joinCode: string;
+  gameId: string;
   createdAt: string;
   updatedAt: string;
 }
@@ -236,6 +244,7 @@ export interface CreateSessionInput {
 
 export interface CreateGameInput {
   gameId: string;
+  joinCode?: string | null;
   leagueId: string;
   seasonId: string;
   sessionId: string;
@@ -272,6 +281,18 @@ export interface LinkGamePlayerInput {
   gameId: string;
   playerId: string;
   allowFinished?: boolean;
+}
+
+export interface JoinGameByCodeInput {
+  joinCode: string;
+  playerId: string;
+  nickname: string;
+}
+
+export interface JoinGameByCodeResult {
+  game: GameRecord;
+  player: PlayerRecord;
+  link: GamePlayerRecord;
 }
 
 export interface GrantLeagueAccessInput {

--- a/api/src/lambda-core.ts
+++ b/api/src/lambda-core.ts
@@ -5,6 +5,7 @@ import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { SESv2Client, SendEmailCommand } from "@aws-sdk/client-sesv2";
 import {
   buildGameTimerState,
+  DEFAULT_THIRD_LENGTH_MINUTES,
   DEFAULT_TEAMS,
   isThirdLengthMinutes,
   isThirdNumber,
@@ -777,6 +778,30 @@ function buildGameResponse(game: RepositoryGameRecord) {
       thirds: game.thirds,
     }),
   };
+}
+
+function existingGameMatchesCreateRequest(input: {
+  game: RepositoryGameRecord;
+  leagueId: string;
+  seasonId: string;
+  sessionId: string;
+  request: {
+    gameId: string;
+    gameStartTs: string;
+    status?: GameStatus;
+    thirdLengthMinutes?: ThirdLengthMinutes;
+  };
+}): boolean {
+  return (
+    input.game.gameId === input.request.gameId &&
+    input.game.leagueId === input.leagueId &&
+    input.game.seasonId === input.seasonId &&
+    input.game.sessionId === input.sessionId &&
+    input.game.status === (input.request.status ?? "scheduled") &&
+    input.game.gameStartTs === input.request.gameStartTs &&
+    input.game.thirdLengthMinutes ===
+      (input.request.thirdLengthMinutes ?? DEFAULT_THIRD_LENGTH_MINUTES)
+  );
 }
 
 function parseThirdRouteParam(value: string): ThirdNumber | null {
@@ -2413,15 +2438,38 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
               origin,
               allowedOrigins: dependencies.corsAllowedOrigins,
               execute: async () => {
-                const createdGame = await dependencies.repository.createGame({
-                  gameId: parsedBody.data.gameId,
-                  leagueId,
-                  seasonId,
-                  sessionId,
-                  status: parsedBody.data.status as GameStatus | undefined,
-                  gameStartTs: parsedBody.data.gameStartTs,
-                  thirdLengthMinutes: parsedBody.data.thirdLengthMinutes,
-                });
+                let createdGame: RepositoryGameRecord;
+                try {
+                  createdGame = await dependencies.repository.createGame({
+                    gameId: parsedBody.data.gameId,
+                    leagueId,
+                    seasonId,
+                    sessionId,
+                    status: parsedBody.data.status as GameStatus | undefined,
+                    gameStartTs: parsedBody.data.gameStartTs,
+                    thirdLengthMinutes: parsedBody.data.thirdLengthMinutes,
+                  });
+                } catch (error) {
+                  if (!(error instanceof GameAlreadyExistsError)) {
+                    throw error;
+                  }
+
+                  const existingGame = await dependencies.repository.getGame(parsedBody.data.gameId);
+                  if (
+                    !existingGame ||
+                    !existingGameMatchesCreateRequest({
+                      game: existingGame,
+                      leagueId,
+                      seasonId,
+                      sessionId,
+                      request: parsedBody.data,
+                    })
+                  ) {
+                    throw error;
+                  }
+
+                  createdGame = existingGame;
+                }
 
                 await dependencies.repository.createSessionGame({
                   sessionId: createdGame.sessionId,

--- a/api/src/lambda-core.ts
+++ b/api/src/lambda-core.ts
@@ -55,6 +55,8 @@ import {
   upsertTeamRequestSchema,
 } from "./contracts/core-write.js";
 import {
+  GameAlreadyExistsError,
+  GameJoinCodeCollisionError,
   GameJoinRegistrationError,
   GameMutationStateError,
   GameTimerTransitionError,
@@ -909,6 +911,37 @@ function joinStateChangedResponse(
   );
 }
 
+function gameAlreadyExistsConflictResponse(
+  origin: string | undefined,
+  allowedOrigins: string[],
+  gameId: string,
+): ApiGatewayHttpResponse {
+  return createJsonResponse(
+    409,
+    {
+      error: "conflict",
+      code: "game_exists",
+      message: `Game ${gameId} already exists.`,
+    },
+    buildCorsHeaders(origin, allowedOrigins),
+  );
+}
+
+function gameJoinCodeCollisionConflictResponse(
+  origin: string | undefined,
+  allowedOrigins: string[],
+): ApiGatewayHttpResponse {
+  return createJsonResponse(
+    409,
+    {
+      error: "conflict",
+      code: "join_code_collision",
+      message: "Join code is already assigned to another game.",
+    },
+    buildCorsHeaders(origin, allowedOrigins),
+  );
+}
+
 async function buildFinishedGameMutationBlock(input: {
   repository: RepositoryContract;
   game: Pick<RepositoryGameRecord, "gameId" | "leagueId" | "status">;
@@ -1741,7 +1774,13 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
 
       const joinGameMatch = route.match(/^\/v1\/join\/([^/]+)$/);
       if (method === "POST" && joinGameMatch) {
-        const joinCode = decodeRouteParam(joinGameMatch[1]).trim();
+        let joinCode: string;
+        try {
+          joinCode = decodeURIComponent(joinGameMatch[1]).trim();
+        } catch {
+          status = 400;
+          return badRequest(origin, dependencies.corsAllowedOrigins, "Join code must be URL encoded correctly.");
+        }
         if (joinCode.length === 0) {
           status = 400;
           return joinCodeRequiredResponse(origin, dependencies.corsAllowedOrigins);
@@ -2327,42 +2366,60 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
             );
           }
 
-          const mutationResponse = await executeIdempotentMutation({
-            repository: dependencies.repository,
-            idempotencyKey,
-            sessionEmail: session.email,
-            method,
-            route,
-            requestPayload: parsedBody.data,
-            origin,
-            allowedOrigins: dependencies.corsAllowedOrigins,
-            execute: async () => {
-              const createdGame = await dependencies.repository.createGame({
-                gameId: parsedBody.data.gameId,
-                leagueId,
-                seasonId,
-                sessionId,
-                status: parsedBody.data.status as GameStatus | undefined,
-                gameStartTs: parsedBody.data.gameStartTs,
-                thirdLengthMinutes: parsedBody.data.thirdLengthMinutes,
-              });
+          let mutationResponse: ApiGatewayHttpResponse;
+          try {
+            mutationResponse = await executeIdempotentMutation({
+              repository: dependencies.repository,
+              idempotencyKey,
+              sessionEmail: session.email,
+              method,
+              route,
+              requestPayload: parsedBody.data,
+              origin,
+              allowedOrigins: dependencies.corsAllowedOrigins,
+              execute: async () => {
+                const createdGame = await dependencies.repository.createGame({
+                  gameId: parsedBody.data.gameId,
+                  leagueId,
+                  seasonId,
+                  sessionId,
+                  status: parsedBody.data.status as GameStatus | undefined,
+                  gameStartTs: parsedBody.data.gameStartTs,
+                  thirdLengthMinutes: parsedBody.data.thirdLengthMinutes,
+                });
 
-              await dependencies.repository.createSessionGame({
-                sessionId: createdGame.sessionId,
-                gameId: createdGame.gameId,
-                gameStartTs: createdGame.gameStartTs,
-                leagueId: createdGame.leagueId,
-                seasonId: createdGame.seasonId,
-              });
-              await ensureGameTeamsForGame(dependencies.repository, createdGame);
+                await dependencies.repository.createSessionGame({
+                  sessionId: createdGame.sessionId,
+                  gameId: createdGame.gameId,
+                  gameStartTs: createdGame.gameStartTs,
+                  leagueId: createdGame.leagueId,
+                  seasonId: createdGame.seasonId,
+                });
+                await ensureGameTeamsForGame(dependencies.repository, createdGame);
 
-              return createJsonResponse(
-                201,
-                buildGameResponse(createdGame),
-                buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
+                return createJsonResponse(
+                  201,
+                  buildGameResponse(createdGame),
+                  buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
+                );
+              },
+            });
+          } catch (error) {
+            if (error instanceof GameAlreadyExistsError) {
+              status = 409;
+              return gameAlreadyExistsConflictResponse(
+                origin,
+                dependencies.corsAllowedOrigins,
+                parsedBody.data.gameId,
               );
-            },
-          });
+            }
+            if (error instanceof GameJoinCodeCollisionError) {
+              status = 409;
+              return gameJoinCodeCollisionConflictResponse(origin, dependencies.corsAllowedOrigins);
+            }
+
+            throw error;
+          }
 
           status = mutationResponse.statusCode;
           return mutationResponse;

--- a/api/src/lambda-core.ts
+++ b/api/src/lambda-core.ts
@@ -287,7 +287,7 @@ interface RepositoryContract {
   listGamesForSeason(seasonId: string): Promise<RepositoryGameRecord[]>;
   getGame(
     gameId: string,
-    options?: { consistentRead?: boolean },
+    options?: { consistentRead?: boolean; repairLegacyJoinCode?: boolean },
   ): Promise<RepositoryGameRecord | null>;
   getGameByJoinCode(joinCode: string): Promise<RepositoryGameRecord | null>;
   joinGameByCode(input: {
@@ -2584,10 +2584,16 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
             );
           }
 
+          const responseGame =
+            (await dependencies.repository.getGame(gameId, {
+              consistentRead: true,
+              repairLegacyJoinCode: true,
+            })) ?? game;
+
           status = 200;
           return createJsonResponse(
             status,
-            buildGameResponse(game),
+            buildGameResponse(responseGame),
             buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
           );
         }

--- a/api/src/lambda-core.ts
+++ b/api/src/lambda-core.ts
@@ -965,12 +965,13 @@ function joinStateChangedResponse(
   );
 }
 
-function hasJoinStateChangedCode(payload: unknown): boolean {
+function hasNonPersistedPublicJoinConflictCode(payload: unknown): boolean {
+  const code = typeof payload === "object" && payload !== null && "code" in payload
+    ? (payload as { code?: unknown }).code
+    : null;
   return (
-    typeof payload === "object" &&
-    payload !== null &&
-    "code" in payload &&
-    (payload as { code?: unknown }).code === "join_state_changed"
+    code === "join_state_changed" ||
+    code === "game_finished"
   );
 }
 
@@ -984,7 +985,7 @@ function shouldPersistPublicJoinResponse(response: ApiGatewayHttpResponse): bool
   }
 
   try {
-    return !hasJoinStateChangedCode(JSON.parse(response.body));
+    return !hasNonPersistedPublicJoinConflictCode(JSON.parse(response.body));
   } catch {
     return true;
   }

--- a/api/src/lambda-core.ts
+++ b/api/src/lambda-core.ts
@@ -965,6 +965,31 @@ function joinStateChangedResponse(
   );
 }
 
+function hasJoinStateChangedCode(payload: unknown): boolean {
+  return (
+    typeof payload === "object" &&
+    payload !== null &&
+    "code" in payload &&
+    (payload as { code?: unknown }).code === "join_state_changed"
+  );
+}
+
+function shouldPersistPublicJoinResponse(response: ApiGatewayHttpResponse): boolean {
+  if (response.statusCode === 404) {
+    return false;
+  }
+
+  if (response.statusCode !== 409) {
+    return true;
+  }
+
+  try {
+    return !hasJoinStateChangedCode(JSON.parse(response.body));
+  } catch {
+    return true;
+  }
+}
+
 function gameAlreadyExistsConflictResponse(
   origin: string | undefined,
   allowedOrigins: string[],
@@ -1968,7 +1993,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
           origin,
           allowedOrigins: dependencies.corsAllowedOrigins,
           execute: executeJoin,
-          shouldPersistResponse: (response) => response.statusCode !== 404,
+          shouldPersistResponse: shouldPersistPublicJoinResponse,
         });
         status = mutationResponse.statusCode;
         return mutationResponse;

--- a/api/src/lambda-core.ts
+++ b/api/src/lambda-core.ts
@@ -2264,11 +2264,21 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
           }
 
           const games = await dependencies.repository.listGamesForSeason(seasonId);
+          const gamesWithUsableJoinCodes = await Promise.all(
+            games.map(async (game) => {
+              return (
+                (await dependencies.repository.getGame(game.gameId, {
+                  consistentRead: true,
+                  repairLegacyJoinCode: true,
+                })) ?? game
+              );
+            }),
+          );
           status = 200;
           return createJsonResponse(
             status,
             {
-              games: games.map((game) => buildGameResponse(game)),
+              games: gamesWithUsableJoinCodes.map((game) => buildGameResponse(game)),
             },
             buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
           );

--- a/api/src/lambda-core.ts
+++ b/api/src/lambda-core.ts
@@ -48,7 +48,9 @@ import {
   assignRosterPlayerRequestSchema,
   formatSchemaValidationError,
   idempotencyKeyHeaderSchema,
+  isJoinCodePathParamValid,
   joinGameRequestSchema,
+  normalizeJoinCodePathParam,
   quickCreateGamePlayerRequestSchema,
   undoLastGoalRequestSchema,
   updateGoalRequestSchema,
@@ -860,6 +862,21 @@ function joinCodeRequiredResponse(
       error: "bad_request",
       code: "join_code_required",
       message: "Join code is required.",
+    },
+    buildCorsHeaders(origin, allowedOrigins),
+  );
+}
+
+function joinCodeInvalidFormatResponse(
+  origin: string | undefined,
+  allowedOrigins: string[],
+): ApiGatewayHttpResponse {
+  return createJsonResponse(
+    400,
+    {
+      error: "bad_request",
+      code: "join_code_invalid",
+      message: "Join code must be 8 letters or digits.",
     },
     buildCorsHeaders(origin, allowedOrigins),
   );
@@ -1776,7 +1793,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
       if (method === "POST" && joinGameMatch) {
         let joinCode: string;
         try {
-          joinCode = decodeURIComponent(joinGameMatch[1]).trim();
+          joinCode = normalizeJoinCodePathParam(decodeURIComponent(joinGameMatch[1]));
         } catch {
           status = 400;
           return badRequest(origin, dependencies.corsAllowedOrigins, "Join code must be URL encoded correctly.");
@@ -1784,6 +1801,10 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
         if (joinCode.length === 0) {
           status = 400;
           return joinCodeRequiredResponse(origin, dependencies.corsAllowedOrigins);
+        }
+        if (!isJoinCodePathParamValid(joinCode)) {
+          status = 400;
+          return joinCodeInvalidFormatResponse(origin, dependencies.corsAllowedOrigins);
         }
 
         let rawBody: Record<string, unknown>;
@@ -2406,6 +2427,21 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
             });
           } catch (error) {
             if (error instanceof GameAlreadyExistsError) {
+              const replayResponse = await replayStoredIdempotencyMutation({
+                repository: dependencies.repository,
+                idempotencyKey,
+                sessionEmail: session.email,
+                method,
+                route,
+                requestPayload: parsedBody.data,
+                origin,
+                allowedOrigins: dependencies.corsAllowedOrigins,
+              });
+              if (replayResponse) {
+                status = replayResponse.statusCode;
+                return replayResponse;
+              }
+
               status = 409;
               return gameAlreadyExistsConflictResponse(
                 origin,
@@ -2414,6 +2450,21 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
               );
             }
             if (error instanceof GameJoinCodeCollisionError) {
+              const replayResponse = await replayStoredIdempotencyMutation({
+                repository: dependencies.repository,
+                idempotencyKey,
+                sessionEmail: session.email,
+                method,
+                route,
+                requestPayload: parsedBody.data,
+                origin,
+                allowedOrigins: dependencies.corsAllowedOrigins,
+              });
+              if (replayResponse) {
+                status = replayResponse.statusCode;
+                return replayResponse;
+              }
+
               status = 409;
               return gameJoinCodeCollisionConflictResponse(origin, dependencies.corsAllowedOrigins);
             }

--- a/api/src/lambda-core.ts
+++ b/api/src/lambda-core.ts
@@ -130,6 +130,7 @@ interface MagicLinkServiceContract extends SessionLookup {
 interface RepositoryGameRecord {
   gameId: string;
   joinCode: string;
+  createRequestHash?: string;
   leagueId: string;
   seasonId: string;
   sessionId: string;
@@ -268,6 +269,7 @@ interface RepositoryContract {
   createGame(input: {
     gameId: string;
     joinCode?: string | null;
+    createRequestHash?: string | null;
     leagueId: string;
     seasonId: string;
     sessionId: string;
@@ -770,8 +772,9 @@ function sortTeams<T extends { teamId: TeamId }>(teams: T[]): T[] {
 }
 
 function buildGameResponse(game: RepositoryGameRecord) {
+  const { createRequestHash: _createRequestHash, ...publicGame } = game;
   return {
-    ...game,
+    ...publicGame,
     timer: buildGameTimerState({
       thirdLengthMinutes: game.thirdLengthMinutes,
       thirds: game.thirds,
@@ -784,12 +787,14 @@ function existingGameMatchesCreateRequest(input: {
   leagueId: string;
   seasonId: string;
   sessionId: string;
+  createRequestHash: string;
   request: {
     gameId: string;
   };
 }): boolean {
   return (
     input.game.gameId === input.request.gameId &&
+    input.game.createRequestHash === input.createRequestHash &&
     input.game.leagueId === input.leagueId &&
     input.game.seasonId === input.seasonId &&
     input.game.sessionId === input.sessionId
@@ -2419,6 +2424,12 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
           }
 
           let mutationResponse: ApiGatewayHttpResponse;
+          const createRequestHash = idempotencyKey
+            ? buildIdempotencyRequestHash(
+                buildIdempotencyScope(session.email, method, route),
+                parsedBody.data,
+              )
+            : null;
           try {
             mutationResponse = await executeIdempotentMutation({
               repository: dependencies.repository,
@@ -2434,6 +2445,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
                 try {
                   createdGame = await dependencies.repository.createGame({
                     gameId: parsedBody.data.gameId,
+                    createRequestHash,
                     leagueId,
                     seasonId,
                     sessionId,
@@ -2459,7 +2471,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
                   if (replayResponse) {
                     return replayResponse;
                   }
-                  if (!idempotencyKey) {
+                  if (!idempotencyKey || !createRequestHash) {
                     throw error;
                   }
 
@@ -2471,6 +2483,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
                       leagueId,
                       seasonId,
                       sessionId,
+                      createRequestHash,
                       request: parsedBody.data,
                     })
                   ) {

--- a/api/src/lambda-core.ts
+++ b/api/src/lambda-core.ts
@@ -876,7 +876,22 @@ function joinCodeInvalidFormatResponse(
     {
       error: "bad_request",
       code: "join_code_invalid",
-      message: "Join code must be 8 letters or digits.",
+      message: "Join code must be 8 uppercase non-ambiguous letters or digits.",
+    },
+    buildCorsHeaders(origin, allowedOrigins),
+  );
+}
+
+function joinCodeMalformedResponse(
+  origin: string | undefined,
+  allowedOrigins: string[],
+): ApiGatewayHttpResponse {
+  return createJsonResponse(
+    400,
+    {
+      error: "bad_request",
+      code: "join_code_invalid",
+      message: "Join code must be URL encoded correctly.",
     },
     buildCorsHeaders(origin, allowedOrigins),
   );
@@ -900,14 +915,14 @@ function invalidJoinCodeResponse(
 function finishedGameJoinConflictResponse(
   origin: string | undefined,
   allowedOrigins: string[],
-  gameId: string,
+  message: string,
 ): ApiGatewayHttpResponse {
   return createJsonResponse(
     409,
     {
       error: "conflict",
       code: "game_finished",
-      message: `Game ${gameId} is finished. Join registration is closed.`,
+      message,
     },
     buildCorsHeaders(origin, allowedOrigins),
   );
@@ -1796,7 +1811,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
           joinCode = normalizeJoinCodePathParam(decodeURIComponent(joinGameMatch[1]));
         } catch {
           status = 400;
-          return badRequest(origin, dependencies.corsAllowedOrigins, "Join code must be URL encoded correctly.");
+          return joinCodeMalformedResponse(origin, dependencies.corsAllowedOrigins);
         }
         if (joinCode.length === 0) {
           status = 400;
@@ -1836,11 +1851,10 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
           if (error instanceof GameJoinRegistrationError) {
             status = error.statusCode;
             if (error.code === "game_finished") {
-              const game = await dependencies.repository.getGameByJoinCode(joinCode);
               return finishedGameJoinConflictResponse(
                 origin,
                 dependencies.corsAllowedOrigins,
-                game?.gameId ?? "unknown",
+                error.message,
               );
             }
 

--- a/api/src/lambda-core.ts
+++ b/api/src/lambda-core.ts
@@ -1525,6 +1525,7 @@ async function executeIdempotentMutation(input: {
   origin: string | undefined;
   allowedOrigins: string[];
   execute: () => Promise<ApiGatewayHttpResponse>;
+  shouldPersistResponse?: (response: ApiGatewayHttpResponse) => boolean;
 }): Promise<ApiGatewayHttpResponse> {
   if (!input.idempotencyKey) {
     return input.execute();
@@ -1557,6 +1558,10 @@ async function executeIdempotentMutation(input: {
   }
 
   const mutationResponse = await input.execute();
+  if (input.shouldPersistResponse && !input.shouldPersistResponse(mutationResponse)) {
+    return mutationResponse;
+  }
+
   const created = await input.repository.createIdempotencyRecord({
     scope,
     key: idempotencyKey,
@@ -1963,6 +1968,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
           origin,
           allowedOrigins: dependencies.corsAllowedOrigins,
           execute: executeJoin,
+          shouldPersistResponse: (response) => response.statusCode !== 404,
         });
         status = mutationResponse.statusCode;
         return mutationResponse;

--- a/api/src/lambda-core.ts
+++ b/api/src/lambda-core.ts
@@ -1392,6 +1392,55 @@ function buildIdempotencyRequestHash(scope: string, payload: unknown): string {
     .digest("hex");
 }
 
+function parseOptionalIdempotencyKey(value: string | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const parsed = idempotencyKeyHeaderSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+function buildKeyedRecoveryRequestHash(input: {
+  scope: string;
+  idempotencyKey: string;
+  payload: unknown;
+}): string {
+  return buildIdempotencyRequestHash(input.scope, {
+    idempotencyKey: input.idempotencyKey,
+    payload: input.payload,
+  });
+}
+
+function buildCreateGameRecoveryRequestHash(input: {
+  idempotencyKey: string | undefined;
+  sessionEmail: string;
+  method: string;
+  route: string;
+  payload: unknown;
+}): string | null {
+  const parsedIdempotencyKey = parseOptionalIdempotencyKey(input.idempotencyKey);
+  if (!parsedIdempotencyKey) {
+    return null;
+  }
+
+  return buildKeyedRecoveryRequestHash({
+    scope: buildIdempotencyScope(input.sessionEmail, input.method, input.route),
+    idempotencyKey: parsedIdempotencyKey,
+    payload: input.payload,
+  });
+}
+
+function buildPublicJoinPlayerId(joinCode: string, idempotencyKey: string): string {
+  const fingerprint = createHash("sha256")
+    .update(`public-join:${joinCode}:${idempotencyKey}`)
+    .digest("hex")
+    .slice(0, 32);
+  return `player-join-${fingerprint}`;
+}
+
+const PUBLIC_JOIN_IDEMPOTENCY_SUBJECT = "public-join";
+
 function buildGoalEventId(input: {
   idempotencyKey: string | undefined;
   sessionEmail: string;
@@ -1862,45 +1911,61 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
           );
         }
 
-        let joinResult: Awaited<ReturnType<RepositoryContract["joinGameByCode"]>>;
-        try {
-          joinResult = await dependencies.repository.joinGameByCode({
-            joinCode,
-            playerId: `player-${randomUUID()}`,
-            nickname: parsedBody.data.nickname,
-          });
-        } catch (error) {
-          if (error instanceof GameJoinRegistrationError) {
-            status = error.statusCode;
-            if (error.code === "game_finished") {
-              return finishedGameJoinConflictResponse(
-                origin,
-                dependencies.corsAllowedOrigins,
-                error.message,
-              );
+        const parsedIdempotencyKey = parseOptionalIdempotencyKey(idempotencyKey);
+        const executeJoin = async () => {
+          let joinResult: Awaited<ReturnType<RepositoryContract["joinGameByCode"]>>;
+          try {
+            joinResult = await dependencies.repository.joinGameByCode({
+              joinCode,
+              playerId: parsedIdempotencyKey
+                ? buildPublicJoinPlayerId(joinCode, parsedIdempotencyKey)
+                : `player-${randomUUID()}`,
+              nickname: parsedBody.data.nickname,
+            });
+          } catch (error) {
+            if (error instanceof GameJoinRegistrationError) {
+              if (error.code === "game_finished") {
+                return finishedGameJoinConflictResponse(
+                  origin,
+                  dependencies.corsAllowedOrigins,
+                  error.message,
+                );
+              }
+
+              return joinStateChangedResponse(origin, dependencies.corsAllowedOrigins);
             }
 
-            return joinStateChangedResponse(origin, dependencies.corsAllowedOrigins);
+            throw error;
           }
 
-          throw error;
-        }
+          if (!joinResult) {
+            return invalidJoinCodeResponse(origin, dependencies.corsAllowedOrigins);
+          }
 
-        if (!joinResult) {
-          status = 404;
-          return invalidJoinCodeResponse(origin, dependencies.corsAllowedOrigins);
-        }
+          return createJsonResponse(
+            201,
+            {
+              gameId: joinResult.game.gameId,
+              joinCode: joinResult.game.joinCode,
+              player: toPublicPlayer(joinResult.player),
+            },
+            buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
+          );
+        };
 
-        status = 201;
-        return createJsonResponse(
-          status,
-          {
-            gameId: joinResult.game.gameId,
-            joinCode: joinResult.game.joinCode,
-            player: toPublicPlayer(joinResult.player),
-          },
-          buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
-        );
+        const mutationResponse = await executeIdempotentMutation({
+          repository: dependencies.repository,
+          idempotencyKey,
+          sessionEmail: PUBLIC_JOIN_IDEMPOTENCY_SUBJECT,
+          method,
+          route: `/v1/join/${joinCode}`,
+          requestPayload: parsedBody.data,
+          origin,
+          allowedOrigins: dependencies.corsAllowedOrigins,
+          execute: executeJoin,
+        });
+        status = mutationResponse.statusCode;
+        return mutationResponse;
       }
 
       let session: AuthSessionRecord | null = null;
@@ -2434,12 +2499,13 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
           }
 
           let mutationResponse: ApiGatewayHttpResponse;
-          const createRequestHash = idempotencyKey
-            ? buildIdempotencyRequestHash(
-                buildIdempotencyScope(session.email, method, route),
-                parsedBody.data,
-              )
-            : null;
+          const createRequestHash = buildCreateGameRecoveryRequestHash({
+            idempotencyKey,
+            sessionEmail: session.email,
+            method,
+            route,
+            payload: parsedBody.data,
+          });
           try {
             mutationResponse = await executeIdempotentMutation({
               repository: dependencies.repository,

--- a/api/src/lambda-core.ts
+++ b/api/src/lambda-core.ts
@@ -48,12 +48,14 @@ import {
   assignRosterPlayerRequestSchema,
   formatSchemaValidationError,
   idempotencyKeyHeaderSchema,
+  joinGameRequestSchema,
   quickCreateGamePlayerRequestSchema,
   undoLastGoalRequestSchema,
   updateGoalRequestSchema,
   upsertTeamRequestSchema,
 } from "./contracts/core-write.js";
 import {
+  GameJoinRegistrationError,
   GameMutationStateError,
   GameTimerTransitionError,
   GoalCorrectionError,
@@ -123,6 +125,7 @@ interface MagicLinkServiceContract extends SessionLookup {
 
 interface RepositoryGameRecord {
   gameId: string;
+  joinCode: string;
   leagueId: string;
   seasonId: string;
   sessionId: string;
@@ -260,6 +263,7 @@ interface RepositoryContract {
   createSession(input: { seasonId: string; sessionId: string; sessionDate: string }): Promise<unknown>;
   createGame(input: {
     gameId: string;
+    joinCode?: string | null;
     leagueId: string;
     seasonId: string;
     sessionId: string;
@@ -279,6 +283,21 @@ interface RepositoryContract {
     gameId: string,
     options?: { consistentRead?: boolean },
   ): Promise<RepositoryGameRecord | null>;
+  getGameByJoinCode(joinCode: string): Promise<RepositoryGameRecord | null>;
+  joinGameByCode(input: {
+    joinCode: string;
+    playerId: string;
+    nickname: string;
+  }): Promise<{
+    game: RepositoryGameRecord;
+    player: {
+      playerId: string;
+      nickname: string;
+      claimedByUserId: string | null;
+      createdAt: string;
+      updatedAt: string;
+    };
+  } | null>;
   updateGame(input: {
     gameId: string;
     status?: "scheduled" | "live" | "finished";
@@ -824,6 +843,67 @@ function finishedGameDeleteConflictResponse(
       error: "conflict",
       code: "game_finished",
       message: `Game ${gameId} is finished. Finished games cannot be deleted.`,
+    },
+    buildCorsHeaders(origin, allowedOrigins),
+  );
+}
+
+function joinCodeRequiredResponse(
+  origin: string | undefined,
+  allowedOrigins: string[],
+): ApiGatewayHttpResponse {
+  return createJsonResponse(
+    400,
+    {
+      error: "bad_request",
+      code: "join_code_required",
+      message: "Join code is required.",
+    },
+    buildCorsHeaders(origin, allowedOrigins),
+  );
+}
+
+function invalidJoinCodeResponse(
+  origin: string | undefined,
+  allowedOrigins: string[],
+): ApiGatewayHttpResponse {
+  return createJsonResponse(
+    404,
+    {
+      error: "not_found",
+      code: "invalid_join_code",
+      message: "Join code was not found.",
+    },
+    buildCorsHeaders(origin, allowedOrigins),
+  );
+}
+
+function finishedGameJoinConflictResponse(
+  origin: string | undefined,
+  allowedOrigins: string[],
+  gameId: string,
+): ApiGatewayHttpResponse {
+  return createJsonResponse(
+    409,
+    {
+      error: "conflict",
+      code: "game_finished",
+      message: `Game ${gameId} is finished. Join registration is closed.`,
+    },
+    buildCorsHeaders(origin, allowedOrigins),
+  );
+}
+
+function joinStateChangedResponse(
+  origin: string | undefined,
+  allowedOrigins: string[],
+): ApiGatewayHttpResponse {
+  return createJsonResponse(
+    409,
+    {
+      error: "conflict",
+      code: "join_state_changed",
+      message: "Game join state changed while registering this player. Reload and try again.",
     },
     buildCorsHeaders(origin, allowedOrigins),
   );
@@ -1651,6 +1731,80 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
 
           throw error;
         }
+      }
+
+      const missingJoinCodeMatch = route.match(/^\/v1\/join\/?$/);
+      if (method === "POST" && missingJoinCodeMatch) {
+        status = 400;
+        return joinCodeRequiredResponse(origin, dependencies.corsAllowedOrigins);
+      }
+
+      const joinGameMatch = route.match(/^\/v1\/join\/([^/]+)$/);
+      if (method === "POST" && joinGameMatch) {
+        const joinCode = decodeRouteParam(joinGameMatch[1]).trim();
+        if (joinCode.length === 0) {
+          status = 400;
+          return joinCodeRequiredResponse(origin, dependencies.corsAllowedOrigins);
+        }
+
+        let rawBody: Record<string, unknown>;
+        try {
+          rawBody = parseJsonBody(event);
+        } catch {
+          status = 400;
+          return badRequest(origin, dependencies.corsAllowedOrigins, "Request body must be valid JSON.");
+        }
+
+        const parsedBody = joinGameRequestSchema.safeParse(rawBody);
+        if (!parsedBody.success) {
+          status = 400;
+          return badRequest(
+            origin,
+            dependencies.corsAllowedOrigins,
+            formatSchemaValidationError(parsedBody.error),
+          );
+        }
+
+        let joinResult: Awaited<ReturnType<RepositoryContract["joinGameByCode"]>>;
+        try {
+          joinResult = await dependencies.repository.joinGameByCode({
+            joinCode,
+            playerId: `player-${randomUUID()}`,
+            nickname: parsedBody.data.nickname,
+          });
+        } catch (error) {
+          if (error instanceof GameJoinRegistrationError) {
+            status = error.statusCode;
+            if (error.code === "game_finished") {
+              const game = await dependencies.repository.getGameByJoinCode(joinCode);
+              return finishedGameJoinConflictResponse(
+                origin,
+                dependencies.corsAllowedOrigins,
+                game?.gameId ?? "unknown",
+              );
+            }
+
+            return joinStateChangedResponse(origin, dependencies.corsAllowedOrigins);
+          }
+
+          throw error;
+        }
+
+        if (!joinResult) {
+          status = 404;
+          return invalidJoinCodeResponse(origin, dependencies.corsAllowedOrigins);
+        }
+
+        status = 201;
+        return createJsonResponse(
+          status,
+          {
+            gameId: joinResult.game.gameId,
+            joinCode: joinResult.game.joinCode,
+            player: toPublicPlayer(joinResult.player),
+          },
+          buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
+        );
       }
 
       let session: AuthSessionRecord | null = null;

--- a/api/src/lambda-core.ts
+++ b/api/src/lambda-core.ts
@@ -5,7 +5,6 @@ import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { SESv2Client, SendEmailCommand } from "@aws-sdk/client-sesv2";
 import {
   buildGameTimerState,
-  DEFAULT_THIRD_LENGTH_MINUTES,
   DEFAULT_TEAMS,
   isThirdLengthMinutes,
   isThirdNumber,
@@ -787,20 +786,13 @@ function existingGameMatchesCreateRequest(input: {
   sessionId: string;
   request: {
     gameId: string;
-    gameStartTs: string;
-    status?: GameStatus;
-    thirdLengthMinutes?: ThirdLengthMinutes;
   };
 }): boolean {
   return (
     input.game.gameId === input.request.gameId &&
     input.game.leagueId === input.leagueId &&
     input.game.seasonId === input.seasonId &&
-    input.game.sessionId === input.sessionId &&
-    input.game.status === (input.request.status ?? "scheduled") &&
-    input.game.gameStartTs === input.request.gameStartTs &&
-    input.game.thirdLengthMinutes ===
-      (input.request.thirdLengthMinutes ?? DEFAULT_THIRD_LENGTH_MINUTES)
+    input.game.sessionId === input.sessionId
   );
 }
 
@@ -2451,6 +2443,23 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
                   });
                 } catch (error) {
                   if (!(error instanceof GameAlreadyExistsError)) {
+                    throw error;
+                  }
+
+                  const replayResponse = await replayStoredIdempotencyMutation({
+                    repository: dependencies.repository,
+                    idempotencyKey,
+                    sessionEmail: session.email,
+                    method,
+                    route,
+                    requestPayload: parsedBody.data,
+                    origin,
+                    allowedOrigins: dependencies.corsAllowedOrigins,
+                  });
+                  if (replayResponse) {
+                    return replayResponse;
+                  }
+                  if (!idempotencyKey) {
                     throw error;
                   }
 

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -13,7 +13,6 @@ import {
 import {
   buildGameTimerState,
   DEFAULT_TEAMS,
-  DEFAULT_THIRD_LENGTH_MINUTES,
   isThirdLengthMinutes,
   isThirdNumber,
   TEAM_IDS,
@@ -426,29 +425,19 @@ function existingGameMatchesCreateRequest(input: {
     leagueId: string;
     seasonId: string;
     sessionId: string;
-    status: "scheduled" | "live" | "finished";
-    gameStartTs: string;
-    thirdLengthMinutes: ThirdLengthMinutes;
   };
   leagueId: string;
   seasonId: string;
   sessionId: string;
   request: {
     gameId: string;
-    gameStartTs: string;
-    status?: "scheduled" | "live" | "finished";
-    thirdLengthMinutes?: ThirdLengthMinutes;
   };
 }): boolean {
   return (
     input.game.gameId === input.request.gameId &&
     input.game.leagueId === input.leagueId &&
     input.game.seasonId === input.seasonId &&
-    input.game.sessionId === input.sessionId &&
-    input.game.status === (input.request.status ?? "scheduled") &&
-    input.game.gameStartTs === input.request.gameStartTs &&
-    input.game.thirdLengthMinutes ===
-      (input.request.thirdLengthMinutes ?? DEFAULT_THIRD_LENGTH_MINUTES)
+    input.game.sessionId === input.sessionId
   );
 }
 
@@ -1721,6 +1710,7 @@ async function handleCreateSession(
 async function createGameWithDerivedRecords(input: {
   repositoryClient: LocalCreateGameRouteRepository;
   scope: { leagueId: string; seasonId: string; sessionId: string };
+  allowExistingGameRecovery: boolean;
   request: {
     gameId: string;
     gameStartTs: string;
@@ -1741,6 +1731,9 @@ async function createGameWithDerivedRecords(input: {
     });
   } catch (error) {
     if (!(error instanceof GameAlreadyExistsError)) {
+      throw error;
+    }
+    if (!input.allowExistingGameRecovery) {
       throw error;
     }
 
@@ -1771,6 +1764,11 @@ async function createGameWithDerivedRecords(input: {
   await ensureGameTeamsForGame(game, input.repositoryClient);
 
   return game;
+}
+
+function hasValidIdempotencyKey(request: IncomingMessage): boolean {
+  const raw = readHeaderValue(request, "idempotency-key");
+  return raw ? idempotencyKeyHeaderSchema.safeParse(raw).success : false;
 }
 
 export async function handleLocalCreateGameRoute(input: {
@@ -1813,6 +1811,7 @@ export async function handleLocalCreateGameRoute(input: {
         const game = await createGameWithDerivedRecords({
           repositoryClient,
           scope: input.scope,
+          allowExistingGameRecovery: hasValidIdempotencyKey(input.request),
           request: parsedBody.data,
         });
 

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -2621,9 +2621,19 @@ async function start(): Promise<void> {
         }
 
         const games = await repository.listGamesForSeason(seasonId);
+        const gamesWithUsableJoinCodes = await Promise.all(
+          games.map(async (game) => {
+            return (
+              (await repository.getGame(game.gameId, {
+                consistentRead: true,
+                repairLegacyJoinCode: true,
+              })) ?? game
+            );
+          }),
+        );
         status = 200;
         sendJsonWithCors(request, response, status, {
-          games: games.map((game) => buildGameResponse(game)),
+          games: gamesWithUsableJoinCodes.map((game) => buildGameResponse(game)),
         });
         return;
       }

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -1182,6 +1182,7 @@ async function executeIdempotentMutation(input: {
   requestPayload: unknown;
   execute: () => Promise<JsonMutationResult>;
   repositoryClient?: LocalIdempotencyRepository;
+  shouldPersistResponse?: (response: JsonMutationResult) => boolean;
 }): Promise<number> {
   const repositoryClient = input.repositoryClient ?? repository;
   const idempotencyKeyRaw = readHeaderValue(input.request, "idempotency-key");
@@ -1221,6 +1222,11 @@ async function executeIdempotentMutation(input: {
   }
 
   const mutation = await input.execute();
+  if (input.shouldPersistResponse && !input.shouldPersistResponse(mutation)) {
+    sendJsonWithCors(input.request, input.response, mutation.statusCode, mutation.payload);
+    return mutation.statusCode;
+  }
+
   const mutationBody = JSON.stringify(mutation.payload);
   const created = await repositoryClient.createIdempotencyRecord({
     scope,
@@ -2395,6 +2401,7 @@ async function start(): Promise<void> {
           method,
           route: `/v1/join/${joinCode}`,
           requestPayload: parsedBody.data,
+          shouldPersistResponse: (mutation) => mutation.statusCode !== 404,
           execute: async () => {
             let joinResult: Awaited<ReturnType<ThreeFcRepository["joinGameByCode"]>>;
             try {

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -604,6 +604,27 @@ function joinStateChangedConflict(request: IncomingMessage, response: ServerResp
   return 409;
 }
 
+function hasJoinStateChangedCode(payload: unknown): boolean {
+  return (
+    typeof payload === "object" &&
+    payload !== null &&
+    "code" in payload &&
+    (payload as { code?: unknown }).code === "join_state_changed"
+  );
+}
+
+function shouldPersistPublicJoinMutation(mutation: JsonMutationResult): boolean {
+  if (mutation.statusCode === 404) {
+    return false;
+  }
+
+  if (mutation.statusCode === 409 && hasJoinStateChangedCode(mutation.payload)) {
+    return false;
+  }
+
+  return true;
+}
+
 function gameAlreadyExistsConflict(
   request: IncomingMessage,
   response: ServerResponse,
@@ -2401,7 +2422,7 @@ async function start(): Promise<void> {
           method,
           route: `/v1/join/${joinCode}`,
           requestPayload: parsedBody.data,
-          shouldPersistResponse: (mutation) => mutation.statusCode !== 404,
+          shouldPersistResponse: shouldPersistPublicJoinMutation,
           execute: async () => {
             let joinResult: Awaited<ReturnType<ThreeFcRepository["joinGameByCode"]>>;
             try {

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -58,7 +58,9 @@ import {
   assignRosterPlayerRequestSchema,
   formatSchemaValidationError,
   idempotencyKeyHeaderSchema,
+  isJoinCodePathParamValid,
   joinGameRequestSchema,
+  normalizeJoinCodePathParam,
   quickCreateGamePlayerRequestSchema,
   undoLastGoalRequestSchema,
   updateGoalRequestSchema,
@@ -508,6 +510,15 @@ function joinCodeRequired(request: IncomingMessage, response: ServerResponse): n
     error: "bad_request",
     code: "join_code_required",
     message: "Join code is required.",
+  });
+  return 400;
+}
+
+function joinCodeInvalidFormat(request: IncomingMessage, response: ServerResponse): number {
+  sendJsonWithCors(request, response, 400, {
+    error: "bad_request",
+    code: "join_code_invalid",
+    message: "Join code must be 8 letters or digits.",
   });
   return 400;
 }
@@ -1139,6 +1150,58 @@ async function executeIdempotentMutation(input: {
   return mutation.statusCode;
 }
 
+async function waitForIdempotencyRecord(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 25));
+}
+
+async function replayStoredIdempotencyMutation(input: {
+  request: IncomingMessage;
+  response: ServerResponse;
+  sessionEmail: string;
+  method: string;
+  route: string;
+  requestPayload: unknown;
+  repositoryClient?: LocalIdempotencyRepository;
+}): Promise<number | null> {
+  const repositoryClient = input.repositoryClient ?? repository;
+  const idempotencyKeyRaw = readHeaderValue(input.request, "idempotency-key");
+  if (!idempotencyKeyRaw) {
+    return null;
+  }
+
+  const parsedHeader = idempotencyKeyHeaderSchema.safeParse(idempotencyKeyRaw);
+  if (!parsedHeader.success) {
+    return null;
+  }
+
+  const scope = buildIdempotencyScope(input.sessionEmail, input.method, input.route);
+  const key = parsedHeader.data;
+  const requestHash = buildIdempotencyRequestHash(scope, input.requestPayload);
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const record = await repositoryClient.getIdempotencyRecord(scope, key);
+    if (record) {
+      if (record.requestHash !== requestHash) {
+        return idempotencyConflict(input.request, input.response);
+      }
+
+      sendJsonWithCors(
+        input.request,
+        input.response,
+        record.responseStatusCode,
+        parseStoredIdempotencyResponseBody(record.responseBody),
+      );
+      return record.responseStatusCode;
+    }
+
+    if (attempt < 2) {
+      await waitForIdempotencyRecord();
+    }
+  }
+
+  return null;
+}
+
 export async function handleLocalFinishGameRoute(input: {
   request: IncomingMessage;
   response: ServerResponse;
@@ -1658,9 +1721,33 @@ async function handleCreateGame(
     });
   } catch (error) {
     if (error instanceof GameAlreadyExistsError) {
+      const replayStatus = await replayStoredIdempotencyMutation({
+        request,
+        response,
+        sessionEmail,
+        method,
+        route,
+        requestPayload: parsedBody.data,
+      });
+      if (replayStatus !== null) {
+        return replayStatus;
+      }
+
       return gameAlreadyExistsConflict(request, response, parsedBody.data.gameId);
     }
     if (error instanceof GameJoinCodeCollisionError) {
+      const replayStatus = await replayStoredIdempotencyMutation({
+        request,
+        response,
+        sessionEmail,
+        method,
+        route,
+        requestPayload: parsedBody.data,
+      });
+      if (replayStatus !== null) {
+        return replayStatus;
+      }
+
       return gameJoinCodeCollisionConflict(request, response);
     }
 
@@ -2048,13 +2135,17 @@ async function start(): Promise<void> {
       if (method === "POST" && joinGameMatch) {
         let joinCode: string;
         try {
-          joinCode = decodeURIComponent(joinGameMatch[1]).trim();
+          joinCode = normalizeJoinCodePathParam(decodeURIComponent(joinGameMatch[1]));
         } catch {
           status = badRequest(request, response, "Join code must be URL encoded correctly.");
           return;
         }
         if (joinCode.length === 0) {
           status = joinCodeRequired(request, response);
+          return;
+        }
+        if (!isJoinCodePathParamValid(joinCode)) {
+          status = joinCodeInvalidFormat(request, response);
           return;
         }
 

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -156,6 +156,8 @@ const magicLinkRateLimiter = new AuthRateLimiter(
 );
 const repository = new ThreeFcRepository(ddbClient, TABLE_NAME);
 
+type LocalGetGameRouteRepository = Pick<ThreeFcRepository, "getGame" | "getLeagueAccess">;
+
 type LocalFinishGameRouteRepository = Pick<
   ThreeFcRepository,
   | "getGame"
@@ -1248,6 +1250,39 @@ async function replayStoredIdempotencyMutation(input: {
   }
 
   return null;
+}
+
+export async function handleLocalGetGameRoute(input: {
+  request: IncomingMessage;
+  response: ServerResponse;
+  gameId: string;
+  sessionEmail: string;
+  repositoryClient?: LocalGetGameRouteRepository;
+}): Promise<number> {
+  const repositoryClient = input.repositoryClient ?? repository;
+  const game = await repositoryClient.getGame(input.gameId);
+  if (!game) {
+    return notFound(input.request, input.response, `Game ${input.gameId} was not found.`);
+  }
+
+  const access = await ensureLeagueAccess(game.leagueId, input.sessionEmail, repositoryClient);
+  if (!access.allowed) {
+    return forbidden(
+      input.request,
+      input.response,
+      "league_access_required",
+      `Access to league ${game.leagueId} is required.`,
+    );
+  }
+
+  const responseGame =
+    (await repositoryClient.getGame(input.gameId, {
+      consistentRead: true,
+      repairLegacyJoinCode: true,
+    })) ?? game;
+
+  sendJsonWithCors(input.request, input.response, 200, buildGameResponse(responseGame));
+  return 200;
 }
 
 export async function handleLocalFinishGameRoute(input: {
@@ -2748,26 +2783,12 @@ async function start(): Promise<void> {
           return;
         }
 
-        const gameId = decodeURIComponent(getGameMatch[1]);
-        const game = await repository.getGame(gameId);
-        if (!game) {
-          status = notFound(request, response, `Game ${gameId} was not found.`);
-          return;
-        }
-
-        const access = await ensureLeagueAccess(game.leagueId, authGate.session.email);
-        if (!access.allowed) {
-          status = forbidden(
-            request,
-            response,
-            "league_access_required",
-            `Access to league ${game.leagueId} is required.`,
-          );
-          return;
-        }
-
-        status = 200;
-        sendJsonWithCors(request, response, status, buildGameResponse(game));
+        status = await handleLocalGetGameRoute({
+          request,
+          response,
+          gameId: decodeURIComponent(getGameMatch[1]),
+          sessionEmail: authGate.session.email,
+        });
         return;
       }
 

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -394,6 +394,7 @@ function sortTeams<T extends { teamId: TeamId }>(teams: T[]): T[] {
 function buildGameResponse(game: {
   gameId: string;
   joinCode: string;
+  createRequestHash?: string;
   leagueId: string;
   seasonId: string;
   sessionId: string;
@@ -410,8 +411,9 @@ function buildGameResponse(game: {
   createdAt: string;
   updatedAt: string;
 }) {
+  const { createRequestHash: _createRequestHash, ...publicGame } = game;
   return {
-    ...game,
+    ...publicGame,
     timer: buildGameTimerState({
       thirdLengthMinutes: game.thirdLengthMinutes,
       thirds: game.thirds,
@@ -425,16 +427,19 @@ function existingGameMatchesCreateRequest(input: {
     leagueId: string;
     seasonId: string;
     sessionId: string;
+    createRequestHash?: string;
   };
   leagueId: string;
   seasonId: string;
   sessionId: string;
+  createRequestHash: string;
   request: {
     gameId: string;
   };
 }): boolean {
   return (
     input.game.gameId === input.request.gameId &&
+    input.game.createRequestHash === input.createRequestHash &&
     input.game.leagueId === input.leagueId &&
     input.game.seasonId === input.seasonId &&
     input.game.sessionId === input.sessionId
@@ -1717,11 +1722,13 @@ async function createGameWithDerivedRecords(input: {
     status?: "scheduled" | "live" | "finished";
     thirdLengthMinutes?: ThirdLengthMinutes;
   };
+  createRequestHash: string | null;
 }) {
   let game;
   try {
     game = await input.repositoryClient.createGame({
       gameId: input.request.gameId,
+      createRequestHash: input.createRequestHash,
       leagueId: input.scope.leagueId,
       seasonId: input.scope.seasonId,
       sessionId: input.scope.sessionId,
@@ -1736,6 +1743,9 @@ async function createGameWithDerivedRecords(input: {
     if (!input.allowExistingGameRecovery) {
       throw error;
     }
+    if (!input.createRequestHash) {
+      throw error;
+    }
 
     const existingGame = await input.repositoryClient.getGame(input.request.gameId);
     if (
@@ -1745,6 +1755,7 @@ async function createGameWithDerivedRecords(input: {
         leagueId: input.scope.leagueId,
         seasonId: input.scope.seasonId,
         sessionId: input.scope.sessionId,
+        createRequestHash: input.createRequestHash,
         request: input.request,
       })
     ) {
@@ -1799,6 +1810,12 @@ export async function handleLocalCreateGameRoute(input: {
   }
 
   try {
+    const createRequestHash = hasValidIdempotencyKey(input.request)
+      ? buildIdempotencyRequestHash(
+          buildIdempotencyScope(input.sessionEmail, input.method, input.route),
+          parsedBody.data,
+        )
+      : null;
     return await executeIdempotentMutation({
       request: input.request,
       response: input.response,
@@ -1811,8 +1828,9 @@ export async function handleLocalCreateGameRoute(input: {
         const game = await createGameWithDerivedRecords({
           repositoryClient,
           scope: input.scope,
-          allowExistingGameRecovery: hasValidIdempotencyKey(input.request),
+          allowExistingGameRecovery: createRequestHash !== null,
           request: parsedBody.data,
+          createRequestHash,
         });
 
         return {

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -58,12 +58,14 @@ import {
   assignRosterPlayerRequestSchema,
   formatSchemaValidationError,
   idempotencyKeyHeaderSchema,
+  joinGameRequestSchema,
   quickCreateGamePlayerRequestSchema,
   undoLastGoalRequestSchema,
   updateGoalRequestSchema,
   upsertTeamRequestSchema,
 } from "./contracts/core-write.js";
 import {
+  GameJoinRegistrationError,
   GameMutationStateError,
   GameTimerTransitionError,
   GoalCorrectionError,
@@ -375,6 +377,7 @@ function sortTeams<T extends { teamId: TeamId }>(teams: T[]): T[] {
 
 function buildGameResponse(game: {
   gameId: string;
+  joinCode: string;
   leagueId: string;
   seasonId: string;
   sessionId: string;
@@ -494,6 +497,46 @@ function finishedGameDeleteConflict(
     error: "conflict",
     code: "game_finished",
     message: `Game ${gameId} is finished. Finished games cannot be deleted.`,
+  });
+  return 409;
+}
+
+function joinCodeRequired(request: IncomingMessage, response: ServerResponse): number {
+  sendJsonWithCors(request, response, 400, {
+    error: "bad_request",
+    code: "join_code_required",
+    message: "Join code is required.",
+  });
+  return 400;
+}
+
+function invalidJoinCode(request: IncomingMessage, response: ServerResponse): number {
+  sendJsonWithCors(request, response, 404, {
+    error: "not_found",
+    code: "invalid_join_code",
+    message: "Join code was not found.",
+  });
+  return 404;
+}
+
+function finishedGameJoinConflict(
+  request: IncomingMessage,
+  response: ServerResponse,
+  gameId: string,
+): number {
+  sendJsonWithCors(request, response, 409, {
+    error: "conflict",
+    code: "game_finished",
+    message: `Game ${gameId} is finished. Join registration is closed.`,
+  });
+  return 409;
+}
+
+function joinStateChangedConflict(request: IncomingMessage, response: ServerResponse): number {
+  sendJsonWithCors(request, response, 409, {
+    error: "conflict",
+    code: "join_state_changed",
+    message: "Game join state changed while registering this player. Reload and try again.",
   });
   return 409;
 }
@@ -1957,6 +2000,70 @@ async function start(): Promise<void> {
 
       if (method === "POST" && route === "/v1/auth/magic/complete") {
         status = await handleMagicLinkComplete(request, response);
+        return;
+      }
+
+      const missingJoinCodeMatch = route.match(/^\/v1\/join\/?$/);
+      if (method === "POST" && missingJoinCodeMatch) {
+        status = joinCodeRequired(request, response);
+        return;
+      }
+
+      const joinGameMatch = route.match(/^\/v1\/join\/([^/]+)$/);
+      if (method === "POST" && joinGameMatch) {
+        const joinCode = decodeURIComponent(joinGameMatch[1]).trim();
+        if (joinCode.length === 0) {
+          status = joinCodeRequired(request, response);
+          return;
+        }
+
+        let rawBody: Record<string, unknown>;
+        try {
+          rawBody = await parseJsonBody(request);
+        } catch {
+          status = badRequest(request, response, "Request body must be valid JSON.");
+          return;
+        }
+
+        const parsedBody = joinGameRequestSchema.safeParse(rawBody);
+        if (!parsedBody.success) {
+          status = badRequest(request, response, formatSchemaValidationError(parsedBody.error));
+          return;
+        }
+
+        let joinResult: Awaited<ReturnType<ThreeFcRepository["joinGameByCode"]>>;
+        try {
+          joinResult = await repository.joinGameByCode({
+            joinCode,
+            playerId: `player-${randomUUID()}`,
+            nickname: parsedBody.data.nickname,
+          });
+        } catch (error) {
+          if (error instanceof GameJoinRegistrationError) {
+            if (error.code === "game_finished") {
+              const game = await repository.getGameByJoinCode(joinCode);
+              status = finishedGameJoinConflict(request, response, game?.gameId ?? "unknown");
+              return;
+            }
+
+            status = joinStateChangedConflict(request, response);
+            return;
+          }
+
+          throw error;
+        }
+
+        if (!joinResult) {
+          status = invalidJoinCode(request, response);
+          return;
+        }
+
+        status = 201;
+        sendJsonWithCors(request, response, status, {
+          gameId: joinResult.game.gameId,
+          joinCode: joinResult.game.joinCode,
+          player: toPublicPlayer(joinResult.player),
+        });
         return;
       }
 

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -518,7 +518,16 @@ function joinCodeInvalidFormat(request: IncomingMessage, response: ServerRespons
   sendJsonWithCors(request, response, 400, {
     error: "bad_request",
     code: "join_code_invalid",
-    message: "Join code must be 8 letters or digits.",
+    message: "Join code must be 8 uppercase non-ambiguous letters or digits.",
+  });
+  return 400;
+}
+
+function joinCodeMalformed(request: IncomingMessage, response: ServerResponse): number {
+  sendJsonWithCors(request, response, 400, {
+    error: "bad_request",
+    code: "join_code_invalid",
+    message: "Join code must be URL encoded correctly.",
   });
   return 400;
 }
@@ -535,12 +544,12 @@ function invalidJoinCode(request: IncomingMessage, response: ServerResponse): nu
 function finishedGameJoinConflict(
   request: IncomingMessage,
   response: ServerResponse,
-  gameId: string,
+  message: string,
 ): number {
   sendJsonWithCors(request, response, 409, {
     error: "conflict",
     code: "game_finished",
-    message: `Game ${gameId} is finished. Join registration is closed.`,
+    message,
   });
   return 409;
 }
@@ -2137,7 +2146,7 @@ async function start(): Promise<void> {
         try {
           joinCode = normalizeJoinCodePathParam(decodeURIComponent(joinGameMatch[1]));
         } catch {
-          status = badRequest(request, response, "Join code must be URL encoded correctly.");
+          status = joinCodeMalformed(request, response);
           return;
         }
         if (joinCode.length === 0) {
@@ -2173,8 +2182,7 @@ async function start(): Promise<void> {
         } catch (error) {
           if (error instanceof GameJoinRegistrationError) {
             if (error.code === "game_finished") {
-              const game = await repository.getGameByJoinCode(joinCode);
-              status = finishedGameJoinConflict(request, response, game?.gameId ?? "unknown");
+              status = finishedGameJoinConflict(request, response, error.message);
               return;
             }
 

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -973,6 +973,57 @@ function buildIdempotencyRequestHash(scope: string, payload: unknown): string {
     .digest("hex");
 }
 
+function parseOptionalIdempotencyKey(value: string | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+
+  const parsed = idempotencyKeyHeaderSchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
+}
+
+function buildKeyedRecoveryRequestHash(input: {
+  scope: string;
+  idempotencyKey: string;
+  payload: unknown;
+}): string {
+  return buildIdempotencyRequestHash(input.scope, {
+    idempotencyKey: input.idempotencyKey,
+    payload: input.payload,
+  });
+}
+
+function buildCreateGameRecoveryRequestHash(input: {
+  request: IncomingMessage;
+  sessionEmail: string;
+  method: string;
+  route: string;
+  payload: unknown;
+}): string | null {
+  const parsedIdempotencyKey = parseOptionalIdempotencyKey(
+    readHeaderValue(input.request, "idempotency-key") ?? undefined,
+  );
+  if (!parsedIdempotencyKey) {
+    return null;
+  }
+
+  return buildKeyedRecoveryRequestHash({
+    scope: buildIdempotencyScope(input.sessionEmail, input.method, input.route),
+    idempotencyKey: parsedIdempotencyKey,
+    payload: input.payload,
+  });
+}
+
+function buildPublicJoinPlayerId(joinCode: string, idempotencyKey: string): string {
+  const fingerprint = createHash("sha256")
+    .update(`public-join:${joinCode}:${idempotencyKey}`)
+    .digest("hex")
+    .slice(0, 32);
+  return `player-join-${fingerprint}`;
+}
+
+const PUBLIC_JOIN_IDEMPOTENCY_SUBJECT = "public-join";
+
 function buildGoalEventId(input: {
   request: IncomingMessage;
   sessionEmail: string;
@@ -1812,11 +1863,6 @@ async function createGameWithDerivedRecords(input: {
   return game;
 }
 
-function hasValidIdempotencyKey(request: IncomingMessage): boolean {
-  const raw = readHeaderValue(request, "idempotency-key");
-  return raw ? idempotencyKeyHeaderSchema.safeParse(raw).success : false;
-}
-
 export async function handleLocalCreateGameRoute(input: {
   request: IncomingMessage;
   response: ServerResponse;
@@ -1845,12 +1891,13 @@ export async function handleLocalCreateGameRoute(input: {
   }
 
   try {
-    const createRequestHash = hasValidIdempotencyKey(input.request)
-      ? buildIdempotencyRequestHash(
-          buildIdempotencyScope(input.sessionEmail, input.method, input.route),
-          parsedBody.data,
-        )
-      : null;
+    const createRequestHash = buildCreateGameRecoveryRequestHash({
+      request: input.request,
+      sessionEmail: input.sessionEmail,
+      method: input.method,
+      route: input.route,
+      payload: parsedBody.data,
+    });
     return await executeIdempotentMutation({
       request: input.request,
       response: input.response,
@@ -2338,37 +2385,72 @@ async function start(): Promise<void> {
           return;
         }
 
-        let joinResult: Awaited<ReturnType<ThreeFcRepository["joinGameByCode"]>>;
-        try {
-          joinResult = await repository.joinGameByCode({
-            joinCode,
-            playerId: `player-${randomUUID()}`,
-            nickname: parsedBody.data.nickname,
-          });
-        } catch (error) {
-          if (error instanceof GameJoinRegistrationError) {
-            if (error.code === "game_finished") {
-              status = finishedGameJoinConflict(request, response, error.message);
-              return;
+        const parsedIdempotencyKey = parseOptionalIdempotencyKey(
+          readHeaderValue(request, "idempotency-key") ?? undefined,
+        );
+        status = await executeIdempotentMutation({
+          request,
+          response,
+          sessionEmail: PUBLIC_JOIN_IDEMPOTENCY_SUBJECT,
+          method,
+          route: `/v1/join/${joinCode}`,
+          requestPayload: parsedBody.data,
+          execute: async () => {
+            let joinResult: Awaited<ReturnType<ThreeFcRepository["joinGameByCode"]>>;
+            try {
+              joinResult = await repository.joinGameByCode({
+                joinCode,
+                playerId: parsedIdempotencyKey
+                  ? buildPublicJoinPlayerId(joinCode, parsedIdempotencyKey)
+                  : `player-${randomUUID()}`,
+                nickname: parsedBody.data.nickname,
+              });
+            } catch (error) {
+              if (error instanceof GameJoinRegistrationError) {
+                if (error.code === "game_finished") {
+                  return {
+                    statusCode: 409,
+                    payload: {
+                      error: "conflict",
+                      code: "game_finished",
+                      message: error.message,
+                    },
+                  };
+                }
+
+                return {
+                  statusCode: 409,
+                  payload: {
+                    error: "conflict",
+                    code: "join_state_changed",
+                    message: "Game join state changed while registering this player. Reload and try again.",
+                  },
+                };
+              }
+
+              throw error;
             }
 
-            status = joinStateChangedConflict(request, response);
-            return;
-          }
+            if (!joinResult) {
+              return {
+                statusCode: 404,
+                payload: {
+                  error: "not_found",
+                  code: "invalid_join_code",
+                  message: "Join code was not found.",
+                },
+              };
+            }
 
-          throw error;
-        }
-
-        if (!joinResult) {
-          status = invalidJoinCode(request, response);
-          return;
-        }
-
-        status = 201;
-        sendJsonWithCors(request, response, status, {
-          gameId: joinResult.game.gameId,
-          joinCode: joinResult.game.joinCode,
-          player: toPublicPlayer(joinResult.player),
+            return {
+              statusCode: 201,
+              payload: {
+                gameId: joinResult.game.gameId,
+                joinCode: joinResult.game.joinCode,
+                player: toPublicPlayer(joinResult.player),
+              },
+            };
+          },
         });
         return;
       }

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -13,6 +13,7 @@ import {
 import {
   buildGameTimerState,
   DEFAULT_TEAMS,
+  DEFAULT_THIRD_LENGTH_MINUTES,
   isThirdLengthMinutes,
   isThirdNumber,
   TEAM_IDS,
@@ -180,6 +181,18 @@ type LocalIdempotencyRepository = Pick<
   ThreeFcRepository,
   "getIdempotencyRecord" | "createIdempotencyRecord"
 >;
+
+type LocalCreateGameRouteRepository = LocalIdempotencyRepository &
+  Pick<
+    ThreeFcRepository,
+    | "createGame"
+    | "getGame"
+    | "createSessionGame"
+    | "listTeamsForSeason"
+    | "createTeam"
+    | "listTeamsForGame"
+    | "createGameTeamOverride"
+  >;
 
 async function ensureTable(): Promise<void> {
   try {
@@ -405,6 +418,38 @@ function buildGameResponse(game: {
       thirds: game.thirds,
     }),
   };
+}
+
+function existingGameMatchesCreateRequest(input: {
+  game: {
+    gameId: string;
+    leagueId: string;
+    seasonId: string;
+    sessionId: string;
+    status: "scheduled" | "live" | "finished";
+    gameStartTs: string;
+    thirdLengthMinutes: ThirdLengthMinutes;
+  };
+  leagueId: string;
+  seasonId: string;
+  sessionId: string;
+  request: {
+    gameId: string;
+    gameStartTs: string;
+    status?: "scheduled" | "live" | "finished";
+    thirdLengthMinutes?: ThirdLengthMinutes;
+  };
+}): boolean {
+  return (
+    input.game.gameId === input.request.gameId &&
+    input.game.leagueId === input.leagueId &&
+    input.game.seasonId === input.seasonId &&
+    input.game.sessionId === input.sessionId &&
+    input.game.status === (input.request.status ?? "scheduled") &&
+    input.game.gameStartTs === input.request.gameStartTs &&
+    input.game.thirdLengthMinutes ===
+      (input.request.thirdLengthMinutes ?? DEFAULT_THIRD_LENGTH_MINUTES)
+  );
 }
 
 function parseThirdRouteParam(value: string): ThirdNumber | null {
@@ -1673,54 +1718,103 @@ async function handleCreateSession(
   });
 }
 
-async function handleCreateGame(
-  request: IncomingMessage,
-  response: ServerResponse,
-  scope: { leagueId: string; seasonId: string; sessionId: string },
-  sessionEmail: string,
-  method: string,
-  route: string,
-): Promise<number> {
+async function createGameWithDerivedRecords(input: {
+  repositoryClient: LocalCreateGameRouteRepository;
+  scope: { leagueId: string; seasonId: string; sessionId: string };
+  request: {
+    gameId: string;
+    gameStartTs: string;
+    status?: "scheduled" | "live" | "finished";
+    thirdLengthMinutes?: ThirdLengthMinutes;
+  };
+}) {
+  let game;
+  try {
+    game = await input.repositoryClient.createGame({
+      gameId: input.request.gameId,
+      leagueId: input.scope.leagueId,
+      seasonId: input.scope.seasonId,
+      sessionId: input.scope.sessionId,
+      status: input.request.status,
+      gameStartTs: input.request.gameStartTs,
+      thirdLengthMinutes: input.request.thirdLengthMinutes,
+    });
+  } catch (error) {
+    if (!(error instanceof GameAlreadyExistsError)) {
+      throw error;
+    }
+
+    const existingGame = await input.repositoryClient.getGame(input.request.gameId);
+    if (
+      !existingGame ||
+      !existingGameMatchesCreateRequest({
+        game: existingGame,
+        leagueId: input.scope.leagueId,
+        seasonId: input.scope.seasonId,
+        sessionId: input.scope.sessionId,
+        request: input.request,
+      })
+    ) {
+      throw error;
+    }
+
+    game = existingGame;
+  }
+
+  await input.repositoryClient.createSessionGame({
+    sessionId: game.sessionId,
+    gameId: game.gameId,
+    gameStartTs: game.gameStartTs,
+    leagueId: game.leagueId,
+    seasonId: game.seasonId,
+  });
+  await ensureGameTeamsForGame(game, input.repositoryClient);
+
+  return game;
+}
+
+export async function handleLocalCreateGameRoute(input: {
+  request: IncomingMessage;
+  response: ServerResponse;
+  scope: { leagueId: string; seasonId: string; sessionId: string };
+  sessionEmail: string;
+  method: string;
+  route: string;
+  repositoryClient?: LocalCreateGameRouteRepository;
+}): Promise<number> {
+  const repositoryClient = input.repositoryClient ?? repository;
   let rawBody: Record<string, unknown>;
 
   try {
-    rawBody = await parseJsonBody(request);
+    rawBody = await parseJsonBody(input.request);
   } catch {
-    return badRequest(request, response, "Request body must be valid JSON.");
+    return badRequest(input.request, input.response, "Request body must be valid JSON.");
   }
 
   const parsedBody = createGameRequestSchema.safeParse(rawBody);
   if (!parsedBody.success) {
-    return badRequest(request, response, formatSchemaValidationError(parsedBody.error));
+    return badRequest(
+      input.request,
+      input.response,
+      formatSchemaValidationError(parsedBody.error),
+    );
   }
 
   try {
     return await executeIdempotentMutation({
-      request,
-      response,
-      sessionEmail,
-      method,
-      route,
+      request: input.request,
+      response: input.response,
+      sessionEmail: input.sessionEmail,
+      method: input.method,
+      route: input.route,
       requestPayload: parsedBody.data,
+      repositoryClient,
       execute: async () => {
-        const game = await repository.createGame({
-          gameId: parsedBody.data.gameId,
-          leagueId: scope.leagueId,
-          seasonId: scope.seasonId,
-          sessionId: scope.sessionId,
-          status: parsedBody.data.status,
-          gameStartTs: parsedBody.data.gameStartTs,
-          thirdLengthMinutes: parsedBody.data.thirdLengthMinutes,
+        const game = await createGameWithDerivedRecords({
+          repositoryClient,
+          scope: input.scope,
+          request: parsedBody.data,
         });
-
-        await repository.createSessionGame({
-          sessionId: scope.sessionId,
-          gameId: game.gameId,
-          gameStartTs: game.gameStartTs,
-          leagueId: game.leagueId,
-          seasonId: game.seasonId,
-        });
-        await ensureGameTeamsForGame(game);
 
         return {
           statusCode: 201,
@@ -1731,37 +1825,57 @@ async function handleCreateGame(
   } catch (error) {
     if (error instanceof GameAlreadyExistsError) {
       const replayStatus = await replayStoredIdempotencyMutation({
-        request,
-        response,
-        sessionEmail,
-        method,
-        route,
+        request: input.request,
+        response: input.response,
+        sessionEmail: input.sessionEmail,
+        method: input.method,
+        route: input.route,
         requestPayload: parsedBody.data,
+        repositoryClient,
       });
       if (replayStatus !== null) {
         return replayStatus;
       }
 
-      return gameAlreadyExistsConflict(request, response, parsedBody.data.gameId);
+      return gameAlreadyExistsConflict(input.request, input.response, parsedBody.data.gameId);
     }
     if (error instanceof GameJoinCodeCollisionError) {
       const replayStatus = await replayStoredIdempotencyMutation({
-        request,
-        response,
-        sessionEmail,
-        method,
-        route,
+        request: input.request,
+        response: input.response,
+        sessionEmail: input.sessionEmail,
+        method: input.method,
+        route: input.route,
         requestPayload: parsedBody.data,
+        repositoryClient,
       });
       if (replayStatus !== null) {
         return replayStatus;
       }
 
-      return gameJoinCodeCollisionConflict(request, response);
+      return gameJoinCodeCollisionConflict(input.request, input.response);
     }
 
     throw error;
   }
+}
+
+async function handleCreateGame(
+  request: IncomingMessage,
+  response: ServerResponse,
+  scope: { leagueId: string; seasonId: string; sessionId: string },
+  sessionEmail: string,
+  method: string,
+  route: string,
+): Promise<number> {
+  return handleLocalCreateGameRoute({
+    request,
+    response,
+    scope,
+    sessionEmail,
+    method,
+    route,
+  });
 }
 
 async function handleCreateDevItem(

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -65,6 +65,8 @@ import {
   upsertTeamRequestSchema,
 } from "./contracts/core-write.js";
 import {
+  GameAlreadyExistsError,
+  GameJoinCodeCollisionError,
   GameJoinRegistrationError,
   GameMutationStateError,
   GameTimerTransitionError,
@@ -537,6 +539,28 @@ function joinStateChangedConflict(request: IncomingMessage, response: ServerResp
     error: "conflict",
     code: "join_state_changed",
     message: "Game join state changed while registering this player. Reload and try again.",
+  });
+  return 409;
+}
+
+function gameAlreadyExistsConflict(
+  request: IncomingMessage,
+  response: ServerResponse,
+  gameId: string,
+): number {
+  sendJsonWithCors(request, response, 409, {
+    error: "conflict",
+    code: "game_exists",
+    message: `Game ${gameId} already exists.`,
+  });
+  return 409;
+}
+
+function gameJoinCodeCollisionConflict(request: IncomingMessage, response: ServerResponse): number {
+  sendJsonWithCors(request, response, 409, {
+    error: "conflict",
+    code: "join_code_collision",
+    message: "Join code is already assigned to another game.",
   });
   return 409;
 }
@@ -1598,39 +1622,50 @@ async function handleCreateGame(
     return badRequest(request, response, formatSchemaValidationError(parsedBody.error));
   }
 
-  return executeIdempotentMutation({
-    request,
-    response,
-    sessionEmail,
-    method,
-    route,
-    requestPayload: parsedBody.data,
-    execute: async () => {
-      const game = await repository.createGame({
-        gameId: parsedBody.data.gameId,
-        leagueId: scope.leagueId,
-        seasonId: scope.seasonId,
-        sessionId: scope.sessionId,
-        status: parsedBody.data.status,
-        gameStartTs: parsedBody.data.gameStartTs,
-        thirdLengthMinutes: parsedBody.data.thirdLengthMinutes,
-      });
+  try {
+    return await executeIdempotentMutation({
+      request,
+      response,
+      sessionEmail,
+      method,
+      route,
+      requestPayload: parsedBody.data,
+      execute: async () => {
+        const game = await repository.createGame({
+          gameId: parsedBody.data.gameId,
+          leagueId: scope.leagueId,
+          seasonId: scope.seasonId,
+          sessionId: scope.sessionId,
+          status: parsedBody.data.status,
+          gameStartTs: parsedBody.data.gameStartTs,
+          thirdLengthMinutes: parsedBody.data.thirdLengthMinutes,
+        });
 
-      await repository.createSessionGame({
-        sessionId: scope.sessionId,
-        gameId: game.gameId,
-        gameStartTs: game.gameStartTs,
-        leagueId: game.leagueId,
-        seasonId: game.seasonId,
-      });
-      await ensureGameTeamsForGame(game);
+        await repository.createSessionGame({
+          sessionId: scope.sessionId,
+          gameId: game.gameId,
+          gameStartTs: game.gameStartTs,
+          leagueId: game.leagueId,
+          seasonId: game.seasonId,
+        });
+        await ensureGameTeamsForGame(game);
 
-      return {
-        statusCode: 201,
-        payload: buildGameResponse(game),
-      };
-    },
-  });
+        return {
+          statusCode: 201,
+          payload: buildGameResponse(game),
+        };
+      },
+    });
+  } catch (error) {
+    if (error instanceof GameAlreadyExistsError) {
+      return gameAlreadyExistsConflict(request, response, parsedBody.data.gameId);
+    }
+    if (error instanceof GameJoinCodeCollisionError) {
+      return gameJoinCodeCollisionConflict(request, response);
+    }
+
+    throw error;
+  }
 }
 
 async function handleCreateDevItem(
@@ -2011,7 +2046,13 @@ async function start(): Promise<void> {
 
       const joinGameMatch = route.match(/^\/v1\/join\/([^/]+)$/);
       if (method === "POST" && joinGameMatch) {
-        const joinCode = decodeURIComponent(joinGameMatch[1]).trim();
+        let joinCode: string;
+        try {
+          joinCode = decodeURIComponent(joinGameMatch[1]).trim();
+        } catch {
+          status = badRequest(request, response, "Join code must be URL encoded correctly.");
+          return;
+        }
         if (joinCode.length === 0) {
           status = joinCodeRequired(request, response);
           return;

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -604,12 +604,13 @@ function joinStateChangedConflict(request: IncomingMessage, response: ServerResp
   return 409;
 }
 
-function hasJoinStateChangedCode(payload: unknown): boolean {
+function hasNonPersistedPublicJoinConflictCode(payload: unknown): boolean {
+  const code = typeof payload === "object" && payload !== null && "code" in payload
+    ? (payload as { code?: unknown }).code
+    : null;
   return (
-    typeof payload === "object" &&
-    payload !== null &&
-    "code" in payload &&
-    (payload as { code?: unknown }).code === "join_state_changed"
+    code === "join_state_changed" ||
+    code === "game_finished"
   );
 }
 
@@ -618,7 +619,7 @@ function shouldPersistPublicJoinMutation(mutation: JsonMutationResult): boolean 
     return false;
   }
 
-  if (mutation.statusCode === 409 && hasJoinStateChangedCode(mutation.payload)) {
+  if (mutation.statusCode === 409 && hasNonPersistedPublicJoinConflictCode(mutation.payload)) {
     return false;
   }
 
@@ -815,10 +816,6 @@ async function waitForLocalFinishedRepairCompletion(input: {
   }
 
   return latest;
-}
-
-async function waitForIdempotencyRecord(): Promise<void> {
-  await new Promise((resolve) => setTimeout(resolve, 25));
 }
 
 async function readGameTeams(game: {

--- a/api/src/tests/acl.test.ts
+++ b/api/src/tests/acl.test.ts
@@ -36,8 +36,9 @@ class InMemoryAclLookup implements AclLookup {
   }
 }
 
-function defaultGameStateFields(): Pick<GameRecord, "thirdLengthMinutes" | "thirds" | "finishedAt" | "result"> {
+function defaultGameStateFields(): Pick<GameRecord, "joinCode" | "thirdLengthMinutes" | "thirds" | "finishedAt" | "result"> {
   return {
+    joinCode: "JOIN1234",
     thirdLengthMinutes: DEFAULT_THIRD_LENGTH_MINUTES,
     thirds: createDefaultThirdTimerSegments(),
     finishedAt: null,

--- a/api/src/tests/lambda-core.test.ts
+++ b/api/src/tests/lambda-core.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import test from "node:test";
 
 import {
@@ -230,6 +231,12 @@ interface HarnessConfig {
   rateLimitDecision?:
     | RateLimitDecision
     | ((input: { email: string; clientIp: string }) => RateLimitDecision);
+  beforeIdempotencyRecordRead?: (input: {
+    scope: string;
+    key: string;
+    readCount: number;
+    records: Map<string, StoredIdempotencyRecord>;
+  }) => void;
 }
 
 function createEvent(input: {
@@ -254,6 +261,29 @@ function createEvent(input: {
       },
     },
   };
+}
+
+function normalizePayloadForTestHash(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(normalizePayloadForTestHash);
+  }
+
+  if (value && typeof value === "object") {
+    const source = value as Record<string, unknown>;
+    return Object.fromEntries(
+      Object.keys(source)
+        .sort()
+        .map((key) => [key, normalizePayloadForTestHash(source[key])] as const),
+    );
+  }
+
+  return value;
+}
+
+function buildTestIdempotencyRequestHash(scope: string, payload: unknown): string {
+  return createHash("sha256")
+    .update(`${scope}:${JSON.stringify(normalizePayloadForTestHash(payload))}`)
+    .digest("hex");
 }
 
 function completedThirdTimerSegments(): ThirdTimerSegment[] {
@@ -322,6 +352,7 @@ function createHarness(config: HarnessConfig = {}) {
   let createAndLinkGamePlayerStateChangedOnce = config.createAndLinkGamePlayerStateChangedOnce ?? false;
   let assignRosterPlayerStateChangedOnce = config.assignRosterPlayerStateChangedOnce ?? false;
   let finishBeforeGoalCorrectionOnce = config.finishBeforeGoalCorrectionOnce ?? false;
+  const idempotencyRecordReads = new Map<string, number>();
   const leagues = new Map<string, MockLeagueRecord>(Object.entries(config.leagues ?? {}));
   const seasons = new Map<string, MockSeasonRecord>(Object.entries(config.seasons ?? {}));
   const sessionEntities = new Map<string, MockSessionEntity>(
@@ -1537,7 +1568,16 @@ function createHarness(config: HarnessConfig = {}) {
         return sessionEntities.get(sessionId) ?? null;
       },
       async getIdempotencyRecord(scope: string, key: string) {
-        return idempotencyRecords.get(`${scope}:${key}`) ?? null;
+        const recordKey = `${scope}:${key}`;
+        const readCount = (idempotencyRecordReads.get(recordKey) ?? 0) + 1;
+        idempotencyRecordReads.set(recordKey, readCount);
+        config.beforeIdempotencyRecordRead?.({
+          scope,
+          key,
+          readCount,
+          records: idempotencyRecords,
+        });
+        return idempotencyRecords.get(recordKey) ?? null;
       },
       async createIdempotencyRecord(input) {
         const recordKey = `${input.scope}:${input.key}`;
@@ -2065,6 +2105,26 @@ test("core lambda returns stable errors for invalid and missing join codes", asy
     message: "Join code is required.",
   });
 
+  const invalidFormatResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/join/too-long-code",
+      headers: {
+        Origin: "https://qa.3fc.football",
+      },
+      body: {
+        nickname: "Nia",
+      },
+    }),
+  );
+
+  assert.equal(invalidFormatResponse.statusCode, 400);
+  assert.deepEqual(JSON.parse(invalidFormatResponse.body), {
+    error: "bad_request",
+    code: "join_code_invalid",
+    message: "Join code must be 8 letters or digits.",
+  });
+
   const malformedResponse = await harness.handler(
     createEvent({
       method: "POST",
@@ -2533,6 +2593,100 @@ test("core lambda maps duplicate game IDs to conflict on game creation", async (
     code: "game_exists",
     message: "Game game-1 already exists.",
   });
+  assert.equal(harness.createdGames.length, 0);
+  assert.equal(harness.createdSessionGames.length, 0);
+});
+
+test("core lambda replays idempotent create game response after a duplicate race", async () => {
+  const scope = "admin@example.com:POST:/v1/sessions/session-abc/games";
+  const key = "create-game-race-1";
+  const requestPayload = {
+    gameId: "game-1",
+    gameStartTs: "2026-02-23T11:00:00Z",
+  };
+  const harness = createHarness({
+    sessions: {
+      "session-1": {
+        sessionId: "session-1",
+        email: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    seasonSessions: {
+      "session-abc": {
+        seasonId: "season-1",
+        sessionId: "session-abc",
+        sessionDate: "2026-02-23",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    seasons: {
+      "season-1": {
+        leagueId: "league-1",
+        seasonId: "season-1",
+        name: "Season 1",
+        slug: null,
+        startsOn: null,
+        endsOn: null,
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    games: {
+      "game-1": {
+        gameId: "game-1",
+        leagueId: "league-1",
+        seasonId: "season-1",
+        sessionId: "session-abc",
+        status: "scheduled",
+        gameStartTs: "2026-02-23T10:00:00.000Z",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueAccess: {
+      "league-1:admin@example.com": {
+        leagueId: "league-1",
+        userId: "admin@example.com",
+        role: "admin",
+        grantedByUserId: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    beforeIdempotencyRecordRead: ({ readCount, records }) => {
+      if (readCount !== 2) {
+        return;
+      }
+
+      records.set(`${scope}:${key}`, {
+        scope,
+        key,
+        requestHash: buildTestIdempotencyRequestHash(scope, requestPayload),
+        responseStatusCode: 201,
+        responseBody: JSON.stringify({ replayed: true }),
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      });
+    },
+  });
+
+  const response = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/sessions/session-abc/games",
+      headers: {
+        Cookie: "threefc_session=session-1",
+        "Idempotency-Key": key,
+      },
+      body: requestPayload,
+    }),
+  );
+
+  assert.equal(response.statusCode, 201);
+  assert.deepEqual(JSON.parse(response.body), { replayed: true });
   assert.equal(harness.createdGames.length, 0);
   assert.equal(harness.createdSessionGames.length, 0);
 });

--- a/api/src/tests/lambda-core.test.ts
+++ b/api/src/tests/lambda-core.test.ts
@@ -2437,6 +2437,52 @@ test("core lambda retries retryable public join conflicts without persisting the
   assert.equal(harness.idempotencyRecords.size, 1);
 });
 
+test("core lambda does not persist closed-game public join conflicts", async () => {
+  const harness = createHarness({
+    games: {
+      "game-1": {
+        gameId: "game-1",
+        joinCode: "JNABCD23",
+        leagueId: "league-1",
+        seasonId: "season-1",
+        sessionId: "session-1",
+        status: "finished",
+        gameStartTs: "2026-02-23T10:00:00.000Z",
+        finishedAt: "2026-02-23T00:00:05.000Z",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:05.000Z",
+      },
+    },
+  });
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const response = await harness.handler(
+      createEvent({
+        method: "POST",
+        path: "/v1/join/JNABCD23",
+        headers: {
+          Origin: "https://qa.3fc.football",
+          "Idempotency-Key": "public-join-finished-1",
+        },
+        body: {
+          nickname: "Nia",
+        },
+      }),
+    );
+
+    assert.equal(response.statusCode, 409);
+    assert.deepEqual(JSON.parse(response.body), {
+      error: "conflict",
+      code: "game_finished",
+      message: "Game game-1 is finished. Join registration is closed.",
+    });
+  }
+
+  assert.equal(harness.createdPlayers.length, 0);
+  assert.equal(harness.linkedGamePlayers.length, 0);
+  assert.equal(harness.idempotencyRecords.size, 0);
+});
+
 test("core lambda rejects oversized public join nicknames before persistence", async () => {
   const harness = createHarness({
     games: {

--- a/api/src/tests/lambda-core.test.ts
+++ b/api/src/tests/lambda-core.test.ts
@@ -2130,6 +2130,80 @@ test("core lambda repairs legacy join codes only after game access is authorized
   ]);
 });
 
+test("core lambda repairs legacy join codes in authorized season game listings", async () => {
+  const harness = createHarness({
+    sessions: {
+      "session-1": {
+        sessionId: "session-1",
+        email: "viewer@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    seasons: {
+      "season-1": {
+        leagueId: "league-1",
+        seasonId: "season-1",
+        name: "Season 1",
+        slug: null,
+        startsOn: null,
+        endsOn: null,
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    games: {
+      "game-legacy": {
+        gameId: "game-legacy",
+        joinCode: buildJoinCodeForGameId("game-legacy"),
+        leagueId: "league-1",
+        seasonId: "season-1",
+        sessionId: "session-1",
+        status: "scheduled",
+        gameStartTs: "2026-02-23T10:00:00.000Z",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    legacyJoinCodeRepairs: {
+      "game-legacy": "RNDM2345",
+    },
+    leagueAccess: {
+      "league-1:viewer@example.com": {
+        leagueId: "league-1",
+        userId: "viewer@example.com",
+        role: "viewer",
+        grantedByUserId: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  const response = await harness.handler(
+    createEvent({
+      method: "GET",
+      path: "/v1/seasons/season-1/games",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+    }),
+  );
+
+  assert.equal(response.statusCode, 200);
+  const body = JSON.parse(response.body) as { games: Array<{ gameId: string; joinCode: string }> };
+  assert.deepEqual(body.games.map((game) => ({ gameId: game.gameId, joinCode: game.joinCode })), [
+    { gameId: "game-legacy", joinCode: "RNDM2345" },
+  ]);
+  assert.deepEqual(harness.getGameCalls, [
+    {
+      gameId: "game-legacy",
+      consistentRead: true,
+      repairLegacyJoinCode: true,
+    },
+  ]);
+});
+
 test("core lambda lets players join an active game by join code and appear in the player pool", async () => {
   const harness = createHarness({
     sessions: {

--- a/api/src/tests/lambda-core.test.ts
+++ b/api/src/tests/lambda-core.test.ts
@@ -229,6 +229,7 @@ interface HarnessConfig {
   createGameTeamOverrideStateChangedOnce?: boolean;
   createGameTeamOverrideFinishesIncompleteOnce?: boolean;
   completeFinishedRepairAfterConsistentReads?: number;
+  joinGameByCodeStateChangedOnce?: boolean;
   createAndLinkGamePlayerStateChangedOnce?: boolean;
   assignRosterPlayerStateChangedOnce?: boolean;
   finishBeforeGoalCorrectionOnce?: boolean;
@@ -358,6 +359,7 @@ function createHarness(config: HarnessConfig = {}) {
   let createGameTeamOverrideFinishesIncompleteOnce =
     config.createGameTeamOverrideFinishesIncompleteOnce ?? false;
   let completeFinishedRepairAfterConsistentReads = config.completeFinishedRepairAfterConsistentReads ?? 0;
+  let joinGameByCodeStateChangedOnce = config.joinGameByCodeStateChangedOnce ?? false;
   let createAndLinkGamePlayerStateChangedOnce = config.createAndLinkGamePlayerStateChangedOnce ?? false;
   let assignRosterPlayerStateChangedOnce = config.assignRosterPlayerStateChangedOnce ?? false;
   let finishBeforeGoalCorrectionOnce = config.finishBeforeGoalCorrectionOnce ?? false;
@@ -974,6 +976,15 @@ function createHarness(config: HarnessConfig = {}) {
             "game_finished",
             409,
             `Game ${game.gameId} is finished. Join registration is closed.`,
+          );
+        }
+
+        if (joinGameByCodeStateChangedOnce) {
+          joinGameByCodeStateChangedOnce = false;
+          throw new GameJoinRegistrationError(
+            "join_state_changed",
+            409,
+            "Game join state changed while registering this player. Reload and try again.",
           );
         }
 
@@ -2364,6 +2375,66 @@ test("core lambda replays public join retries by idempotency key", async () => {
   });
   assert.equal(harness.createdPlayers.length, 1);
   assert.equal(harness.linkedGamePlayers.length, 1);
+});
+
+test("core lambda retries retryable public join conflicts without persisting them", async () => {
+  const harness = createHarness({
+    joinGameByCodeStateChangedOnce: true,
+    games: {
+      "game-1": {
+        gameId: "game-1",
+        joinCode: "JNABCD23",
+        leagueId: "league-1",
+        seasonId: "season-1",
+        sessionId: "session-1",
+        status: "live",
+        gameStartTs: "2026-02-23T10:00:00.000Z",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  const conflictResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/join/JNABCD23",
+      headers: {
+        Origin: "https://qa.3fc.football",
+        "Idempotency-Key": "public-join-retry-1",
+      },
+      body: {
+        nickname: "Nia",
+      },
+    }),
+  );
+
+  assert.equal(conflictResponse.statusCode, 409);
+  assert.deepEqual(JSON.parse(conflictResponse.body), {
+    error: "conflict",
+    code: "join_state_changed",
+    message: "Game join state changed while registering this player. Reload and try again.",
+  });
+  assert.equal(harness.idempotencyRecords.size, 0);
+
+  const retryResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/join/JNABCD23",
+      headers: {
+        Origin: "https://qa.3fc.football",
+        "Idempotency-Key": "public-join-retry-1",
+      },
+      body: {
+        nickname: "Nia",
+      },
+    }),
+  );
+
+  assert.equal(retryResponse.statusCode, 201);
+  assert.equal(harness.createdPlayers.length, 1);
+  assert.equal(harness.linkedGamePlayers.length, 1);
+  assert.equal(harness.idempotencyRecords.size, 1);
 });
 
 test("core lambda rejects oversized public join nicknames before persistence", async () => {

--- a/api/src/tests/lambda-core.test.ts
+++ b/api/src/tests/lambda-core.test.ts
@@ -2426,6 +2426,29 @@ test("core lambda returns stable errors for invalid and missing join codes", asy
     code: "invalid_join_code",
     message: "Join code was not found.",
   });
+  assert.equal(harness.idempotencyRecords.size, 0);
+
+  const invalidResponseWithIdempotencyKey = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/join/ABCDEFGH",
+      headers: {
+        Origin: "https://qa.3fc.football",
+        "Idempotency-Key": "unknown-public-join-1",
+      },
+      body: {
+        nickname: "Nia",
+      },
+    }),
+  );
+
+  assert.equal(invalidResponseWithIdempotencyKey.statusCode, 404);
+  assert.deepEqual(JSON.parse(invalidResponseWithIdempotencyKey.body), {
+    error: "not_found",
+    code: "invalid_join_code",
+    message: "Join code was not found.",
+  });
+  assert.equal(harness.idempotencyRecords.size, 0);
 
   const missingResponse = await harness.handler(
     createEvent({

--- a/api/src/tests/lambda-core.test.ts
+++ b/api/src/tests/lambda-core.test.ts
@@ -7,6 +7,7 @@ import {
   type ApiGatewayHttpEvent,
 } from "../lambda-core.js";
 import type { RateLimitDecision } from "../auth/rate-limit.js";
+import { PUBLIC_JOIN_NICKNAME_MAX_LENGTH } from "../contracts/core-write.js";
 import {
   createDefaultThirdTimerSegments,
   DEFAULT_THIRD_LENGTH_MINUTES,
@@ -2068,6 +2069,44 @@ test("core lambda lets players join an active game by join code and appear in th
   assert.deepEqual(JSON.parse(playerPoolResponse.body), {
     players: [joinBody.player],
   });
+});
+
+test("core lambda rejects oversized public join nicknames before persistence", async () => {
+  const harness = createHarness({
+    games: {
+      "game-1": {
+        gameId: "game-1",
+        joinCode: "JNABCD23",
+        leagueId: "league-1",
+        seasonId: "season-1",
+        sessionId: "session-1",
+        status: "live",
+        gameStartTs: "2026-02-23T10:00:00.000Z",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  const response = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/join/JNABCD23",
+      headers: {
+        Origin: "https://qa.3fc.football",
+      },
+      body: {
+        nickname: "N".repeat(PUBLIC_JOIN_NICKNAME_MAX_LENGTH + 1),
+      },
+    }),
+  );
+
+  assert.equal(response.statusCode, 400);
+  assert.deepEqual(JSON.parse(response.body), {
+    error: `Field \`nickname\` must be ${PUBLIC_JOIN_NICKNAME_MAX_LENGTH} characters or fewer.`,
+  });
+  assert.equal(harness.createdPlayers.length, 0);
+  assert.equal(harness.linkedGamePlayers.length, 0);
 });
 
 test("core lambda returns stable errors for invalid and missing join codes", async () => {

--- a/api/src/tests/lambda-core.test.ts
+++ b/api/src/tests/lambda-core.test.ts
@@ -1628,6 +1628,7 @@ function createHarness(config: HarnessConfig = {}) {
     listTeamsForGameCalls,
     idempotencyRecords,
     goalAuditEntries,
+    games,
   };
 }
 
@@ -2588,16 +2589,34 @@ test("core lambda recovers idempotent create game retry after the game write com
   assert.equal(failedResponse.statusCode, 500);
   assert.equal(harness.createdGames.length, 1);
   assert.equal(harness.createdSessionGames.length, 0);
+  const existingGame = harness.games.get("game-1");
+  assert.ok(existingGame);
+  harness.games.set("game-1", {
+    ...existingGame,
+    status: "live",
+    gameStartTs: "2026-02-23T11:00:00Z",
+    thirdLengthMinutes: 25,
+    updatedAt: "2026-02-23T00:01:00.000Z",
+  });
 
   const retryResponse = await harness.handler(event);
   assert.equal(retryResponse.statusCode, 201);
   assert.equal(harness.createdGames.length, 1);
   assert.equal(harness.createdSessionGames.length, 1);
+  assert.equal(harness.createdSessionGames[0]?.gameStartTs, "2026-02-23T11:00:00Z");
   assert.deepEqual(
     harness.createdGameTeams.map((team) => team.teamId),
     ["red", "blue", "yellow"],
   );
   assert.equal(harness.idempotencyRecords.size, 1);
+  const retryBody = JSON.parse(retryResponse.body) as {
+    status: string;
+    gameStartTs: string;
+    thirdLengthMinutes: number;
+  };
+  assert.equal(retryBody.status, "live");
+  assert.equal(retryBody.gameStartTs, "2026-02-23T11:00:00Z");
+  assert.equal(retryBody.thirdLengthMinutes, 25);
 
   const replayResponse = await harness.handler(event);
   assert.equal(replayResponse.statusCode, 201);

--- a/api/src/tests/lambda-core.test.ts
+++ b/api/src/tests/lambda-core.test.ts
@@ -2285,6 +2285,87 @@ test("core lambda lets players join an active game by join code and appear in th
   });
 });
 
+test("core lambda replays public join retries by idempotency key", async () => {
+  const harness = createHarness({
+    games: {
+      "game-1": {
+        gameId: "game-1",
+        joinCode: "JNABCD23",
+        leagueId: "league-1",
+        seasonId: "season-1",
+        sessionId: "session-1",
+        status: "live",
+        gameStartTs: "2026-02-23T10:00:00.000Z",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  const response = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/join/jnabcd23",
+      headers: {
+        Origin: "https://qa.3fc.football",
+        "Idempotency-Key": "public-join-1",
+      },
+      body: {
+        nickname: "Nia",
+      },
+    }),
+  );
+  assert.equal(response.statusCode, 201);
+  const body = JSON.parse(response.body) as {
+    gameId: string;
+    player: { playerId: string; nickname: string };
+  };
+  assert.equal(body.gameId, "game-1");
+  assert.equal(body.player.nickname, "Nia");
+  assert.match(body.player.playerId, /^player-join-/);
+  assert.equal(harness.createdPlayers.length, 1);
+  assert.equal(harness.linkedGamePlayers.length, 1);
+
+  const replayResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/join/JNABCD23",
+      headers: {
+        Origin: "https://qa.3fc.football",
+        "Idempotency-Key": "public-join-1",
+      },
+      body: {
+        nickname: "Nia",
+      },
+    }),
+  );
+  assert.equal(replayResponse.statusCode, 201);
+  assert.deepEqual(JSON.parse(replayResponse.body), body);
+  assert.equal(harness.createdPlayers.length, 1);
+  assert.equal(harness.linkedGamePlayers.length, 1);
+
+  const conflictResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/join/JNABCD23",
+      headers: {
+        Origin: "https://qa.3fc.football",
+        "Idempotency-Key": "public-join-1",
+      },
+      body: {
+        nickname: "Mia",
+      },
+    }),
+  );
+  assert.equal(conflictResponse.statusCode, 409);
+  assert.deepEqual(JSON.parse(conflictResponse.body), {
+    error: "idempotency_conflict",
+    message: "Idempotency key has already been used with a different payload.",
+  });
+  assert.equal(harness.createdPlayers.length, 1);
+  assert.equal(harness.linkedGamePlayers.length, 1);
+});
+
 test("core lambda rejects oversized public join nicknames before persistence", async () => {
   const harness = createHarness({
     games: {
@@ -2869,6 +2950,28 @@ test("core lambda recovers idempotent create game retry after the game write com
   );
   assert.equal(unrelatedRetryResponse.statusCode, 409);
   assert.deepEqual(JSON.parse(unrelatedRetryResponse.body), {
+    error: "conflict",
+    code: "game_exists",
+    message: "Game game-1 already exists.",
+  });
+  assert.equal(harness.createdSessionGames.length, 0);
+
+  const differentKeyRetryResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/sessions/session-abc/games",
+      headers: {
+        Cookie: "threefc_session=session-1",
+        "Idempotency-Key": "create-game-recover-2",
+      },
+      body: {
+        gameId: "game-1",
+        gameStartTs: "2026-02-23T10:00:00Z",
+      },
+    }),
+  );
+  assert.equal(differentKeyRetryResponse.statusCode, 409);
+  assert.deepEqual(JSON.parse(differentKeyRetryResponse.body), {
     error: "conflict",
     code: "game_exists",
     message: "Game game-1 already exists.",

--- a/api/src/tests/lambda-core.test.ts
+++ b/api/src/tests/lambda-core.test.ts
@@ -18,6 +18,8 @@ import {
 } from "@3fc/contracts";
 import {
   buildJoinCodeForGameId,
+  GameAlreadyExistsError,
+  GameJoinCodeCollisionError,
   GameJoinRegistrationError,
   GameMutationStateError,
   GameTimerTransitionError,
@@ -821,10 +823,22 @@ function createHarness(config: HarnessConfig = {}) {
         return record;
       },
       async createGame(input) {
+        if (games.has(input.gameId)) {
+          throw new GameAlreadyExistsError(input.gameId);
+        }
+        const joinCode = input.joinCode ?? buildJoinCodeForGameId(input.gameId);
+        if (
+          [...games.values()].some(
+            (game) => game.joinCode.trim().toUpperCase() === joinCode.trim().toUpperCase(),
+          )
+        ) {
+          throw new GameJoinCodeCollisionError();
+        }
+
         createdGames.push(input);
         const record = {
           gameId: input.gameId,
-          joinCode: input.joinCode ?? buildJoinCodeForGameId(input.gameId),
+          joinCode,
           leagueId: input.leagueId,
           seasonId: input.seasonId,
           sessionId: input.sessionId,
@@ -2050,6 +2064,24 @@ test("core lambda returns stable errors for invalid and missing join codes", asy
     code: "join_code_required",
     message: "Join code is required.",
   });
+
+  const malformedResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/join/%E0%A4%A",
+      headers: {
+        Origin: "https://qa.3fc.football",
+      },
+      body: {
+        nickname: "Nia",
+      },
+    }),
+  );
+
+  assert.equal(malformedResponse.statusCode, 400);
+  assert.deepEqual(JSON.parse(malformedResponse.body), {
+    error: "Join code must be URL encoded correctly.",
+  });
   assert.equal(harness.createdPlayers.length, 0);
   assert.equal(harness.linkedGamePlayers.length, 0);
 });
@@ -2422,6 +2454,85 @@ test("core lambda rejects creating games directly as finished", async () => {
 
   assert.equal(response.statusCode, 400);
   assert.match((JSON.parse(response.body) as { error: string }).error, /status/);
+  assert.equal(harness.createdGames.length, 0);
+  assert.equal(harness.createdSessionGames.length, 0);
+});
+
+test("core lambda maps duplicate game IDs to conflict on game creation", async () => {
+  const harness = createHarness({
+    sessions: {
+      "session-1": {
+        sessionId: "session-1",
+        email: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    seasonSessions: {
+      "session-abc": {
+        seasonId: "season-1",
+        sessionId: "session-abc",
+        sessionDate: "2026-02-23",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    seasons: {
+      "season-1": {
+        leagueId: "league-1",
+        seasonId: "season-1",
+        name: "Season 1",
+        slug: null,
+        startsOn: null,
+        endsOn: null,
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    games: {
+      "game-1": {
+        gameId: "game-1",
+        leagueId: "league-1",
+        seasonId: "season-1",
+        sessionId: "session-abc",
+        status: "scheduled",
+        gameStartTs: "2026-02-23T10:00:00.000Z",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueAccess: {
+      "league-1:admin@example.com": {
+        leagueId: "league-1",
+        userId: "admin@example.com",
+        role: "admin",
+        grantedByUserId: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  const response = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/sessions/session-abc/games",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+      body: {
+        gameId: "game-1",
+        gameStartTs: "2026-02-23T11:00:00Z",
+      },
+    }),
+  );
+
+  assert.equal(response.statusCode, 409);
+  assert.deepEqual(JSON.parse(response.body), {
+    error: "conflict",
+    code: "game_exists",
+    message: "Game game-1 already exists.",
+  });
   assert.equal(harness.createdGames.length, 0);
   assert.equal(harness.createdSessionGames.length, 0);
 });

--- a/api/src/tests/lambda-core.test.ts
+++ b/api/src/tests/lambda-core.test.ts
@@ -216,6 +216,7 @@ interface HarnessConfig {
   seasons?: Record<string, MockSeasonRecord>;
   seasonSessions?: Record<string, MockSessionEntity>;
   games?: Record<string, MockGameInput>;
+  legacyJoinCodeRepairs?: Record<string, string>;
   seasonTeams?: Record<string, MockSeasonTeamRecord>;
   gameTeams?: Record<string, MockGameTeamInput>;
   players?: Record<string, MockPlayerRecord>;
@@ -340,7 +341,11 @@ function createHarness(config: HarnessConfig = {}) {
   const magicLinkStarts: string[] = [];
   const magicLinkCompletes: string[] = [];
   const magicLinkRateLimitChecks: Array<{ email: string; clientIp: string }> = [];
-  const getGameCalls: Array<{ gameId: string; consistentRead: boolean }> = [];
+  const getGameCalls: Array<{
+    gameId: string;
+    consistentRead: boolean;
+    repairLegacyJoinCode: boolean;
+  }> = [];
   const listTeamsForSeasonCalls: Array<{ seasonId: string; consistentRead: boolean }> = [];
   const listTeamsForGameCalls: Array<{ gameId: string; consistentRead: boolean }> = [];
   const idempotencyRecords = new Map<string, StoredIdempotencyRecord>();
@@ -904,8 +909,15 @@ function createHarness(config: HarnessConfig = {}) {
       async listGamesForSeason(seasonId: string) {
         return [...games.values()].filter((game) => game.seasonId === seasonId);
       },
-      async getGame(gameId: string, options: { consistentRead?: boolean } = {}) {
-        getGameCalls.push({ gameId, consistentRead: options.consistentRead ?? false });
+      async getGame(
+        gameId: string,
+        options: { consistentRead?: boolean; repairLegacyJoinCode?: boolean } = {},
+      ) {
+        getGameCalls.push({
+          gameId,
+          consistentRead: options.consistentRead ?? false,
+          repairLegacyJoinCode: options.repairLegacyJoinCode ?? false,
+        });
         const game = games.get(gameId) ?? null;
         if (
           game &&
@@ -925,6 +937,18 @@ function createHarness(config: HarnessConfig = {}) {
             });
           }
         }
+
+        const repairedJoinCode = config.legacyJoinCodeRepairs?.[gameId];
+        if (game && options.repairLegacyJoinCode && repairedJoinCode) {
+          const repairedGame = {
+            ...game,
+            joinCode: repairedJoinCode,
+            updatedAt: "2026-02-23T00:00:05.000Z",
+          };
+          games.set(gameId, repairedGame);
+          return repairedGame;
+        }
+
         return game;
       },
       async getGameByJoinCode(joinCode: string) {
@@ -1992,6 +2016,118 @@ test("core lambda completes magic-link auth and returns a session cookie", async
       expiresAt: "2026-02-24T00:00:00.000Z",
     },
   });
+});
+
+test("core lambda does not repair legacy join codes before game access is authorized", async () => {
+  const harness = createHarness({
+    sessions: {
+      "session-1": {
+        sessionId: "session-1",
+        email: "outsider@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    games: {
+      "game-legacy": {
+        gameId: "game-legacy",
+        joinCode: buildJoinCodeForGameId("game-legacy"),
+        leagueId: "league-1",
+        seasonId: "season-1",
+        sessionId: "session-1",
+        status: "scheduled",
+        gameStartTs: "2026-02-23T10:00:00.000Z",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    legacyJoinCodeRepairs: {
+      "game-legacy": "RNDM2345",
+    },
+  });
+
+  const response = await harness.handler(
+    createEvent({
+      method: "GET",
+      path: "/v1/games/game-legacy",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+    }),
+  );
+
+  assert.equal(response.statusCode, 403);
+  assert.deepEqual(harness.getGameCalls, [
+    {
+      gameId: "game-legacy",
+      consistentRead: false,
+      repairLegacyJoinCode: false,
+    },
+  ]);
+});
+
+test("core lambda repairs legacy join codes only after game access is authorized", async () => {
+  const harness = createHarness({
+    sessions: {
+      "session-1": {
+        sessionId: "session-1",
+        email: "viewer@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    games: {
+      "game-legacy": {
+        gameId: "game-legacy",
+        joinCode: buildJoinCodeForGameId("game-legacy"),
+        leagueId: "league-1",
+        seasonId: "season-1",
+        sessionId: "session-1",
+        status: "scheduled",
+        gameStartTs: "2026-02-23T10:00:00.000Z",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    legacyJoinCodeRepairs: {
+      "game-legacy": "RNDM2345",
+    },
+    leagueAccess: {
+      "league-1:viewer@example.com": {
+        leagueId: "league-1",
+        userId: "viewer@example.com",
+        role: "viewer",
+        grantedByUserId: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  const response = await harness.handler(
+    createEvent({
+      method: "GET",
+      path: "/v1/games/game-legacy",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+    }),
+  );
+
+  assert.equal(response.statusCode, 200);
+  assert.equal((JSON.parse(response.body) as { joinCode: string }).joinCode, "RNDM2345");
+  assert.deepEqual(harness.getGameCalls, [
+    {
+      gameId: "game-legacy",
+      consistentRead: false,
+      repairLegacyJoinCode: false,
+    },
+    {
+      gameId: "game-legacy",
+      consistentRead: true,
+      repairLegacyJoinCode: true,
+    },
+  ]);
 });
 
 test("core lambda lets players join an active game by join code and appear in the player pool", async () => {

--- a/api/src/tests/lambda-core.test.ts
+++ b/api/src/tests/lambda-core.test.ts
@@ -228,6 +228,7 @@ interface HarnessConfig {
   createAndLinkGamePlayerStateChangedOnce?: boolean;
   assignRosterPlayerStateChangedOnce?: boolean;
   finishBeforeGoalCorrectionOnce?: boolean;
+  createSessionGameFailures?: number;
   rateLimitDecision?:
     | RateLimitDecision
     | ((input: { email: string; clientIp: string }) => RateLimitDecision);
@@ -352,6 +353,7 @@ function createHarness(config: HarnessConfig = {}) {
   let createAndLinkGamePlayerStateChangedOnce = config.createAndLinkGamePlayerStateChangedOnce ?? false;
   let assignRosterPlayerStateChangedOnce = config.assignRosterPlayerStateChangedOnce ?? false;
   let finishBeforeGoalCorrectionOnce = config.finishBeforeGoalCorrectionOnce ?? false;
+  let createSessionGameFailures = config.createSessionGameFailures ?? 0;
   const idempotencyRecordReads = new Map<string, number>();
   const leagues = new Map<string, MockLeagueRecord>(Object.entries(config.leagues ?? {}));
   const seasons = new Map<string, MockSeasonRecord>(Object.entries(config.seasons ?? {}));
@@ -886,6 +888,11 @@ function createHarness(config: HarnessConfig = {}) {
         return record;
       },
       async createSessionGame(input) {
+        if (createSessionGameFailures > 0) {
+          createSessionGameFailures -= 1;
+          throw new Error("Session game index write failed.");
+        }
+
         createdSessionGames.push(input);
         return input;
       },
@@ -2518,6 +2525,83 @@ test("core lambda rejects creating games directly as finished", async () => {
   assert.match((JSON.parse(response.body) as { error: string }).error, /status/);
   assert.equal(harness.createdGames.length, 0);
   assert.equal(harness.createdSessionGames.length, 0);
+});
+
+test("core lambda recovers idempotent create game retry after the game write commits", async () => {
+  const harness = createHarness({
+    createSessionGameFailures: 1,
+    sessions: {
+      "session-1": {
+        sessionId: "session-1",
+        email: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    seasonSessions: {
+      "session-abc": {
+        seasonId: "season-1",
+        sessionId: "session-abc",
+        sessionDate: "2026-02-23",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    seasons: {
+      "season-1": {
+        leagueId: "league-1",
+        seasonId: "season-1",
+        name: "Season 1",
+        slug: null,
+        startsOn: null,
+        endsOn: null,
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueAccess: {
+      "league-1:admin@example.com": {
+        leagueId: "league-1",
+        userId: "admin@example.com",
+        role: "admin",
+        grantedByUserId: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  const event = createEvent({
+    method: "POST",
+    path: "/v1/sessions/session-abc/games",
+    headers: {
+      Cookie: "threefc_session=session-1",
+      "Idempotency-Key": "create-game-recover-1",
+    },
+    body: {
+      gameId: "game-1",
+      gameStartTs: "2026-02-23T10:00:00Z",
+    },
+  });
+
+  const failedResponse = await harness.handler(event);
+  assert.equal(failedResponse.statusCode, 500);
+  assert.equal(harness.createdGames.length, 1);
+  assert.equal(harness.createdSessionGames.length, 0);
+
+  const retryResponse = await harness.handler(event);
+  assert.equal(retryResponse.statusCode, 201);
+  assert.equal(harness.createdGames.length, 1);
+  assert.equal(harness.createdSessionGames.length, 1);
+  assert.deepEqual(
+    harness.createdGameTeams.map((team) => team.teamId),
+    ["red", "blue", "yellow"],
+  );
+  assert.equal(harness.idempotencyRecords.size, 1);
+
+  const replayResponse = await harness.handler(event);
+  assert.equal(replayResponse.statusCode, 201);
+  assert.equal(harness.createdSessionGames.length, 1);
 });
 
 test("core lambda maps duplicate game IDs to conflict on game creation", async () => {

--- a/api/src/tests/lambda-core.test.ts
+++ b/api/src/tests/lambda-core.test.ts
@@ -1994,7 +1994,7 @@ test("core lambda lets players join an active game by join code and appear in th
     games: {
       "game-1": {
         gameId: "game-1",
-        joinCode: "JOINABCD",
+        joinCode: "JNABCD23",
         leagueId: "league-1",
         seasonId: "season-1",
         sessionId: "session-1",
@@ -2019,7 +2019,7 @@ test("core lambda lets players join an active game by join code and appear in th
   const joinResponse = await harness.handler(
     createEvent({
       method: "POST",
-      path: "/v1/join/joinabcd",
+      path: "/v1/join/jnabcd23",
       headers: {
         Origin: "https://qa.3fc.football",
       },
@@ -2038,7 +2038,7 @@ test("core lambda lets players join an active game by join code and appear in th
     player: { playerId: string; nickname: string; createdAt: string; updatedAt: string };
   };
   assert.equal(joinBody.gameId, "game-1");
-  assert.equal(joinBody.joinCode, "JOINABCD");
+  assert.equal(joinBody.joinCode, "JNABCD23");
   assert.equal(joinBody.player.nickname, "Nia");
   assert.match(joinBody.player.playerId, /^player-/);
   assert.deepEqual(harness.linkedGamePlayers[0], {
@@ -2068,7 +2068,7 @@ test("core lambda returns stable errors for invalid and missing join codes", asy
   const invalidResponse = await harness.handler(
     createEvent({
       method: "POST",
-      path: "/v1/join/NOPE1234",
+      path: "/v1/join/ABCDEFGH",
       headers: {
         Origin: "https://qa.3fc.football",
       },
@@ -2122,7 +2122,7 @@ test("core lambda returns stable errors for invalid and missing join codes", asy
   assert.deepEqual(JSON.parse(invalidFormatResponse.body), {
     error: "bad_request",
     code: "join_code_invalid",
-    message: "Join code must be 8 letters or digits.",
+    message: "Join code must be 8 uppercase non-ambiguous letters or digits.",
   });
 
   const malformedResponse = await harness.handler(
@@ -2140,7 +2140,9 @@ test("core lambda returns stable errors for invalid and missing join codes", asy
 
   assert.equal(malformedResponse.statusCode, 400);
   assert.deepEqual(JSON.parse(malformedResponse.body), {
-    error: "Join code must be URL encoded correctly.",
+    error: "bad_request",
+    code: "join_code_invalid",
+    message: "Join code must be URL encoded correctly.",
   });
   assert.equal(harness.createdPlayers.length, 0);
   assert.equal(harness.linkedGamePlayers.length, 0);
@@ -2151,7 +2153,7 @@ test("core lambda rejects join registration for finished games", async () => {
     games: {
       "game-1": {
         gameId: "game-1",
-        joinCode: "FINISHED",
+        joinCode: "FNSH2DAB",
         leagueId: "league-1",
         seasonId: "season-1",
         sessionId: "session-1",
@@ -2166,7 +2168,7 @@ test("core lambda rejects join registration for finished games", async () => {
   const response = await harness.handler(
     createEvent({
       method: "POST",
-      path: "/v1/join/FINISHED",
+      path: "/v1/join/FNSH2DAB",
       headers: {
         Origin: "https://qa.3fc.football",
       },

--- a/api/src/tests/lambda-core.test.ts
+++ b/api/src/tests/lambda-core.test.ts
@@ -76,6 +76,7 @@ interface MockSessionEntity {
 interface MockGameRecord {
   gameId: string;
   joinCode: string;
+  createRequestHash?: string;
   leagueId: string;
   seasonId: string;
   sessionId: string;
@@ -181,6 +182,7 @@ interface CreatedSessionInput {
 interface CreatedGameInput {
   gameId: string;
   joinCode?: string | null;
+  createRequestHash?: string | null;
   leagueId: string;
   seasonId: string;
   sessionId: string;
@@ -367,6 +369,7 @@ function createHarness(config: HarnessConfig = {}) {
       {
         ...game,
         joinCode: game.joinCode ?? buildJoinCodeForGameId(game.gameId),
+        ...(game.createRequestHash ? { createRequestHash: game.createRequestHash } : {}),
         thirdLengthMinutes: game.thirdLengthMinutes ?? DEFAULT_THIRD_LENGTH_MINUTES,
         thirds: game.thirds ?? createDefaultThirdTimerSegments(),
         finishedAt: game.finishedAt ?? null,
@@ -873,6 +876,7 @@ function createHarness(config: HarnessConfig = {}) {
         const record = {
           gameId: input.gameId,
           joinCode,
+          ...(input.createRequestHash ? { createRequestHash: input.createRequestHash } : {}),
           leagueId: input.leagueId,
           seasonId: input.seasonId,
           sessionId: input.sessionId,
@@ -2627,6 +2631,7 @@ test("core lambda recovers idempotent create game retry after the game write com
   const failedResponse = await harness.handler(event);
   assert.equal(failedResponse.statusCode, 500);
   assert.equal(harness.createdGames.length, 1);
+  assert.ok(harness.createdGames[0]?.createRequestHash);
   assert.equal(harness.createdSessionGames.length, 0);
   const existingGame = harness.games.get("game-1");
   assert.ok(existingGame);
@@ -2637,6 +2642,28 @@ test("core lambda recovers idempotent create game retry after the game write com
     thirdLengthMinutes: 25,
     updatedAt: "2026-02-23T00:01:00.000Z",
   });
+
+  const unrelatedRetryResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/sessions/session-abc/games",
+      headers: {
+        Cookie: "threefc_session=session-1",
+        "Idempotency-Key": "create-game-recover-1",
+      },
+      body: {
+        gameId: "game-1",
+        gameStartTs: "2026-02-23T12:00:00Z",
+      },
+    }),
+  );
+  assert.equal(unrelatedRetryResponse.statusCode, 409);
+  assert.deepEqual(JSON.parse(unrelatedRetryResponse.body), {
+    error: "conflict",
+    code: "game_exists",
+    message: "Game game-1 already exists.",
+  });
+  assert.equal(harness.createdSessionGames.length, 0);
 
   const retryResponse = await harness.handler(event);
   assert.equal(retryResponse.statusCode, 201);
@@ -2656,6 +2683,7 @@ test("core lambda recovers idempotent create game retry after the game write com
   assert.equal(retryBody.status, "live");
   assert.equal(retryBody.gameStartTs, "2026-02-23T11:00:00Z");
   assert.equal(retryBody.thirdLengthMinutes, 25);
+  assert.equal("createRequestHash" in retryBody, false);
 
   const replayResponse = await harness.handler(event);
   assert.equal(replayResponse.statusCode, 201);

--- a/api/src/tests/lambda-core.test.ts
+++ b/api/src/tests/lambda-core.test.ts
@@ -17,6 +17,8 @@ import {
   type ThirdTimerSegment,
 } from "@3fc/contracts";
 import {
+  buildJoinCodeForGameId,
+  GameJoinRegistrationError,
   GameMutationStateError,
   GameTimerTransitionError,
   GoalCorrectionError,
@@ -69,6 +71,7 @@ interface MockSessionEntity {
 
 interface MockGameRecord {
   gameId: string;
+  joinCode: string;
   leagueId: string;
   seasonId: string;
   sessionId: string;
@@ -82,8 +85,8 @@ interface MockGameRecord {
   updatedAt: string;
 }
 
-type MockGameInput = Omit<MockGameRecord, "thirdLengthMinutes" | "thirds" | "finishedAt" | "result"> &
-  Partial<Pick<MockGameRecord, "thirdLengthMinutes" | "thirds" | "finishedAt" | "result">>;
+type MockGameInput = Omit<MockGameRecord, "joinCode" | "thirdLengthMinutes" | "thirds" | "finishedAt" | "result"> &
+  Partial<Pick<MockGameRecord, "joinCode" | "thirdLengthMinutes" | "thirds" | "finishedAt" | "result">>;
 
 interface MockSeasonTeamRecord {
   seasonId: string;
@@ -173,6 +176,7 @@ interface CreatedSessionInput {
 
 interface CreatedGameInput {
   gameId: string;
+  joinCode?: string | null;
   leagueId: string;
   seasonId: string;
   sessionId: string;
@@ -326,6 +330,7 @@ function createHarness(config: HarnessConfig = {}) {
       gameId,
       {
         ...game,
+        joinCode: game.joinCode ?? buildJoinCodeForGameId(game.gameId),
         thirdLengthMinutes: game.thirdLengthMinutes ?? DEFAULT_THIRD_LENGTH_MINUTES,
         thirds: game.thirds ?? createDefaultThirdTimerSegments(),
         finishedAt: game.finishedAt ?? null,
@@ -819,6 +824,7 @@ function createHarness(config: HarnessConfig = {}) {
         createdGames.push(input);
         const record = {
           gameId: input.gameId,
+          joinCode: input.joinCode ?? buildJoinCodeForGameId(input.gameId),
           leagueId: input.leagueId,
           seasonId: input.seasonId,
           sessionId: input.sessionId,
@@ -863,6 +869,62 @@ function createHarness(config: HarnessConfig = {}) {
           }
         }
         return game;
+      },
+      async getGameByJoinCode(joinCode: string) {
+        const normalizedJoinCode = joinCode.trim().toUpperCase();
+        return (
+          [...games.values()].find(
+            (game) => game.joinCode.trim().toUpperCase() === normalizedJoinCode,
+          ) ?? null
+        );
+      },
+      async joinGameByCode(input) {
+        const normalizedJoinCode = input.joinCode.trim().toUpperCase();
+        const game =
+          [...games.values()].find(
+            (candidate) => candidate.joinCode.trim().toUpperCase() === normalizedJoinCode,
+          ) ?? null;
+        if (!game) {
+          return null;
+        }
+
+        if (game.status === "finished") {
+          throw new GameJoinRegistrationError(
+            "game_finished",
+            409,
+            `Game ${game.gameId} is finished. Join registration is closed.`,
+          );
+        }
+
+        const player = {
+          playerId: input.playerId,
+          nickname: input.nickname,
+          claimedByUserId: null,
+          createdAt: "2026-02-23T00:00:00.000Z",
+          updatedAt: "2026-02-23T00:00:00.000Z",
+        };
+        const link = {
+          gameId: game.gameId,
+          playerId: input.playerId,
+          createdAt: "2026-02-23T00:00:00.000Z",
+          updatedAt: "2026-02-23T00:00:00.000Z",
+        };
+        createdPlayers.push({
+          playerId: input.playerId,
+          nickname: input.nickname,
+          claimedByUserId: null,
+        });
+        linkedGamePlayers.push({
+          gameId: game.gameId,
+          playerId: input.playerId,
+        });
+        players.set(input.playerId, player);
+        gamePlayers.set(`${game.gameId}:${input.playerId}`, link);
+
+        return {
+          game,
+          player,
+        };
       },
       async updateGame(input) {
         const existing = games.get(input.gameId);
@@ -1863,6 +1925,173 @@ test("core lambda completes magic-link auth and returns a session cookie", async
       expiresAt: "2026-02-24T00:00:00.000Z",
     },
   });
+});
+
+test("core lambda lets players join an active game by join code and appear in the player pool", async () => {
+  const harness = createHarness({
+    sessions: {
+      "session-1": {
+        sessionId: "session-1",
+        email: "scorekeeper@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    games: {
+      "game-1": {
+        gameId: "game-1",
+        joinCode: "JOINABCD",
+        leagueId: "league-1",
+        seasonId: "season-1",
+        sessionId: "session-1",
+        status: "live",
+        gameStartTs: "2026-02-23T10:00:00.000Z",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueAccess: {
+      "league-1:scorekeeper@example.com": {
+        leagueId: "league-1",
+        userId: "scorekeeper@example.com",
+        role: "scorekeeper",
+        grantedByUserId: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  const joinResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/join/joinabcd",
+      headers: {
+        Origin: "https://qa.3fc.football",
+      },
+      body: {
+        nickname: "Nia",
+      },
+    }),
+  );
+
+  assert.equal(joinResponse.statusCode, 201);
+  assert.equal(harness.createdPlayers.length, 1);
+  assert.equal(harness.linkedGamePlayers.length, 1);
+  const joinBody = JSON.parse(joinResponse.body) as {
+    gameId: string;
+    joinCode: string;
+    player: { playerId: string; nickname: string; createdAt: string; updatedAt: string };
+  };
+  assert.equal(joinBody.gameId, "game-1");
+  assert.equal(joinBody.joinCode, "JOINABCD");
+  assert.equal(joinBody.player.nickname, "Nia");
+  assert.match(joinBody.player.playerId, /^player-/);
+  assert.deepEqual(harness.linkedGamePlayers[0], {
+    gameId: "game-1",
+    playerId: joinBody.player.playerId,
+  });
+
+  const playerPoolResponse = await harness.handler(
+    createEvent({
+      method: "GET",
+      path: "/v1/games/game-1/players",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+    }),
+  );
+
+  assert.equal(playerPoolResponse.statusCode, 200);
+  assert.deepEqual(JSON.parse(playerPoolResponse.body), {
+    players: [joinBody.player],
+  });
+});
+
+test("core lambda returns stable errors for invalid and missing join codes", async () => {
+  const harness = createHarness();
+
+  const invalidResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/join/NOPE1234",
+      headers: {
+        Origin: "https://qa.3fc.football",
+      },
+      body: {
+        nickname: "Nia",
+      },
+    }),
+  );
+
+  assert.equal(invalidResponse.statusCode, 404);
+  assert.deepEqual(JSON.parse(invalidResponse.body), {
+    error: "not_found",
+    code: "invalid_join_code",
+    message: "Join code was not found.",
+  });
+
+  const missingResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/join",
+      headers: {
+        Origin: "https://qa.3fc.football",
+      },
+      body: {
+        nickname: "Nia",
+      },
+    }),
+  );
+
+  assert.equal(missingResponse.statusCode, 400);
+  assert.deepEqual(JSON.parse(missingResponse.body), {
+    error: "bad_request",
+    code: "join_code_required",
+    message: "Join code is required.",
+  });
+  assert.equal(harness.createdPlayers.length, 0);
+  assert.equal(harness.linkedGamePlayers.length, 0);
+});
+
+test("core lambda rejects join registration for finished games", async () => {
+  const harness = createHarness({
+    games: {
+      "game-1": {
+        gameId: "game-1",
+        joinCode: "FINISHED",
+        leagueId: "league-1",
+        seasonId: "season-1",
+        sessionId: "session-1",
+        status: "finished",
+        gameStartTs: "2026-02-23T10:00:00.000Z",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  const response = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/join/FINISHED",
+      headers: {
+        Origin: "https://qa.3fc.football",
+      },
+      body: {
+        nickname: "Late",
+      },
+    }),
+  );
+
+  assert.equal(response.statusCode, 409);
+  assert.deepEqual(JSON.parse(response.body), {
+    error: "conflict",
+    code: "game_finished",
+    message: "Game game-1 is finished. Join registration is closed.",
+  });
+  assert.equal(harness.createdPlayers.length, 0);
+  assert.equal(harness.linkedGamePlayers.length, 0);
 });
 
 test("core lambda accepts session cookie from API Gateway cookies array", async () => {

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -1456,6 +1456,46 @@ test("repository rejects join registration for finished games without creating a
   assert.deepEqual(await repository.listGamePlayers(game.gameId), []);
 });
 
+test("repository rejects join registration if join code lookup changes before write", async () => {
+  const { repository, client } = createRepositoryHarness();
+  const game = await repository.createGame({
+    gameId: "game-join-code-race",
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "session-1",
+    gameStartTs: "2026-02-22T10:00:00Z",
+  });
+
+  client.runBeforeNextPut(() => {
+    const item = client.readItem(`JOIN_CODE#${game.joinCode}`, "METADATA");
+    if (!item?.data?.S) {
+      throw new Error("Expected join code lookup item.");
+    }
+
+    const data = JSON.parse(item.data.S) as {
+      gameId: string;
+    };
+    data.gameId = "game-rotated-join-code";
+    item.data.S = JSON.stringify(data);
+    item.updatedAt = { S: "2026-02-22T00:01:39.000Z" };
+    client.seedItem(item);
+  });
+
+  await assert.rejects(
+    repository.joinGameByCode({
+      joinCode: game.joinCode,
+      playerId: "player-racy-join",
+      nickname: "Racy Join",
+    }),
+    (error) =>
+      error instanceof GameJoinRegistrationError &&
+      error.code === "join_state_changed" &&
+      error.statusCode === 409,
+  );
+  assert.equal(await repository.getPlayer("player-racy-join"), null);
+  assert.deepEqual(await repository.listGamePlayers(game.gameId), []);
+});
+
 test("repository rethrows non-conditional transaction cancellation when joining by code", async () => {
   const { repository, client } = createRepositoryHarness();
   const game = await repository.createGame({

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -1475,6 +1475,78 @@ test("repository repairs legacy game join-code collisions with a usable fallback
   });
 });
 
+test("repository repairs missing legacy join codes before game metadata mutations", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  client.seedItem({
+    pk: { S: "GAME#game-legacy" },
+    sk: { S: "METADATA" },
+    entityType: { S: "game" },
+    createdAt: { S: "2026-02-22T00:00:00.000Z" },
+    updatedAt: { S: "2026-02-22T00:00:00.000Z" },
+    data: {
+      S: JSON.stringify({
+        gameId: "game-legacy",
+        leagueId: "league-1",
+        seasonId: "season-1",
+        sessionId: "session-legacy",
+        status: "scheduled",
+        gameStartTs: "2026-02-22T10:00:00.000Z",
+      }),
+    },
+  });
+
+  const updatedGame = await repository.updateGame({
+    gameId: "game-legacy",
+    gameStartTs: "2026-02-22T10:15:00.000Z",
+  });
+  assert.ok(updatedGame);
+  assert.match(updatedGame.joinCode, /^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{8}$/);
+  assert.notEqual(updatedGame.joinCode, buildJoinCodeForGameId("game-legacy"));
+
+  const storedGame = client.readItem("GAME#game-legacy", "METADATA");
+  assert.equal(JSON.parse(storedGame?.data?.S ?? "{}").joinCode, updatedGame.joinCode);
+  const lookupItem = client.readItem(`JOIN_CODE#${updatedGame.joinCode}`, "METADATA");
+  assert.deepEqual(JSON.parse(lookupItem?.data?.S ?? "{}"), {
+    joinCode: updatedGame.joinCode,
+    gameId: "game-legacy",
+  });
+  assert.deepEqual(await repository.getGameByJoinCode(updatedGame.joinCode), updatedGame);
+});
+
+test("repository repairs stored join codes that are missing lookup ownership", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  client.seedItem({
+    pk: { S: "GAME#game-legacy" },
+    sk: { S: "METADATA" },
+    entityType: { S: "game" },
+    createdAt: { S: "2026-02-22T00:00:00.000Z" },
+    updatedAt: { S: "2026-02-22T00:00:00.000Z" },
+    data: {
+      S: JSON.stringify({
+        gameId: "game-legacy",
+        joinCode: "LEGACY23",
+        leagueId: "league-1",
+        seasonId: "season-1",
+        sessionId: "session-legacy",
+        status: "scheduled",
+        gameStartTs: "2026-02-22T10:00:00.000Z",
+      }),
+    },
+  });
+
+  const repairedGame = await repository.getGame("game-legacy", { repairLegacyJoinCode: true });
+  assert.ok(repairedGame);
+  assert.equal(repairedGame.joinCode, "LEGACY23");
+  const lookupItem = client.readItem("JOIN_CODE#LEGACY23", "METADATA");
+  assert.deepEqual(JSON.parse(lookupItem?.data?.S ?? "{}"), {
+    joinCode: "LEGACY23",
+    gameId: "game-legacy",
+  });
+  assert.deepEqual(await repository.getGameByJoinCode("LEGACY23"), repairedGame);
+});
+
 test("repository does not delete another game's join-code lookup for legacy games", async () => {
   const { repository, client } = createRepositoryHarness();
   const claimedJoinCode = buildJoinCodeForGameId("game-legacy");
@@ -1612,6 +1684,44 @@ test("repository rejects join registration if join code lookup changes before wr
   );
   assert.equal(await repository.getPlayer("player-racy-join"), null);
   assert.deepEqual(await repository.listGamePlayers(game.gameId), []);
+});
+
+test("repository replays existing public join registration after idempotency recording failures", async () => {
+  const repository = createRepository();
+  const game = await repository.createGame({
+    gameId: "game-join-replay",
+    joinCode: "REPLAY23",
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "session-1",
+    status: "live",
+    gameStartTs: "2026-02-22T10:00:00.000Z",
+  });
+
+  const firstJoin = await repository.joinGameByCode({
+    joinCode: game.joinCode,
+    playerId: "player-join-replay",
+    nickname: "Nia",
+  });
+  assert.ok(firstJoin);
+
+  const replayedJoin = await repository.joinGameByCode({
+    joinCode: game.joinCode,
+    playerId: "player-join-replay",
+    nickname: "Nia",
+  });
+  assert.deepEqual(replayedJoin, firstJoin);
+
+  await assert.rejects(
+    repository.joinGameByCode({
+      joinCode: game.joinCode,
+      playerId: "player-join-replay",
+      nickname: "Mia",
+    }),
+    (error) =>
+      error instanceof GameJoinRegistrationError &&
+      error.code === "join_state_changed",
+  );
 });
 
 test("repository rethrows non-conditional transaction cancellation when joining by code", async () => {

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -1391,7 +1391,13 @@ test("repository gives legacy games default timer state", async () => {
   assert.equal(game?.thirdLengthMinutes, DEFAULT_THIRD_LENGTH_MINUTES);
   assert.deepEqual(game?.thirds, createDefaultThirdTimerSegments());
   assert.equal(game?.joinCode, buildJoinCodeForGameId("game-legacy"));
-  assert.equal(await repository.getGameByJoinCode(buildJoinCodeForGameId("game-legacy")), null);
+  assert.deepEqual(await repository.getGameByJoinCode(buildJoinCodeForGameId("game-legacy")), game);
+  const lookupItem = client.readItem(`JOIN_CODE#${buildJoinCodeForGameId("game-legacy")}`, "METADATA");
+  assert.equal(lookupItem?.entityType?.S, "gameJoinCode");
+  assert.deepEqual(JSON.parse(lookupItem?.data?.S ?? "{}"), {
+    joinCode: buildJoinCodeForGameId("game-legacy"),
+    gameId: "game-legacy",
+  });
 });
 
 test("repository does not delete another game's join-code lookup for legacy games", async () => {
@@ -1428,6 +1434,43 @@ test("repository does not delete another game's join-code lookup for legacy game
   assert.equal(await repository.deleteGame("game-legacy"), true);
   assert.equal(await repository.getGame("game-legacy"), null);
   assert.deepEqual(await repository.getGameByJoinCode(claimedJoinCode), currentGame);
+});
+
+test("repository leaves game and join-code lookup intact if delete sees a join-code race", async () => {
+  const { repository, client } = createRepositoryHarness();
+  const game = await repository.createGame({
+    gameId: "game-delete-race",
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "session-1",
+    status: "scheduled",
+    gameStartTs: "2026-02-22T10:00:00.000Z",
+  });
+
+  client.runBeforeNextPut(() => {
+    const item = client.readItem(`JOIN_CODE#${game.joinCode}`, "METADATA");
+    if (!item?.data?.S) {
+      throw new Error("Expected join code lookup item.");
+    }
+
+    const data = JSON.parse(item.data.S) as {
+      gameId: string;
+      joinCode: string;
+    };
+    item.data.S = JSON.stringify({
+      ...data,
+      gameId: "game-other",
+    });
+    item.updatedAt = { S: "2026-02-22T00:01:39.000Z" };
+    client.seedItem(item);
+  });
+
+  assert.equal(await repository.deleteGame("game-delete-race"), false);
+  assert.deepEqual(await repository.getGame("game-delete-race"), game);
+  assert.equal(
+    JSON.parse(client.readItem(`JOIN_CODE#${game.joinCode}`, "METADATA")?.data?.S ?? "{}").gameId,
+    "game-other",
+  );
 });
 
 test("repository rejects join registration for finished games without creating a player", async () => {

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -247,9 +247,7 @@ class InMemoryDynamoClient {
               write.ConditionCheck.ExpressionAttributeValues ?? {},
             )
           ) {
-            const error = new Error("Conditional transaction request failed.");
-            (error as Error & { name: string }).name = "ConditionalCheckFailedException";
-            throw error;
+            throwConditionalCancellation(write);
           }
         }
       }
@@ -1369,6 +1367,45 @@ test("repository rejects join registration for finished games without creating a
       error.statusCode === 409,
   );
   assert.equal(await repository.getPlayer("player-late"), null);
+  assert.deepEqual(await repository.listGamePlayers(game.gameId), []);
+});
+
+test("repository rethrows non-conditional transaction cancellation when joining by code", async () => {
+  const { repository, client } = createRepositoryHarness();
+  const game = await repository.createGame({
+    gameId: "game-join-cancelled",
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "session-1",
+    gameStartTs: "2026-02-22T10:00:00Z",
+  });
+
+  client.runBeforeNextPut(() => {
+    const error = new Error("Join transaction validation failed.");
+    (
+      error as Error & {
+        name: string;
+        CancellationReasons: Array<{ Code: string }>;
+      }
+    ).name = "TransactionCanceledException";
+    (
+      error as Error & {
+        name: string;
+        CancellationReasons: Array<{ Code: string }>;
+      }
+    ).CancellationReasons = [{ Code: "ValidationError" }];
+    throw error;
+  });
+
+  await assert.rejects(
+    repository.joinGameByCode({
+      joinCode: game.joinCode,
+      playerId: "player-join-cancelled",
+      nickname: "Join Cancelled",
+    }),
+    /Join transaction validation failed/,
+  );
+  assert.equal(await repository.getPlayer("player-join-cancelled"), null);
   assert.deepEqual(await repository.listGamePlayers(game.gameId), []);
 });
 

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -1344,6 +1344,42 @@ test("repository gives legacy games default timer state", async () => {
   assert.equal(await repository.getGameByJoinCode(buildJoinCodeForGameId("game-legacy")), null);
 });
 
+test("repository does not delete another game's join-code lookup for legacy games", async () => {
+  const { repository, client } = createRepositoryHarness();
+  const claimedJoinCode = buildJoinCodeForGameId("game-legacy");
+  const currentGame = await repository.createGame({
+    gameId: "game-current",
+    joinCode: claimedJoinCode,
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "session-current",
+    status: "scheduled",
+    gameStartTs: "2026-02-22T10:00:00.000Z",
+  });
+
+  client.seedItem({
+    pk: { S: "GAME#game-legacy" },
+    sk: { S: "METADATA" },
+    entityType: { S: "game" },
+    createdAt: { S: "2026-02-22T00:00:00.000Z" },
+    updatedAt: { S: "2026-02-22T00:00:00.000Z" },
+    data: {
+      S: JSON.stringify({
+        gameId: "game-legacy",
+        leagueId: "league-1",
+        seasonId: "season-1",
+        sessionId: "session-legacy",
+        status: "scheduled",
+        gameStartTs: "2026-02-22T11:00:00.000Z",
+      }),
+    },
+  });
+
+  assert.equal(await repository.deleteGame("game-legacy"), true);
+  assert.equal(await repository.getGame("game-legacy"), null);
+  assert.deepEqual(await repository.getGameByJoinCode(claimedJoinCode), currentGame);
+});
+
 test("repository rejects join registration for finished games without creating a player", async () => {
   const repository = createRepository();
   const game = await repository.createGame({

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -578,7 +578,7 @@ test("repository rejects duplicate join code lookup records", async () => {
 
   await repository.createGame({
     gameId: "game-join-a",
-    joinCode: "SHARED01",
+    joinCode: "SHARED23",
     leagueId: "league-1",
     seasonId: "season-1",
     sessionId: "session-1",
@@ -588,7 +588,7 @@ test("repository rejects duplicate join code lookup records", async () => {
   await assert.rejects(
     repository.createGame({
       gameId: "game-join-b",
-      joinCode: "SHARED01",
+      joinCode: "SHARED23",
       leagueId: "league-1",
       seasonId: "season-1",
       sessionId: "session-1",
@@ -605,13 +605,13 @@ test("repository rejects custom join codes that do not match the public contract
   await assert.rejects(
     repository.createGame({
       gameId: "game-invalid-join-code",
-      joinCode: "STRONG1",
+      joinCode: "STRONG01",
       leagueId: "league-1",
       seasonId: "season-1",
       sessionId: "session-1",
       gameStartTs: "2026-02-22T10:00:00Z",
     }),
-    /joinCode must be 8 letters or digits/,
+    /joinCode must be 8 uppercase non-ambiguous letters or digits/,
   );
   assert.equal(await repository.getGame("game-invalid-join-code"), null);
 });
@@ -677,7 +677,7 @@ test("repository strongly reads game join-code lookups", async () => {
 
   const game = await repository.createGame({
     gameId: "game-join-strong",
-    joinCode: "STRONG01",
+    joinCode: "STRNG234",
     leagueId: "league-1",
     seasonId: "season-1",
     sessionId: "session-1",
@@ -685,7 +685,7 @@ test("repository strongly reads game join-code lookups", async () => {
   });
   client.getItemRequests.length = 0;
 
-  assert.deepEqual(await repository.getGameByJoinCode("strong01"), game);
+  assert.deepEqual(await repository.getGameByJoinCode("strng234"), game);
   assert.deepEqual(
     client.getItemRequests.map((request) => request.consistentRead),
     [true, true],
@@ -1768,7 +1768,7 @@ test("repository blocks deleting season or league while descendants exist", asyn
 });
 
 test("repository supports idempotency record create/get semantics", async () => {
-  const repository = createRepository();
+  const { repository, client } = createRepositoryHarness();
 
   const created = await repository.createIdempotencyRecord({
     scope: "admin@example.com:POST:/v1/leagues",
@@ -1786,6 +1786,7 @@ test("repository supports idempotency record create/get semantics", async () => 
     responseBody: JSON.stringify({ leagueId: "league-1" }),
   });
 
+  client.getItemRequests.length = 0;
   const record = await repository.getIdempotencyRecord(
     "admin@example.com:POST:/v1/leagues",
     "create-league-1",
@@ -1796,6 +1797,10 @@ test("repository supports idempotency record create/get semantics", async () => 
   assert.equal(record?.requestHash, "hash-1");
   assert.equal(record?.responseStatusCode, 201);
   assert.equal(record?.responseBody, JSON.stringify({ leagueId: "league-1" }));
+  assert.deepEqual(
+    client.getItemRequests.map((request) => request.consistentRead),
+    [true],
+  );
 });
 
 async function setupScoringGame(repository: ThreeFcRepository): Promise<void> {

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -17,7 +17,14 @@ import {
   type TeamId,
 } from "@3fc/contracts";
 
-import { GameMutationStateError, GameTimerTransitionError, ThreeFcRepository } from "../data/repository.js";
+import {
+  buildJoinCodeForGameId,
+  GameJoinCodeCollisionError,
+  GameJoinRegistrationError,
+  GameMutationStateError,
+  GameTimerTransitionError,
+  ThreeFcRepository,
+} from "../data/repository.js";
 
 type Item = Record<string, AttributeValue>;
 
@@ -476,6 +483,9 @@ test("repository supports round-trip create/read for core entities", async () =>
     gameStartTs: "2026-02-22T10:00:00Z",
   });
   assert.deepEqual(await repository.getGame("game-1"), game);
+  assert.equal(game.joinCode, buildJoinCodeForGameId("game-1"));
+  assert.deepEqual(await repository.getGameByJoinCode(game.joinCode), game);
+  assert.deepEqual(await repository.getGameByJoinCode(game.joinCode.toLowerCase()), game);
 
   const gameTeam = await repository.createGameTeamOverride({
     gameId: "game-1",
@@ -498,6 +508,16 @@ test("repository supports round-trip create/read for core entities", async () =>
   });
   assert.deepEqual(await repository.listGamePlayers("game-1"), [gamePlayer]);
 
+  const joinResult = await repository.joinGameByCode({
+    joinCode: game.joinCode.toLowerCase(),
+    playerId: "player-join",
+    nickname: "Nia",
+  });
+  assert.ok(joinResult);
+  assert.equal(joinResult.game.gameId, "game-1");
+  assert.deepEqual(await repository.getPlayer("player-join"), joinResult.player);
+  assert.deepEqual(await repository.listGamePlayers("game-1"), [gamePlayer, joinResult.link]);
+
   const accessGrant = await repository.grantLeagueAccess({
     leagueId: "league-1",
     userId: "user-scorekeeper",
@@ -518,7 +538,7 @@ test("repository supports round-trip create/read for core entities", async () =>
     playerId: "player-1",
   });
   assert.deepEqual(await repository.listGameRoster("game-1"), [rosterAssignment]);
-  assert.equal((await repository.listGamePlayers("game-1")).length, 1);
+  assert.equal((await repository.listGamePlayers("game-1")).length, 2);
 
   const reassignedRoster = await repository.assignRosterPlayer({
     gameId: "game-1",
@@ -546,6 +566,32 @@ test("repository rejects creating games directly as finished", async () => {
       error.code === "invalid_status_transition" &&
       /cannot be created directly as finished/.test(error.message),
   );
+});
+
+test("repository rejects duplicate join code lookup records", async () => {
+  const repository = createRepository();
+
+  await repository.createGame({
+    gameId: "game-join-a",
+    joinCode: "SHARED01",
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "session-1",
+    gameStartTs: "2026-02-22T10:00:00Z",
+  });
+
+  await assert.rejects(
+    repository.createGame({
+      gameId: "game-join-b",
+      joinCode: "SHARED01",
+      leagueId: "league-1",
+      seasonId: "season-1",
+      sessionId: "session-1",
+      gameStartTs: "2026-02-22T11:00:00Z",
+    }),
+    GameJoinCodeCollisionError,
+  );
+  assert.equal(await repository.getGame("game-join-b"), null);
 });
 
 test("repository query supports deterministic session->games ordering", async () => {
@@ -1246,6 +1292,34 @@ test("repository gives legacy games default timer state", async () => {
   const game = await repository.getGame("game-legacy");
   assert.equal(game?.thirdLengthMinutes, DEFAULT_THIRD_LENGTH_MINUTES);
   assert.deepEqual(game?.thirds, createDefaultThirdTimerSegments());
+  assert.equal(game?.joinCode, buildJoinCodeForGameId("game-legacy"));
+  assert.equal(await repository.getGameByJoinCode(buildJoinCodeForGameId("game-legacy")), null);
+});
+
+test("repository rejects join registration for finished games without creating a player", async () => {
+  const repository = createRepository();
+  const game = await repository.createGame({
+    gameId: "game-finished-join",
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "session-1",
+    status: "finished",
+    gameStartTs: "2026-02-22T10:00:00Z",
+  });
+
+  await assert.rejects(
+    repository.joinGameByCode({
+      joinCode: game.joinCode,
+      playerId: "player-late",
+      nickname: "Late",
+    }),
+    (error) =>
+      error instanceof GameJoinRegistrationError &&
+      error.code === "game_finished" &&
+      error.statusCode === 409,
+  );
+  assert.equal(await repository.getPlayer("player-late"), null);
+  assert.deepEqual(await repository.listGamePlayers(game.gameId), []);
 });
 
 test("repository enforces third timer transitions in order", async () => {

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -1520,15 +1520,15 @@ test("repository leaves game and join-code lookup intact if delete sees a join-c
 });
 
 test("repository rejects join registration for finished games without creating a player", async () => {
-  const repository = createRepository();
+  const { repository, client } = createRepositoryHarness();
   const game = await repository.createGame({
     gameId: "game-finished-join",
     leagueId: "league-1",
     seasonId: "season-1",
     sessionId: "session-1",
-    status: "finished",
     gameStartTs: "2026-02-22T10:00:00Z",
   });
+  markStoredGameFinished(client, "game-finished-join");
 
   await assert.rejects(
     repository.joinGameByCode({

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -599,6 +599,23 @@ test("repository rejects duplicate join code lookup records", async () => {
   assert.equal(await repository.getGame("game-join-b"), null);
 });
 
+test("repository rejects custom join codes that do not match the public contract", async () => {
+  const repository = createRepository();
+
+  await assert.rejects(
+    repository.createGame({
+      gameId: "game-invalid-join-code",
+      joinCode: "STRONG1",
+      leagueId: "league-1",
+      seasonId: "season-1",
+      sessionId: "session-1",
+      gameStartTs: "2026-02-22T10:00:00Z",
+    }),
+    /joinCode must be 8 letters or digits/,
+  );
+  assert.equal(await repository.getGame("game-invalid-join-code"), null);
+});
+
 test("repository distinguishes duplicate game IDs from join-code collisions", async () => {
   const repository = createRepository();
 
@@ -660,7 +677,7 @@ test("repository strongly reads game join-code lookups", async () => {
 
   const game = await repository.createGame({
     gameId: "game-join-strong",
-    joinCode: "STRONG1",
+    joinCode: "STRONG01",
     leagueId: "league-1",
     seasonId: "season-1",
     sessionId: "session-1",
@@ -668,7 +685,7 @@ test("repository strongly reads game join-code lookups", async () => {
   });
   client.getItemRequests.length = 0;
 
-  assert.deepEqual(await repository.getGameByJoinCode("strong1"), game);
+  assert.deepEqual(await repository.getGameByJoinCode("strong01"), game);
   assert.deepEqual(
     client.getItemRequests.map((request) => request.consistentRead),
     [true, true],

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -19,6 +19,7 @@ import {
 
 import {
   buildJoinCodeForGameId,
+  GameAlreadyExistsError,
   GameJoinCodeCollisionError,
   GameJoinRegistrationError,
   GameMutationStateError,
@@ -38,6 +39,7 @@ class InMemoryDynamoClient {
   private readonly items = new Map<string, Item>();
   private readonly queries: ObservedQuery[] = [];
   private beforeNextPut: (() => void) | null = null;
+  readonly getItemRequests: Array<{ pk: string; sk: string; consistentRead: boolean }> = [];
 
   seedItem(item: Item): void {
     const pk = this.readString(item.pk, "pk");
@@ -100,6 +102,11 @@ class InMemoryDynamoClient {
 
       const pk = this.readString(key.pk, "pk");
       const sk = this.readString(key.sk, "sk");
+      this.getItemRequests.push({
+        pk,
+        sk,
+        consistentRead: command.input.ConsistentRead === true,
+      });
       const item = this.items.get(`${pk}|${sk}`);
       return { Item: item };
     }
@@ -592,6 +599,49 @@ test("repository rejects duplicate join code lookup records", async () => {
     GameJoinCodeCollisionError,
   );
   assert.equal(await repository.getGame("game-join-b"), null);
+});
+
+test("repository distinguishes duplicate game IDs from join-code collisions", async () => {
+  const repository = createRepository();
+
+  await repository.createGame({
+    gameId: "game-existing",
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "session-1",
+    gameStartTs: "2026-02-22T10:00:00Z",
+  });
+
+  await assert.rejects(
+    repository.createGame({
+      gameId: "game-existing",
+      leagueId: "league-1",
+      seasonId: "season-1",
+      sessionId: "session-1",
+      gameStartTs: "2026-02-22T11:00:00Z",
+    }),
+    GameAlreadyExistsError,
+  );
+});
+
+test("repository strongly reads game join-code lookups", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  const game = await repository.createGame({
+    gameId: "game-join-strong",
+    joinCode: "STRONG1",
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "session-1",
+    gameStartTs: "2026-02-22T10:00:00Z",
+  });
+  client.getItemRequests.length = 0;
+
+  assert.deepEqual(await repository.getGameByJoinCode("strong1"), game);
+  assert.deepEqual(
+    client.getItemRequests.map((request) => request.consistentRead),
+    [true, true],
+  );
 });
 
 test("repository query supports deterministic session->games ordering", async () => {

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -622,6 +622,39 @@ test("repository distinguishes duplicate game IDs from join-code collisions", as
   );
 });
 
+test("repository rethrows non-conditional transaction cancellation when creating games", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  client.runBeforeNextPut(() => {
+    const error = new Error("Create game transaction validation failed.");
+    (
+      error as Error & {
+        name: string;
+        CancellationReasons: Array<{ Code: string }>;
+      }
+    ).name = "TransactionCanceledException";
+    (
+      error as Error & {
+        name: string;
+        CancellationReasons: Array<{ Code: string }>;
+      }
+    ).CancellationReasons = [{ Code: "ValidationError" }];
+    throw error;
+  });
+
+  await assert.rejects(
+    repository.createGame({
+      gameId: "game-create-cancelled",
+      leagueId: "league-1",
+      seasonId: "season-1",
+      sessionId: "session-1",
+      gameStartTs: "2026-02-22T11:00:00Z",
+    }),
+    /Create game transaction validation failed/,
+  );
+  assert.equal(await repository.getGame("game-create-cancelled"), null);
+});
+
 test("repository strongly reads game join-code lookups", async () => {
   const { repository, client } = createRepositoryHarness();
 

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -1400,6 +1400,52 @@ test("repository gives legacy games default timer state", async () => {
   });
 });
 
+test("repository repairs legacy game join-code collisions with a usable fallback", async () => {
+  const { repository, client } = createRepositoryHarness();
+  const claimedJoinCode = buildJoinCodeForGameId("game-legacy");
+  const currentGame = await repository.createGame({
+    gameId: "game-current",
+    joinCode: claimedJoinCode,
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "session-current",
+    status: "scheduled",
+    gameStartTs: "2026-02-22T10:00:00.000Z",
+  });
+
+  client.seedItem({
+    pk: { S: "GAME#game-legacy" },
+    sk: { S: "METADATA" },
+    entityType: { S: "game" },
+    createdAt: { S: "2026-02-22T00:00:00.000Z" },
+    updatedAt: { S: "2026-02-22T00:00:00.000Z" },
+    data: {
+      S: JSON.stringify({
+        gameId: "game-legacy",
+        leagueId: "league-1",
+        seasonId: "season-1",
+        sessionId: "session-legacy",
+        status: "scheduled",
+        gameStartTs: "2026-02-22T11:00:00.000Z",
+      }),
+    },
+  });
+
+  const repairedGame = await repository.getGame("game-legacy");
+  assert.ok(repairedGame);
+  assert.notEqual(repairedGame.joinCode, claimedJoinCode);
+  assert.deepEqual(await repository.getGameByJoinCode(claimedJoinCode), currentGame);
+  assert.deepEqual(await repository.getGameByJoinCode(repairedGame.joinCode), repairedGame);
+
+  const storedGame = client.readItem("GAME#game-legacy", "METADATA");
+  assert.equal(JSON.parse(storedGame?.data?.S ?? "{}").joinCode, repairedGame.joinCode);
+  const repairedLookup = client.readItem(`JOIN_CODE#${repairedGame.joinCode}`, "METADATA");
+  assert.deepEqual(JSON.parse(repairedLookup?.data?.S ?? "{}"), {
+    joinCode: repairedGame.joinCode,
+    gameId: "game-legacy",
+  });
+});
+
 test("repository does not delete another game's join-code lookup for legacy games", async () => {
   const { repository, client } = createRepositoryHarness();
   const claimedJoinCode = buildJoinCodeForGameId("game-legacy");

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -1366,7 +1366,7 @@ test("repository rejects quick player creation if the game finalizes before the 
   assert.equal((await repository.getGame("game-1"))?.status, "finished");
 });
 
-test("repository gives legacy games default timer state", async () => {
+test("repository gives legacy games default timer state without repairing join codes by default", async () => {
   const { repository, client } = createRepositoryHarness();
 
   client.seedItem({
@@ -1391,11 +1391,40 @@ test("repository gives legacy games default timer state", async () => {
   assert.equal(game?.thirdLengthMinutes, DEFAULT_THIRD_LENGTH_MINUTES);
   assert.deepEqual(game?.thirds, createDefaultThirdTimerSegments());
   assert.equal(game?.joinCode, buildJoinCodeForGameId("game-legacy"));
-  assert.deepEqual(await repository.getGameByJoinCode(buildJoinCodeForGameId("game-legacy")), game);
   const lookupItem = client.readItem(`JOIN_CODE#${buildJoinCodeForGameId("game-legacy")}`, "METADATA");
+  assert.equal(lookupItem ?? null, null);
+});
+
+test("repository repairs legacy game join codes with a random usable lookup when requested", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  client.seedItem({
+    pk: { S: "GAME#game-legacy" },
+    sk: { S: "METADATA" },
+    entityType: { S: "game" },
+    createdAt: { S: "2026-02-22T00:00:00.000Z" },
+    updatedAt: { S: "2026-02-22T00:00:00.000Z" },
+    data: {
+      S: JSON.stringify({
+        gameId: "game-legacy",
+        leagueId: "league-1",
+        seasonId: "season-1",
+        sessionId: "session-1",
+        status: "scheduled",
+        gameStartTs: "2026-02-22T10:00:00.000Z",
+      }),
+    },
+  });
+
+  const game = await repository.getGame("game-legacy", { repairLegacyJoinCode: true });
+  assert.ok(game);
+  assert.match(game.joinCode, /^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{8}$/);
+  assert.notEqual(game.joinCode, buildJoinCodeForGameId("game-legacy"));
+  assert.deepEqual(await repository.getGameByJoinCode(game.joinCode), game);
+  const lookupItem = client.readItem(`JOIN_CODE#${game.joinCode}`, "METADATA");
   assert.equal(lookupItem?.entityType?.S, "gameJoinCode");
   assert.deepEqual(JSON.parse(lookupItem?.data?.S ?? "{}"), {
-    joinCode: buildJoinCodeForGameId("game-legacy"),
+    joinCode: game.joinCode,
     gameId: "game-legacy",
   });
 });
@@ -1431,7 +1460,7 @@ test("repository repairs legacy game join-code collisions with a usable fallback
     },
   });
 
-  const repairedGame = await repository.getGame("game-legacy");
+  const repairedGame = await repository.getGame("game-legacy", { repairLegacyJoinCode: true });
   assert.ok(repairedGame);
   assert.notEqual(repairedGame.joinCode, claimedJoinCode);
   assert.deepEqual(await repository.getGameByJoinCode(claimedJoinCode), currentGame);

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -488,7 +488,7 @@ test("repository supports round-trip create/read for core entities", async () =>
     gameStartTs: "2026-02-22T10:00:00Z",
   });
   assert.deepEqual(await repository.getGame("game-1"), game);
-  assert.equal(game.joinCode, buildJoinCodeForGameId("game-1"));
+  assert.match(game.joinCode, /^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{8}$/);
   assert.deepEqual(await repository.getGameByJoinCode(game.joinCode), game);
   assert.deepEqual(await repository.getGameByJoinCode(game.joinCode.toLowerCase()), game);
 

--- a/api/src/tests/server-route.test.ts
+++ b/api/src/tests/server-route.test.ts
@@ -9,6 +9,7 @@ import {
   handleLocalCreateGameRoute,
   handleLocalDeleteGameRoute,
   handleLocalFinishGameRoute,
+  handleLocalGetGameRoute,
   handleLocalUpdateGameTeamRoute,
 } from "../server.js";
 import {
@@ -146,6 +147,72 @@ const scorekeeperAccess = {
   createdAt: "2026-02-23T00:00:00.000Z",
   updatedAt: "2026-02-23T00:00:00.000Z",
 };
+
+test("local server get game route does not repair legacy join codes before access is authorized", async () => {
+  const request = createMockRequest();
+  const response = createMockResponse();
+  const getGameCalls: Array<{ consistentRead: boolean; repairLegacyJoinCode: boolean }> = [];
+  const repositoryClient = {
+    async getGame(_gameId: string, options: { consistentRead?: boolean; repairLegacyJoinCode?: boolean } = {}) {
+      getGameCalls.push({
+        consistentRead: options.consistentRead ?? false,
+        repairLegacyJoinCode: options.repairLegacyJoinCode ?? false,
+      });
+      return gameRecord({ status: "scheduled", joinCode: "FALL2345" });
+    },
+    async getLeagueAccess() {
+      return null;
+    },
+  };
+
+  const status = await handleLocalGetGameRoute({
+    request,
+    response,
+    gameId: "game-1",
+    sessionEmail: "outsider@example.com",
+    repositoryClient,
+  });
+
+  assert.equal(status, 403);
+  assert.equal(response.statusCode, 403);
+  assert.deepEqual(getGameCalls, [{ consistentRead: false, repairLegacyJoinCode: false }]);
+});
+
+test("local server get game route repairs legacy join codes after access is authorized", async () => {
+  const request = createMockRequest();
+  const response = createMockResponse();
+  const getGameCalls: Array<{ consistentRead: boolean; repairLegacyJoinCode: boolean }> = [];
+  const repositoryClient = {
+    async getGame(_gameId: string, options: { consistentRead?: boolean; repairLegacyJoinCode?: boolean } = {}) {
+      getGameCalls.push({
+        consistentRead: options.consistentRead ?? false,
+        repairLegacyJoinCode: options.repairLegacyJoinCode ?? false,
+      });
+      return options.repairLegacyJoinCode
+        ? gameRecord({ status: "scheduled", joinCode: "RNDM2345" })
+        : gameRecord({ status: "scheduled", joinCode: "FALL2345" });
+    },
+    async getLeagueAccess() {
+      return scorekeeperAccess;
+    },
+  };
+
+  const status = await handleLocalGetGameRoute({
+    request,
+    response,
+    gameId: "game-1",
+    sessionEmail: "scorekeeper@example.com",
+    repositoryClient,
+  });
+
+  assert.equal(status, 200);
+  assert.equal(response.statusCode, 200);
+  assert.equal((JSON.parse(response.body) as { joinCode: string }).joinCode, "RNDM2345");
+  assert.deepEqual(getGameCalls, [
+    { consistentRead: false, repairLegacyJoinCode: false },
+    { consistentRead: true, repairLegacyJoinCode: true },
+  ]);
+});
 
 test("local server create game route recovers retry after the game write commits", async () => {
   const idempotencyRecords = new Map<string, {

--- a/api/src/tests/server-route.test.ts
+++ b/api/src/tests/server-route.test.ts
@@ -167,15 +167,17 @@ test("local server create game route recovers retry after the game write commits
   }> = [];
   const createdGameTeams: GameTeamRecord[] = [];
   let createSessionGameFailures = 1;
-  const buildRequest = () =>
+  const buildRequest = (
+    body: { gameId: string; gameStartTs: string; thirdLengthMinutes?: ThirdLengthMinutes } = {
+      gameId: "game-local",
+      gameStartTs: "2026-02-23T10:00:00.000Z",
+    },
+  ) =>
     createMockRequest({
       headers: {
         "idempotency-key": "local-create-game-recover-1",
       },
-      body: {
-        gameId: "game-local",
-        gameStartTs: "2026-02-23T10:00:00.000Z",
-      },
+      body,
     });
   const repositoryClient = {
     async getIdempotencyRecord(scope: string, key: string) {
@@ -202,6 +204,7 @@ test("local server create game route recovers retry after the game write commits
     },
     async createGame(input: {
       gameId: string;
+      createRequestHash?: string | null;
       leagueId: string;
       seasonId: string;
       sessionId: string;
@@ -220,6 +223,7 @@ test("local server create game route recovers retry after the game write commits
         }),
         gameId: input.gameId,
         joinCode: "LOCAL234",
+        ...(input.createRequestHash ? { createRequestHash: input.createRequestHash } : {}),
         leagueId: input.leagueId,
         seasonId: input.seasonId,
         sessionId: input.sessionId,
@@ -305,6 +309,27 @@ test("local server create game route recovers retry after the game write commits
     updatedAt: "2026-02-23T00:01:00.000Z",
   });
 
+  const unrelatedRetryResponse = createMockResponse();
+  const unrelatedRetryStatus = await handleLocalCreateGameRoute({
+    request: buildRequest({
+      gameId: "game-local",
+      gameStartTs: "2026-02-23T12:00:00.000Z",
+    }),
+    response: unrelatedRetryResponse,
+    scope: { leagueId: "league-1", seasonId: "season-1", sessionId: "session-1" },
+    sessionEmail: "admin@example.com",
+    method: "POST",
+    route: "/v1/sessions/session-1/games",
+    repositoryClient,
+  });
+  assert.equal(unrelatedRetryStatus, 409);
+  assert.deepEqual(JSON.parse(unrelatedRetryResponse.body), {
+    error: "conflict",
+    code: "game_exists",
+    message: "Game game-local already exists.",
+  });
+  assert.equal(createdSessionGames.length, 0);
+
   const retryResponse = createMockResponse();
   const retryStatus = await handleLocalCreateGameRoute({
     request: buildRequest(),
@@ -350,6 +375,7 @@ test("local server create game route recovers retry after the game write commits
   assert.equal(replayStatus, 201);
   assert.equal(createdSessionGames.length, 1);
   assert.equal(JSON.parse(replayResponse.body).gameId, "game-local");
+  assert.equal("createRequestHash" in JSON.parse(replayResponse.body), false);
 });
 
 test("local server finish route returns finished game result", async () => {

--- a/api/src/tests/server-route.test.ts
+++ b/api/src/tests/server-route.test.ts
@@ -295,6 +295,15 @@ test("local server create game route recovers retry after the game write commits
   );
   assert.equal(games.size, 1);
   assert.equal(createdSessionGames.length, 0);
+  const existingGame = games.get("game-local");
+  assert.ok(existingGame);
+  games.set("game-local", {
+    ...existingGame,
+    status: "live",
+    gameStartTs: "2026-02-23T11:00:00.000Z",
+    thirdLengthMinutes: 25,
+    updatedAt: "2026-02-23T00:01:00.000Z",
+  });
 
   const retryResponse = createMockResponse();
   const retryStatus = await handleLocalCreateGameRoute({
@@ -308,11 +317,25 @@ test("local server create game route recovers retry after the game write commits
   });
   assert.equal(retryStatus, 201);
   assert.equal(createdSessionGames.length, 1);
+  assert.equal(createdSessionGames[0]?.gameStartTs, "2026-02-23T11:00:00.000Z");
   assert.deepEqual(
     createdGameTeams.map((team) => team.teamId),
     ["red", "blue", "yellow"],
   );
-  assert.equal(JSON.parse(retryResponse.body).gameId, "game-local");
+  assert.deepEqual(
+    {
+      gameId: JSON.parse(retryResponse.body).gameId,
+      status: JSON.parse(retryResponse.body).status,
+      gameStartTs: JSON.parse(retryResponse.body).gameStartTs,
+      thirdLengthMinutes: JSON.parse(retryResponse.body).thirdLengthMinutes,
+    },
+    {
+      gameId: "game-local",
+      status: "live",
+      gameStartTs: "2026-02-23T11:00:00.000Z",
+      thirdLengthMinutes: 25,
+    },
+  );
 
   const replayResponse = createMockResponse();
   const replayStatus = await handleLocalCreateGameRoute({

--- a/api/src/tests/server-route.test.ts
+++ b/api/src/tests/server-route.test.ts
@@ -239,10 +239,11 @@ test("local server create game route recovers retry after the game write commits
       gameId: "game-local",
       gameStartTs: "2026-02-23T10:00:00.000Z",
     },
+    idempotencyKey = "local-create-game-recover-1",
   ) =>
     createMockRequest({
       headers: {
-        "idempotency-key": "local-create-game-recover-1",
+        "idempotency-key": idempotencyKey,
       },
       body,
     });
@@ -391,6 +392,24 @@ test("local server create game route recovers retry after the game write commits
   });
   assert.equal(unrelatedRetryStatus, 409);
   assert.deepEqual(JSON.parse(unrelatedRetryResponse.body), {
+    error: "conflict",
+    code: "game_exists",
+    message: "Game game-local already exists.",
+  });
+  assert.equal(createdSessionGames.length, 0);
+
+  const differentKeyRetryResponse = createMockResponse();
+  const differentKeyRetryStatus = await handleLocalCreateGameRoute({
+    request: buildRequest(undefined, "local-create-game-recover-2"),
+    response: differentKeyRetryResponse,
+    scope: { leagueId: "league-1", seasonId: "season-1", sessionId: "session-1" },
+    sessionEmail: "admin@example.com",
+    method: "POST",
+    route: "/v1/sessions/session-1/games",
+    repositoryClient,
+  });
+  assert.equal(differentKeyRetryStatus, 409);
+  assert.deepEqual(JSON.parse(differentKeyRetryResponse.body), {
     error: "conflict",
     code: "game_exists",
     message: "Game game-local already exists.",

--- a/api/src/tests/server-route.test.ts
+++ b/api/src/tests/server-route.test.ts
@@ -2,15 +2,21 @@ import assert from "node:assert/strict";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import test from "node:test";
 
-import type { GameResult, TeamId, ThirdTimerSegment } from "@3fc/contracts";
+import type { GameResult, TeamId, ThirdLengthMinutes, ThirdTimerSegment } from "@3fc/contracts";
 import { createDefaultThirdTimerSegments } from "@3fc/contracts";
 
 import {
+  handleLocalCreateGameRoute,
   handleLocalDeleteGameRoute,
   handleLocalFinishGameRoute,
   handleLocalUpdateGameTeamRoute,
 } from "../server.js";
-import { GameMutationStateError, GameTimerTransitionError } from "../data/repository.js";
+import {
+  GameAlreadyExistsError,
+  GameMutationStateError,
+  GameTimerTransitionError,
+} from "../data/repository.js";
+import type { GameRecord, GameTeamRecord } from "../data/types.js";
 
 class MockResponse {
   statusCode = 0;
@@ -140,6 +146,188 @@ const scorekeeperAccess = {
   createdAt: "2026-02-23T00:00:00.000Z",
   updatedAt: "2026-02-23T00:00:00.000Z",
 };
+
+test("local server create game route recovers retry after the game write commits", async () => {
+  const idempotencyRecords = new Map<string, {
+    scope: string;
+    key: string;
+    requestHash: string;
+    responseStatusCode: number;
+    responseBody: string;
+    createdAt: string;
+    updatedAt: string;
+  }>();
+  const games = new Map<string, GameRecord>();
+  const createdSessionGames: Array<{
+    sessionId: string;
+    gameId: string;
+    gameStartTs: string;
+    leagueId: string;
+    seasonId: string;
+  }> = [];
+  const createdGameTeams: GameTeamRecord[] = [];
+  let createSessionGameFailures = 1;
+  const buildRequest = () =>
+    createMockRequest({
+      headers: {
+        "idempotency-key": "local-create-game-recover-1",
+      },
+      body: {
+        gameId: "game-local",
+        gameStartTs: "2026-02-23T10:00:00.000Z",
+      },
+    });
+  const repositoryClient = {
+    async getIdempotencyRecord(scope: string, key: string) {
+      return idempotencyRecords.get(`${scope}:${key}`) ?? null;
+    },
+    async createIdempotencyRecord(input: {
+      scope: string;
+      key: string;
+      requestHash: string;
+      responseStatusCode: number;
+      responseBody: string;
+    }) {
+      const id = `${input.scope}:${input.key}`;
+      if (idempotencyRecords.has(id)) {
+        return false;
+      }
+
+      idempotencyRecords.set(id, {
+        ...input,
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      });
+      return true;
+    },
+    async createGame(input: {
+      gameId: string;
+      leagueId: string;
+      seasonId: string;
+      sessionId: string;
+      status?: "scheduled" | "live" | "finished";
+      gameStartTs: string;
+      thirdLengthMinutes?: ThirdLengthMinutes;
+    }) {
+      if (games.has(input.gameId)) {
+        throw new GameAlreadyExistsError(input.gameId);
+      }
+
+      const game = {
+        ...gameRecord({
+          status: input.status ?? "scheduled",
+          thirds: createDefaultThirdTimerSegments(),
+        }),
+        gameId: input.gameId,
+        joinCode: "LOCAL234",
+        leagueId: input.leagueId,
+        seasonId: input.seasonId,
+        sessionId: input.sessionId,
+        gameStartTs: input.gameStartTs,
+        thirdLengthMinutes: input.thirdLengthMinutes ?? 20,
+      };
+      games.set(input.gameId, game);
+      return game;
+    },
+    async getGame(gameId: string) {
+      return games.get(gameId) ?? null;
+    },
+    async createSessionGame(input: {
+      sessionId: string;
+      gameId: string;
+      gameStartTs: string;
+      leagueId: string;
+      seasonId: string;
+    }) {
+      if (createSessionGameFailures > 0) {
+        createSessionGameFailures -= 1;
+        throw new Error("Session game index write failed.");
+      }
+
+      createdSessionGames.push(input);
+      return {
+        ...input,
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      };
+    },
+    async listTeamsForSeason() {
+      return seasonTeams;
+    },
+    async createTeam() {
+      throw new Error("Default season teams should already exist.");
+    },
+    async listTeamsForGame() {
+      return [];
+    },
+    async createGameTeamOverride(input: {
+      gameId: string;
+      teamId: TeamId;
+      name: string;
+      color: string | null;
+    }) {
+      const gameTeam = {
+        gameId: input.gameId,
+        teamId: input.teamId,
+        name: input.name,
+        color: input.color,
+        scored: 0,
+        conceded: 0,
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      };
+      createdGameTeams.push(gameTeam);
+      return gameTeam;
+    },
+  };
+
+  await assert.rejects(
+    handleLocalCreateGameRoute({
+      request: buildRequest(),
+      response: createMockResponse(),
+      scope: { leagueId: "league-1", seasonId: "season-1", sessionId: "session-1" },
+      sessionEmail: "admin@example.com",
+      method: "POST",
+      route: "/v1/sessions/session-1/games",
+      repositoryClient,
+    }),
+    /Session game index write failed/,
+  );
+  assert.equal(games.size, 1);
+  assert.equal(createdSessionGames.length, 0);
+
+  const retryResponse = createMockResponse();
+  const retryStatus = await handleLocalCreateGameRoute({
+    request: buildRequest(),
+    response: retryResponse,
+    scope: { leagueId: "league-1", seasonId: "season-1", sessionId: "session-1" },
+    sessionEmail: "admin@example.com",
+    method: "POST",
+    route: "/v1/sessions/session-1/games",
+    repositoryClient,
+  });
+  assert.equal(retryStatus, 201);
+  assert.equal(createdSessionGames.length, 1);
+  assert.deepEqual(
+    createdGameTeams.map((team) => team.teamId),
+    ["red", "blue", "yellow"],
+  );
+  assert.equal(JSON.parse(retryResponse.body).gameId, "game-local");
+
+  const replayResponse = createMockResponse();
+  const replayStatus = await handleLocalCreateGameRoute({
+    request: buildRequest(),
+    response: replayResponse,
+    scope: { leagueId: "league-1", seasonId: "season-1", sessionId: "session-1" },
+    sessionEmail: "admin@example.com",
+    method: "POST",
+    route: "/v1/sessions/session-1/games",
+    repositoryClient,
+  });
+  assert.equal(replayStatus, 201);
+  assert.equal(createdSessionGames.length, 1);
+  assert.equal(JSON.parse(replayResponse.body).gameId, "game-local");
+});
 
 test("local server finish route returns finished game result", async () => {
   const request = createMockRequest({

--- a/api/src/tests/server-route.test.ts
+++ b/api/src/tests/server-route.test.ts
@@ -93,12 +93,14 @@ const result: GameResult = {
 
 function gameRecord(input: {
   status?: "scheduled" | "live" | "finished";
+  joinCode?: string;
   finishedAt?: string | null;
   result?: GameResult | null;
   thirds?: ThirdTimerSegment[];
 } = {}) {
   return {
     gameId: "game-1",
+    joinCode: input.joinCode ?? "JOIN1234",
     leagueId: "league-1",
     seasonId: "season-1",
     sessionId: "session-1",

--- a/app/src/server.ts
+++ b/app/src/server.ts
@@ -7,6 +7,7 @@ import { buildSecurityHeaders } from "./security.js";
 import {
   renderComponentShowcasePage,
   renderGamePage,
+  renderJoinPage,
   renderLeaguePage,
   renderMagicLinkCallbackPage,
   renderSeasonPage,
@@ -219,6 +220,18 @@ export function createAppRequestHandler(apiBaseUrl: string) {
     if (method === "GET" && gamePageMatch) {
       const gameId = decodeURIComponent(gamePageMatch[1]);
       sendHtml(response, securityHeaders, 200, renderGamePage(apiBaseUrl, { gameId }));
+      return;
+    }
+
+    if (method === "GET" && route === "/join") {
+      sendHtml(response, securityHeaders, 200, renderJoinPage(apiBaseUrl, ""));
+      return;
+    }
+
+    const joinPageMatch = route.match(/^\/join\/([^/]+)$/);
+    if (method === "GET" && joinPageMatch) {
+      const joinCode = decodeURIComponent(joinPageMatch[1]);
+      sendHtml(response, securityHeaders, 200, renderJoinPage(apiBaseUrl, joinCode));
       return;
     }
 

--- a/app/src/static-export.ts
+++ b/app/src/static-export.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import {
   renderComponentShowcasePage,
   renderGamePage,
+  renderJoinPage,
   renderLeaguePage,
   renderMagicLinkCallbackPage,
   renderSeasonPage,
@@ -92,6 +93,7 @@ export function buildStaticSite(options: StaticSiteBuildOptions): string {
     { path: "/leagues", html: renderLeaguePage(options.apiBaseUrl, "") },
     { path: "/seasons", html: renderSeasonPage(options.apiBaseUrl, "") },
     { path: "/games", html: renderGamePage(options.apiBaseUrl, { gameId: "" }) },
+    { path: "/join", html: renderJoinPage(options.apiBaseUrl, "") },
   ];
 
   rmSync(outputDir, { recursive: true, force: true });

--- a/app/src/tests/server.test.ts
+++ b/app/src/tests/server.test.ts
@@ -127,7 +127,7 @@ test("setup and auth flow script routes serve external javascript", () => {
   assert.match(authFlowResponse.body, /auth\/callback/);
 });
 
-test("league, season, and game routes render their shells", () => {
+test("league, season, game, and join routes render their shells", () => {
   const leagueResponse = executeRoute("GET", "/leagues/league-1");
   assert.equal(leagueResponse.statusCode, 200);
   assert.match(leagueResponse.body, /data-testid="league-shell"/);
@@ -149,6 +149,14 @@ test("league, season, and game routes render their shells", () => {
   assert.match(response.body, /data-testid="game-shell"/);
   assert.match(response.body, /data-page="game"/);
   assert.match(response.body, /game-123/);
+
+  const joinResponse = executeRoute("GET", "/join/join0001");
+  assert.equal(joinResponse.statusCode, 200);
+  assertSecurityHeaders(joinResponse.headers);
+  assert.equal(joinResponse.headers["Content-Type"], "text/html; charset=utf-8");
+  assert.match(joinResponse.body, /data-testid="join-shell"/);
+  assert.match(joinResponse.body, /data-page="join"/);
+  assert.match(joinResponse.body, /data-join-code="join0001"/);
 });
 
 test("auth callback error and success responses include security headers", () => {

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -148,6 +148,7 @@ interface MockApiState {
   roster: Map<string, MockRosterAssignment>;
   goalEvents: Map<string, MockGoalEvent>;
   goalSequence: number;
+  lastPublicJoinRequest: { body: Record<string, unknown>; idempotencyKey: string | null } | null;
 }
 
 function readUiScript(fileName: string): string {
@@ -173,6 +174,7 @@ function createMockApiState(): MockApiState {
     roster: new Map<string, MockRosterAssignment>(),
     goalEvents: new Map<string, MockGoalEvent>(),
     goalSequence: 0,
+    lastPublicJoinRequest: null,
   };
 }
 
@@ -657,7 +659,8 @@ function createMockFetch(state: MockApiState) {
     if (method === "POST" && joinMatch) {
       const joinCode = decodeURIComponent(joinMatch[1]).trim().toUpperCase();
       const nickname = String(body.nickname ?? "").trim();
-      const playerId = String(body.playerId ?? "").trim();
+      const idempotencyKey = readInitHeader(init, "idempotency-key");
+      state.lastPublicJoinRequest = { body, idempotencyKey };
       const game = [...state.games.values()].find((candidate) => candidate.joinCode === joinCode);
       if (!game) {
         return createJsonResponse(404, {
@@ -671,13 +674,26 @@ function createMockFetch(state: MockApiState) {
           message: "Finished games cannot accept new joins.",
         });
       }
-      if (!nickname || !playerId) {
+      if (!idempotencyKey?.trim()) {
         return createJsonResponse(400, {
           error: "bad_request",
-          message: "playerId and nickname are required.",
+          message: "Idempotency-Key header is required.",
+        });
+      }
+      if ("playerId" in body) {
+        return createJsonResponse(400, {
+          error: "bad_request",
+          message: "playerId is not accepted on public join.",
+        });
+      }
+      if (!nickname) {
+        return createJsonResponse(400, {
+          error: "bad_request",
+          message: "nickname is required.",
         });
       }
 
+      const playerId = `player-${idempotencyKey}`;
       const now = "2026-03-28T11:00:12.000Z";
       const player: MockPlayer = {
         playerId,
@@ -3615,6 +3631,9 @@ test("join page registers a player without organizer authentication", async () =
   const player = [...apiState.players.values()][0];
   assert(player);
   assert.equal(player.nickname, "Cy");
+  assert.equal(apiState.lastPublicJoinRequest?.body.nickname, "Cy");
+  assert.equal("playerId" in (apiState.lastPublicJoinRequest?.body ?? {}), false);
+  assert.match(apiState.lastPublicJoinRequest?.idempotencyKey ?? "", /^join-player-JOIN0001-Cy-/);
   assert.equal(apiState.gamePlayers.has(`game-join-1:${player.playerId}`), true);
   assert.equal(joinPage.document.getElementById("join-result")?.hidden, false);
   assert.equal(joinPage.document.getElementById("join-result-player")?.textContent, "Cy");

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -60,6 +60,7 @@ interface MockSessionEntity {
 
 interface MockGame {
   gameId: string;
+  joinCode?: string;
   leagueId: string;
   seasonId: string;
   sessionId: string;
@@ -821,6 +822,7 @@ function createMockFetch(state: MockApiState) {
       const now = "2026-03-28T11:00:04.000Z";
       const game: MockGame = {
         gameId,
+        joinCode: `JOIN${gameId.slice(-4).toUpperCase()}`,
         leagueId: season.leagueId,
         seasonId: season.seasonId,
         sessionId,
@@ -1843,6 +1845,7 @@ test("game page quick-creates and assigns roster players", async () => {
   });
   apiState.games.set("game-1", {
     gameId: "game-1",
+    joinCode: "JOIN0001",
     leagueId: "three-sided-football-club",
     seasonId: "autumn-cup",
     sessionId: "20260328",
@@ -2999,6 +3002,7 @@ test("setup smoke completes live game through finish", async () => {
   });
   apiState.games.set("game-smoke-1", {
     gameId: "game-smoke-1",
+    joinCode: "SMOKE123",
     leagueId: "three-sided-football-club",
     seasonId: "autumn-cup",
     sessionId: "20260328",
@@ -3035,6 +3039,7 @@ test("setup smoke completes live game through finish", async () => {
   const undoLastGoalButton = gamePage.document.querySelector('[data-action="undo-last-goal"]');
   const deleteGameButton = gamePage.document.querySelector('[data-action="delete-game"]');
   const statusInput = gamePage.document.getElementById("game-edit-status");
+  const joinCodeValue = gamePage.document.getElementById("game-join-code-value");
   const scoreboard = gamePage.document.getElementById("live-scoreboard");
   const goalFormNote = gamePage.document.getElementById("goal-form-note");
   const resultSummary = gamePage.document.getElementById("game-result-summary");
@@ -3051,10 +3056,12 @@ test("setup smoke completes live game through finish", async () => {
   assert(undoLastGoalButton instanceof gamePage.window.HTMLButtonElement);
   assert(deleteGameButton instanceof gamePage.window.HTMLButtonElement);
   assert(statusInput instanceof gamePage.window.HTMLSelectElement);
+  assert(joinCodeValue instanceof gamePage.window.HTMLElement);
   assert(scoreboard instanceof gamePage.window.HTMLElement);
   assert(goalFormNote instanceof gamePage.window.HTMLElement);
   assert(resultSummary instanceof gamePage.window.HTMLElement);
   assert.equal(finishGameButton.disabled, true);
+  assert.equal(joinCodeValue.textContent, "SMOKE123");
   assert.equal(resultSummary.hidden, true);
 
   nicknameInput.value = "Ari";

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -16,6 +16,7 @@ import {
 
 import {
   renderGamePage,
+  renderJoinPage,
   renderLeaguePage,
   renderMagicLinkCallbackPage,
   renderSeasonPage,
@@ -649,6 +650,55 @@ function createMockFetch(state: MockApiState) {
       return createJsonResponse(200, {
         authenticated: true,
         session: state.session,
+      });
+    }
+
+    const joinMatch = path.match(/^\/v1\/join\/([^/]+)$/);
+    if (method === "POST" && joinMatch) {
+      const joinCode = decodeURIComponent(joinMatch[1]).trim().toUpperCase();
+      const nickname = String(body.nickname ?? "").trim();
+      const playerId = String(body.playerId ?? "").trim();
+      const game = [...state.games.values()].find((candidate) => candidate.joinCode === joinCode);
+      if (!game) {
+        return createJsonResponse(404, {
+          error: "not_found",
+          message: "Join code was not found.",
+        });
+      }
+      if (game.status === "finished") {
+        return createJsonResponse(409, {
+          error: "conflict",
+          message: "Finished games cannot accept new joins.",
+        });
+      }
+      if (!nickname || !playerId) {
+        return createJsonResponse(400, {
+          error: "bad_request",
+          message: "playerId and nickname are required.",
+        });
+      }
+
+      const now = "2026-03-28T11:00:12.000Z";
+      const player: MockPlayer = {
+        playerId,
+        nickname,
+        claimedByUserId: null,
+        createdAt: now,
+        updatedAt: now,
+      };
+      const link: MockGamePlayer = {
+        gameId: game.gameId,
+        playerId,
+        createdAt: now,
+        updatedAt: now,
+      };
+      state.players.set(playerId, player);
+      state.gamePlayers.set(`${game.gameId}:${playerId}`, link);
+      return createJsonResponse(201, {
+        gameId: game.gameId,
+        joinCode: game.joinCode,
+        player,
+        link,
       });
     }
 
@@ -3040,6 +3090,7 @@ test("setup smoke completes live game through finish", async () => {
   const deleteGameButton = gamePage.document.querySelector('[data-action="delete-game"]');
   const statusInput = gamePage.document.getElementById("game-edit-status");
   const joinCodeValue = gamePage.document.getElementById("game-join-code-value");
+  const joinLink = gamePage.document.getElementById("game-join-link");
   const scoreboard = gamePage.document.getElementById("live-scoreboard");
   const goalFormNote = gamePage.document.getElementById("goal-form-note");
   const resultSummary = gamePage.document.getElementById("game-result-summary");
@@ -3057,11 +3108,14 @@ test("setup smoke completes live game through finish", async () => {
   assert(deleteGameButton instanceof gamePage.window.HTMLButtonElement);
   assert(statusInput instanceof gamePage.window.HTMLSelectElement);
   assert(joinCodeValue instanceof gamePage.window.HTMLElement);
+  assert(joinLink instanceof gamePage.window.HTMLAnchorElement);
   assert(scoreboard instanceof gamePage.window.HTMLElement);
   assert(goalFormNote instanceof gamePage.window.HTMLElement);
   assert(resultSummary instanceof gamePage.window.HTMLElement);
   assert.equal(finishGameButton.disabled, true);
   assert.equal(joinCodeValue.textContent, "SMOKE123");
+  assert.equal(joinLink.getAttribute("href"), "/join/SMOKE123");
+  assert.equal(joinLink.textContent, "/join/SMOKE123");
   assert.equal(resultSummary.hidden, true);
 
   nicknameInput.value = "Ari";
@@ -3518,4 +3572,51 @@ test("setup flow resolves route ids from static shells", async () => {
   });
   assert.equal(gamePage.document.getElementById("game-title")?.textContent, "game-20260328-abc123");
   assert.equal(gamePage.document.getElementById("game-id-value")?.textContent, "game-20260328-abc123");
+});
+
+test("join page registers a player without organizer authentication", async () => {
+  const apiState = createMockApiState();
+  apiState.games.set("game-join-1", {
+    gameId: "game-join-1",
+    joinCode: "JOIN0001",
+    leagueId: "autumn-league",
+    seasonId: "autumn-cup",
+    sessionId: "20260328",
+    status: "scheduled",
+    gameStartTs: "2026-03-28T10:00:00.000Z",
+    thirdLengthMinutes: DEFAULT_THIRD_LENGTH_MINUTES,
+    thirds: createDefaultThirdTimerSegments(),
+    finishedAt: null,
+    result: null,
+    createdAt: "2026-03-28T11:00:03.000Z",
+    updatedAt: "2026-03-28T11:00:03.000Z",
+  });
+
+  const joinPage = await bootPage({
+    html: renderJoinPage("http://localhost:3001", "join0001"),
+    url: "http://localhost:3000/join/join0001",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+
+  assert.equal(joinPage.navigations.length, 0);
+  assert.equal(joinPage.document.getElementById("join-code-value")?.textContent, "JOIN0001");
+
+  const nicknameInput = joinPage.document.getElementById("join-player-nickname");
+  const form = joinPage.document.getElementById("join-game-form");
+  assert(nicknameInput instanceof joinPage.window.HTMLInputElement);
+  assert(form instanceof joinPage.window.HTMLFormElement);
+
+  nicknameInput.value = "Cy";
+  nicknameInput.dispatchEvent(new joinPage.window.Event("input", { bubbles: true }));
+  dispatchSubmit(form);
+  await flushAsync();
+
+  const player = [...apiState.players.values()][0];
+  assert(player);
+  assert.equal(player.nickname, "Cy");
+  assert.equal(apiState.gamePlayers.has(`game-join-1:${player.playerId}`), true);
+  assert.equal(joinPage.document.getElementById("join-result")?.hidden, false);
+  assert.equal(joinPage.document.getElementById("join-result-player")?.textContent, "Cy");
+  assert.equal(joinPage.document.getElementById("join-result-game")?.textContent, "game-join-1");
 });

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -3633,9 +3633,33 @@ test("join page registers a player without organizer authentication", async () =
   assert.equal(player.nickname, "Cy");
   assert.equal(apiState.lastPublicJoinRequest?.body.nickname, "Cy");
   assert.equal("playerId" in (apiState.lastPublicJoinRequest?.body ?? {}), false);
-  assert.match(apiState.lastPublicJoinRequest?.idempotencyKey ?? "", /^join-player-JOIN0001-Cy-/);
+  const firstJoinKey = apiState.lastPublicJoinRequest?.idempotencyKey ?? "";
+  assert.match(firstJoinKey, /^join-player-JOIN0001-Cy-/);
+  assert.equal(apiState.storage.has("threefc-idempotency:join-player:JOIN0001-Cy"), false);
   assert.equal(apiState.gamePlayers.has(`game-join-1:${player.playerId}`), true);
   assert.equal(joinPage.document.getElementById("join-result")?.hidden, false);
   assert.equal(joinPage.document.getElementById("join-result-player")?.textContent, "Cy");
   assert.equal(joinPage.document.getElementById("join-result-game")?.textContent, "game-join-1");
+
+  const secondJoinPage = await bootPage({
+    html: renderJoinPage("http://localhost:3001", "join0001"),
+    url: "http://localhost:3000/join/join0001",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+  const secondNicknameInput = secondJoinPage.document.getElementById("join-player-nickname");
+  const secondForm = secondJoinPage.document.getElementById("join-game-form");
+  assert(secondNicknameInput instanceof secondJoinPage.window.HTMLInputElement);
+  assert(secondForm instanceof secondJoinPage.window.HTMLFormElement);
+
+  secondNicknameInput.value = "Cy";
+  secondNicknameInput.dispatchEvent(new secondJoinPage.window.Event("input", { bubbles: true }));
+  dispatchSubmit(secondForm);
+  await flushAsync();
+
+  const secondJoinKey = apiState.lastPublicJoinRequest?.idempotencyKey ?? "";
+  assert.match(secondJoinKey, /^join-player-JOIN0001-Cy-/);
+  assert.notEqual(secondJoinKey, firstJoinKey);
+  assert.equal(apiState.players.size, 2);
+  assert.equal(apiState.storage.has("threefc-idempotency:join-player:JOIN0001-Cy"), false);
 });

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -3107,6 +3107,7 @@ test("setup smoke completes live game through finish", async () => {
   const statusInput = gamePage.document.getElementById("game-edit-status");
   const joinCodeValue = gamePage.document.getElementById("game-join-code-value");
   const joinLink = gamePage.document.getElementById("game-join-link");
+  const joinQr = gamePage.document.getElementById("game-join-qr");
   const scoreboard = gamePage.document.getElementById("live-scoreboard");
   const goalFormNote = gamePage.document.getElementById("goal-form-note");
   const resultSummary = gamePage.document.getElementById("game-result-summary");
@@ -3125,13 +3126,18 @@ test("setup smoke completes live game through finish", async () => {
   assert(statusInput instanceof gamePage.window.HTMLSelectElement);
   assert(joinCodeValue instanceof gamePage.window.HTMLElement);
   assert(joinLink instanceof gamePage.window.HTMLAnchorElement);
+  assert(joinQr instanceof gamePage.window.HTMLElement);
   assert(scoreboard instanceof gamePage.window.HTMLElement);
   assert(goalFormNote instanceof gamePage.window.HTMLElement);
   assert(resultSummary instanceof gamePage.window.HTMLElement);
   assert.equal(finishGameButton.disabled, true);
   assert.equal(joinCodeValue.textContent, "SMOKE123");
-  assert.equal(joinLink.getAttribute("href"), "/join/SMOKE123");
-  assert.equal(joinLink.textContent, "/join/SMOKE123");
+  assert.equal(joinLink.getAttribute("href"), "http://localhost:3000/join/SMOKE123");
+  assert.equal(joinLink.textContent, "http://localhost:3000/join/SMOKE123");
+  const joinQrSvg = joinQr.querySelector("svg");
+  assert(joinQrSvg instanceof gamePage.window.SVGElement);
+  assert.equal(joinQrSvg.getAttribute("aria-label"), "Join QR code for http://localhost:3000/join/SMOKE123");
+  assert.match(joinQrSvg.innerHTML, /<path/);
   assert.equal(resultSummary.hidden, true);
 
   nicknameInput.value = "Ari";

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -3663,3 +3663,84 @@ test("join page registers a player without organizer authentication", async () =
   assert.equal(apiState.players.size, 2);
   assert.equal(apiState.storage.has("threefc-idempotency:join-player:JOIN0001-Cy"), false);
 });
+
+test("join page preserves distinct retry keys for similar public nicknames", async () => {
+  const apiState = createMockApiState();
+  apiState.games.set("game-join-1", {
+    gameId: "game-join-1",
+    joinCode: "JOIN0001",
+    leagueId: "autumn-league",
+    seasonId: "autumn-cup",
+    sessionId: "20260328",
+    status: "scheduled",
+    gameStartTs: "2026-03-28T10:00:00.000Z",
+    thirdLengthMinutes: DEFAULT_THIRD_LENGTH_MINUTES,
+    thirds: createDefaultThirdTimerSegments(),
+    finishedAt: null,
+    result: null,
+    createdAt: "2026-03-28T11:00:03.000Z",
+    updatedAt: "2026-03-28T11:00:03.000Z",
+  });
+
+  const defaultFetch = createMockFetch(apiState);
+  const requestedKeys: string[] = [];
+  const failingJoinFetch: ReturnType<typeof createMockFetch> = async (input, init = {}) => {
+    const target =
+      typeof input === "string" || input instanceof URL
+        ? new URL(String(input))
+        : new URL(input.url);
+    const method = (init.method ?? "GET").toUpperCase();
+
+    if (method === "POST" && target.pathname === "/v1/join/JOIN0001") {
+      const idempotencyKey = readInitHeader(init, "idempotency-key");
+      if (idempotencyKey) {
+        requestedKeys.push(idempotencyKey);
+      }
+      return createJsonResponse(503, {
+        error: "temporary_failure",
+        message: "Temporary failure.",
+      });
+    }
+
+    return defaultFetch(input, init);
+  };
+
+  const firstJoinPage = await bootPage({
+    html: renderJoinPage("http://localhost:3001", "join0001"),
+    url: "http://localhost:3000/join/join0001",
+    scriptFile: "setup-flow.js",
+    apiState,
+    fetch: failingJoinFetch,
+  });
+  const firstNicknameInput = firstJoinPage.document.getElementById("join-player-nickname");
+  const firstForm = firstJoinPage.document.getElementById("join-game-form");
+  assert(firstNicknameInput instanceof firstJoinPage.window.HTMLInputElement);
+  assert(firstForm instanceof firstJoinPage.window.HTMLFormElement);
+
+  firstNicknameInput.value = "A B";
+  firstNicknameInput.dispatchEvent(new firstJoinPage.window.Event("input", { bubbles: true }));
+  dispatchSubmit(firstForm);
+  await flushAsync();
+
+  const secondJoinPage = await bootPage({
+    html: renderJoinPage("http://localhost:3001", "join0001"),
+    url: "http://localhost:3000/join/join0001",
+    scriptFile: "setup-flow.js",
+    apiState,
+    fetch: failingJoinFetch,
+  });
+  const secondNicknameInput = secondJoinPage.document.getElementById("join-player-nickname");
+  const secondForm = secondJoinPage.document.getElementById("join-game-form");
+  assert(secondNicknameInput instanceof secondJoinPage.window.HTMLInputElement);
+  assert(secondForm instanceof secondJoinPage.window.HTMLFormElement);
+
+  secondNicknameInput.value = "A-B";
+  secondNicknameInput.dispatchEvent(new secondJoinPage.window.Event("input", { bubbles: true }));
+  dispatchSubmit(secondForm);
+  await flushAsync();
+
+  assert.equal(requestedKeys.length, 2);
+  assert.notEqual(requestedKeys[0], requestedKeys[1]);
+  assert.equal(apiState.storage.get("threefc-idempotency:join-player:JOIN0001-A%20B"), requestedKeys[0]);
+  assert.equal(apiState.storage.get("threefc-idempotency:join-player:JOIN0001-A-B"), requestedKeys[1]);
+});

--- a/app/src/tests/static-export.test.ts
+++ b/app/src/tests/static-export.test.ts
@@ -3,8 +3,26 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import test from "node:test";
+import { createContext, Script } from "node:vm";
 
 import { buildStaticSite } from "../static-export.js";
+
+function runCloudFrontRouter(uri: string): string {
+  const source = readFileSync(resolve(process.cwd(), "../infra/application/cloudfront-site-router.js"), "utf8");
+  const context = createContext({
+    event: {
+      request: { uri },
+    },
+    result: null,
+  });
+  new Script(`${source}\nresult = handler(event);`).runInContext(context);
+
+  const result = context.result as { uri?: string } | null;
+  if (!result?.uri) {
+    throw new Error(`CloudFront router did not return a request for ${uri}.`);
+  }
+  return result.uri;
+}
 
 test("buildStaticSite exports static route shells and ui assets", () => {
   const outputDir = mkdtempSync(resolve(tmpdir(), "3fc-static-site-"));
@@ -44,4 +62,10 @@ test("buildStaticSite exports static route shells and ui assets", () => {
   } finally {
     rmSync(outputDir, { recursive: true, force: true });
   }
+});
+
+test("CloudFront router maps deployed join deep links to the exported shell", () => {
+  assert.equal(runCloudFrontRouter("/join"), "/join/index.html");
+  assert.equal(runCloudFrontRouter("/join/ABCD2345"), "/join/index.html");
+  assert.equal(runCloudFrontRouter("/ui/setup-flow.js"), "/ui/setup-flow.js");
 });

--- a/app/src/tests/static-export.test.ts
+++ b/app/src/tests/static-export.test.ts
@@ -23,6 +23,7 @@ test("buildStaticSite exports static route shells and ui assets", () => {
     assert.equal(existsSync(resolve(outputDir, "leagues/index.html")), true);
     assert.equal(existsSync(resolve(outputDir, "seasons/index.html")), true);
     assert.equal(existsSync(resolve(outputDir, "games/index.html")), true);
+    assert.equal(existsSync(resolve(outputDir, "join/index.html")), true);
     assert.equal(existsSync(resolve(outputDir, "ui/styles.css")), true);
     assert.equal(existsSync(resolve(outputDir, "ui/setup-flow.js")), true);
     assert.equal(existsSync(resolve(outputDir, "ui/auth-flow.js")), true);
@@ -36,6 +37,10 @@ test("buildStaticSite exports static route shells and ui assets", () => {
     const leagueHtml = readFileSync(resolve(outputDir, "leagues/index.html"), "utf8");
     assert.match(leagueHtml, /data-page="league"/);
     assert.match(leagueHtml, /data-league-id=""/);
+
+    const joinHtml = readFileSync(resolve(outputDir, "join/index.html"), "utf8");
+    assert.match(joinHtml, /data-page="join"/);
+    assert.match(joinHtml, /data-join-code=""/);
   } finally {
     rmSync(outputDir, { recursive: true, force: true });
   }

--- a/app/src/tests/ui-layout.test.ts
+++ b/app/src/tests/ui-layout.test.ts
@@ -4,6 +4,7 @@ import test from "node:test";
 import {
   renderComponentShowcasePage,
   renderGamePage,
+  renderJoinPage,
   renderLeaguePage,
   renderMagicLinkCallbackPage,
   renderSeasonPage,
@@ -194,6 +195,7 @@ test("game page renders editable game metadata view", () => {
   assert.match(html, /data-page="game"/);
   assert.match(html, /game-20260223-a1b2c3d4/);
   assert.match(html, /data-testid="game-join-code-value"/);
+  assert.match(html, /data-testid="game-join-link"/);
   assert.match(html, /data-testid="save-game"/);
   assert.match(html, /data-testid="delete-game"/);
   assert.match(html, /data-testid="create-another-game"/);
@@ -221,4 +223,17 @@ test("game page renders editable game metadata view", () => {
   assert.match(html, /data-testid="panel-game-roster"/);
   assert.match(html, /data-testid="quick-create-player"/);
   assert.match(html, /data-testid="roster-teams"/);
+});
+
+test("join page renders player registration shell", () => {
+  const html = renderJoinPage("https://qa-api.3fc.football", "join0001");
+
+  assert.match(html, /data-testid="join-shell"/);
+  assert.match(html, /data-page="join"/);
+  assert.match(html, /data-join-code="join0001"/);
+  assert.match(html, /data-testid="join-code-value"/);
+  assert.match(html, /JOIN GAME|Join game/);
+  assert.match(html, /id="join-player-nickname"/);
+  assert.match(html, /data-testid="join-game"/);
+  assert.match(html, /data-testid="join-result"/);
 });

--- a/app/src/tests/ui-layout.test.ts
+++ b/app/src/tests/ui-layout.test.ts
@@ -193,6 +193,7 @@ test("game page renders editable game metadata view", () => {
   assert.match(html, /data-testid="game-shell"/);
   assert.match(html, /data-page="game"/);
   assert.match(html, /game-20260223-a1b2c3d4/);
+  assert.match(html, /data-testid="game-join-code-value"/);
   assert.match(html, /data-testid="save-game"/);
   assert.match(html, /data-testid="delete-game"/);
   assert.match(html, /data-testid="create-another-game"/);

--- a/app/src/tests/ui-layout.test.ts
+++ b/app/src/tests/ui-layout.test.ts
@@ -196,6 +196,7 @@ test("game page renders editable game metadata view", () => {
   assert.match(html, /game-20260223-a1b2c3d4/);
   assert.match(html, /data-testid="game-join-code-value"/);
   assert.match(html, /data-testid="game-join-link"/);
+  assert.match(html, /data-testid="game-join-qr"/);
   assert.match(html, /data-testid="save-game"/);
   assert.match(html, /data-testid="delete-game"/);
   assert.match(html, /data-testid="create-another-game"/);

--- a/app/src/ui/layout.ts
+++ b/app/src/ui/layout.ts
@@ -738,6 +738,7 @@ export function renderGamePage(apiBaseUrl: string, input: GameContextPageInput):
               <div><dt>Game ID</dt><dd id="game-id-value">${gameHeading}</dd></div>
               <div><dt>Join code</dt><dd id="game-join-code-value" data-testid="game-join-code-value">Loading…</dd></div>
               <div><dt>Join link</dt><dd><a id="game-join-link" data-testid="game-join-link" href="/join">Loading…</a></dd></div>
+              <div data-ui="join-qr-row"><dt>Join QR</dt><dd id="game-join-qr" data-ui="join-qr" data-testid="game-join-qr">Loading…</dd></div>
               <div><dt>League ID</dt><dd id="game-league-id">Loading…</dd></div>
               <div><dt>Season ID</dt><dd id="game-season-id">Loading…</dd></div>
             </dl>

--- a/app/src/ui/layout.ts
+++ b/app/src/ui/layout.ts
@@ -643,6 +643,64 @@ export function renderMagicLinkCallbackPage(apiBaseUrl: string): string {
 </html>`;
 }
 
+export function renderJoinPage(apiBaseUrl: string, joinCode: string): string {
+  const safeJoinCode = escapeHtml(joinCode);
+  const joinHeading = safeJoinCode.length > 0 ? safeJoinCode : "Join game";
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>3FC Join</title>
+    ${renderStylesheetLink()}
+  </head>
+  <body data-api-base-url="${escapeHtml(apiBaseUrl)}">
+    <main data-ui="app-shell" data-testid="join-shell" data-api-base-url="${escapeHtml(apiBaseUrl)}">
+      <section data-ui="hero">
+        <span data-ui="hero-kicker">3FC Join</span>
+        <h1>Join game</h1>
+        <p data-ui="hero-copy">Code <code>${joinHeading}</code></p>
+      </section>
+      <section data-ui="setup-flow" id="setup-flow-root" data-testid="setup-flow-root" data-page="join" data-api-base-url="${escapeHtml(apiBaseUrl)}" data-join-code="${safeJoinCode}">
+        <p data-ui="status-note" id="setup-status">Ready.</p>
+        <p data-ui="status-note" data-state="error" id="setup-error" hidden></p>
+        <section data-ui="panel-grid" data-testid="join-grid">
+          ${renderPanel(
+            "Player registration",
+            "Enter the name that should appear on the scorekeeper roster.",
+            `<dl data-ui="id-preview" data-testid="join-context-details">
+              <div><dt>Join code</dt><dd id="join-code-value" data-testid="join-code-value">${joinHeading}</dd></div>
+            </dl>
+            <form data-ui="auth-form" id="join-game-form" novalidate>
+              ${renderValidatedField({
+                id: "join-player-nickname",
+                label: "Nickname",
+                placeholder: "Ari",
+                required: true,
+                hint: "Use the name the scorekeeper expects.",
+              })}
+              <div data-ui="button-row">${renderButton("Join game", "primary", {
+                type: "submit",
+                "data-action": "join-game",
+                "data-testid": "join-game",
+              })}</div>
+            </form>
+            <dl data-ui="id-preview" data-testid="join-result" id="join-result" hidden>
+              <div><dt>Player</dt><dd id="join-result-player"></dd></div>
+              <div><dt>Game</dt><dd id="join-result-game"></dd></div>
+            </dl>`,
+            "",
+            "panel-join-player",
+          )}
+        </section>
+      </section>
+    </main>
+    ${renderSetupScriptTag()}
+  </body>
+</html>`;
+}
+
 export interface GameContextPageInput {
   gameId: string;
   leagueId?: string;
@@ -679,6 +737,7 @@ export function renderGamePage(apiBaseUrl: string, input: GameContextPageInput):
             `<dl data-ui="id-preview" data-testid="game-context-details">
               <div><dt>Game ID</dt><dd id="game-id-value">${gameHeading}</dd></div>
               <div><dt>Join code</dt><dd id="game-join-code-value" data-testid="game-join-code-value">Loading…</dd></div>
+              <div><dt>Join link</dt><dd><a id="game-join-link" data-testid="game-join-link" href="/join">Loading…</a></dd></div>
               <div><dt>League ID</dt><dd id="game-league-id">Loading…</dd></div>
               <div><dt>Season ID</dt><dd id="game-season-id">Loading…</dd></div>
             </dl>

--- a/app/src/ui/layout.ts
+++ b/app/src/ui/layout.ts
@@ -678,6 +678,7 @@ export function renderGamePage(apiBaseUrl: string, input: GameContextPageInput):
             "Edit core game metadata.",
             `<dl data-ui="id-preview" data-testid="game-context-details">
               <div><dt>Game ID</dt><dd id="game-id-value">${gameHeading}</dd></div>
+              <div><dt>Join code</dt><dd id="game-join-code-value" data-testid="game-join-code-value">Loading…</dd></div>
               <div><dt>League ID</dt><dd id="game-league-id">Loading…</dd></div>
               <div><dt>Season ID</dt><dd id="game-season-id">Loading…</dd></div>
             </dl>

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -1036,6 +1036,7 @@
 
     const gameIdValue = document.getElementById("game-id-value");
     const gameJoinCodeValue = document.getElementById("game-join-code-value");
+    const gameJoinLink = document.getElementById("game-join-link");
     const gameLeagueId = document.getElementById("game-league-id");
     const gameSeasonId = document.getElementById("game-season-id");
 
@@ -2081,8 +2082,19 @@
         gameIdValue.textContent = game.gameId;
       }
       if (gameJoinCodeValue) {
-        gameJoinCodeValue.textContent =
-          typeof game.joinCode === "string" && game.joinCode.length > 0 ? game.joinCode : "Unavailable";
+        gameJoinCodeValue.textContent = typeof game.joinCode === "string" && game.joinCode.length > 0
+          ? game.joinCode
+          : "Unavailable";
+      }
+      if (gameJoinLink instanceof HTMLAnchorElement) {
+        if (typeof game.joinCode === "string" && game.joinCode.length > 0) {
+          const joinPath = `/join/${encodeURIComponent(game.joinCode)}`;
+          gameJoinLink.href = joinPath;
+          gameJoinLink.textContent = joinPath;
+        } else {
+          gameJoinLink.href = "/join";
+          gameJoinLink.textContent = "Unavailable";
+        }
       }
       if (gameLeagueId) {
         gameLeagueId.textContent = game.leagueId;
@@ -2661,8 +2673,105 @@
     }
   }
 
+  async function initJoinPage() {
+    const routeJoinCode = resolveRouteEntityId("data-join-code", "join") ?? "";
+    const joinCode = routeJoinCode.trim().toUpperCase();
+    const joinCodeValue = document.getElementById("join-code-value");
+    const form = document.getElementById("join-game-form");
+    const nicknameInput = document.getElementById("join-player-nickname");
+    const joinButton = root.querySelector('[data-action="join-game"]');
+    const resultElement = document.getElementById("join-result");
+    const resultPlayer = document.getElementById("join-result-player");
+    const resultGame = document.getElementById("join-result-game");
+
+    if (joinCodeValue) {
+      joinCodeValue.textContent = joinCode || "Missing";
+    }
+
+    if (!joinCode) {
+      setStatus("Join code missing.", "error");
+      showError("Open a join link from a game page.");
+      return;
+    }
+
+    if (!(form instanceof HTMLFormElement) || !(nicknameInput instanceof HTMLInputElement)) {
+      setStatus("Join form unavailable.", "error");
+      return;
+    }
+
+    nicknameInput.addEventListener("input", () => {
+      clearError();
+      setFieldMessage("join-player-nickname");
+    });
+
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      clearError();
+
+      const nickname = nicknameInput.value.trim();
+      if (!nickname) {
+        setFieldMessage("join-player-nickname", "invalid", "Nickname is required.");
+        setStatus("Nickname required.", "error");
+        return;
+      }
+
+      if (joinButton instanceof HTMLButtonElement) {
+        joinButton.disabled = true;
+      }
+      nicknameInput.disabled = true;
+      setStatus("Joining game...", "default");
+
+      try {
+        const playerId = createIdempotencyKey("join-player", `${joinCode}-${nickname}`);
+        const result = await requestJsonOrThrow(`/v1/join/${encodeURIComponent(joinCode)}`, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            playerId,
+            nickname,
+          }),
+        });
+
+        setFieldMessage("join-player-nickname", "valid", "Joined.");
+        setStatus("Joined game.", "success");
+        if (resultPlayer) {
+          resultPlayer.textContent = result?.player?.nickname ?? nickname;
+        }
+        if (resultGame) {
+          resultGame.textContent = result?.gameId ?? "";
+        }
+        if (resultElement) {
+          resultElement.hidden = false;
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Could not join game.";
+        showError(message);
+        setStatus("Join failed.", "error");
+        nicknameInput.disabled = false;
+        if (joinButton instanceof HTMLButtonElement) {
+          joinButton.disabled = false;
+        }
+      }
+    });
+
+    setStatus("Join page ready.", "success");
+  }
+
   async function initialize() {
     clearError();
+
+    if (page === "join") {
+      try {
+        await initJoinPage();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Unexpected join page error.";
+        showError(message);
+        setStatus("Page load failed.", "error");
+      }
+      return;
+    }
 
     try {
       await ensureAuthenticatedSession();

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -192,6 +192,273 @@
     return `${prefix}-${safeStable}-${Date.now().toString(36)}-${nonce}`;
   }
 
+  const JOIN_QR_VERSION = 5;
+  const JOIN_QR_SIZE = 21 + 4 * (JOIN_QR_VERSION - 1);
+  const JOIN_QR_DATA_CODEWORDS = 108;
+  const JOIN_QR_EC_CODEWORDS = 26;
+  const JOIN_QR_ALIGNMENT_CENTER = 30;
+  const JOIN_QR_MAX_BYTES = 106;
+
+  function utf8Bytes(value) {
+    try {
+      if (typeof TextEncoder === "function") {
+        return Array.from(new TextEncoder().encode(value));
+      }
+    } catch {
+      // Fall through to the percent-encoding path.
+    }
+
+    const encoded = encodeURIComponent(value);
+    const bytes = [];
+    for (let index = 0; index < encoded.length; index += 1) {
+      if (encoded[index] === "%") {
+        bytes.push(Number.parseInt(encoded.slice(index + 1, index + 3), 16));
+        index += 2;
+      } else {
+        bytes.push(encoded.charCodeAt(index));
+      }
+    }
+    return bytes;
+  }
+
+  function appendQrBits(bits, value, length) {
+    for (let index = length - 1; index >= 0; index -= 1) {
+      bits.push(((value >>> index) & 1) === 1);
+    }
+  }
+
+  function qrMultiply(left, right) {
+    let result = 0;
+    let a = left;
+    let b = right;
+
+    while (b > 0) {
+      if ((b & 1) !== 0) {
+        result ^= a;
+      }
+      a <<= 1;
+      if ((a & 0x100) !== 0) {
+        a ^= 0x11d;
+      }
+      b >>>= 1;
+    }
+
+    return result;
+  }
+
+  function qrReedSolomonDivisor(degree) {
+    const result = new Array(degree).fill(0);
+    result[degree - 1] = 1;
+    let root = 1;
+
+    for (let index = 0; index < degree; index += 1) {
+      for (let resultIndex = 0; resultIndex < result.length; resultIndex += 1) {
+        result[resultIndex] = qrMultiply(result[resultIndex], root);
+        if (resultIndex + 1 < result.length) {
+          result[resultIndex] ^= result[resultIndex + 1];
+        }
+      }
+      root = qrMultiply(root, 0x02);
+    }
+
+    return result;
+  }
+
+  function qrReedSolomonRemainder(data, divisor) {
+    const result = new Array(divisor.length).fill(0);
+
+    for (const byte of data) {
+      const factor = byte ^ result.shift();
+      result.push(0);
+      for (let index = 0; index < divisor.length; index += 1) {
+        result[index] ^= qrMultiply(divisor[index], factor);
+      }
+    }
+
+    return result;
+  }
+
+  function qrFormatBits(mask) {
+    const data = (1 << 3) | mask;
+    let remainder = data << 10;
+
+    for (let index = 14; index >= 10; index -= 1) {
+      if (((remainder >>> index) & 1) !== 0) {
+        remainder ^= 0x537 << (index - 10);
+      }
+    }
+
+    return ((data << 10) | (remainder & 0x3ff)) ^ 0x5412;
+  }
+
+  function qrDataCodewords(value) {
+    const bytes = utf8Bytes(value);
+    if (bytes.length > JOIN_QR_MAX_BYTES) {
+      return null;
+    }
+
+    const bits = [];
+    appendQrBits(bits, 0x4, 4);
+    appendQrBits(bits, bytes.length, 8);
+    for (const byte of bytes) {
+      appendQrBits(bits, byte, 8);
+    }
+
+    const capacity = JOIN_QR_DATA_CODEWORDS * 8;
+    const terminatorLength = Math.min(4, capacity - bits.length);
+    for (let index = 0; index < terminatorLength; index += 1) {
+      bits.push(false);
+    }
+    while (bits.length % 8 !== 0) {
+      bits.push(false);
+    }
+
+    const codewords = [];
+    for (let index = 0; index < bits.length; index += 8) {
+      let byte = 0;
+      for (let bit = 0; bit < 8; bit += 1) {
+        byte = (byte << 1) | (bits[index + bit] ? 1 : 0);
+      }
+      codewords.push(byte);
+    }
+
+    const pads = [0xec, 0x11];
+    let padIndex = 0;
+    while (codewords.length < JOIN_QR_DATA_CODEWORDS) {
+      codewords.push(pads[padIndex % pads.length]);
+      padIndex += 1;
+    }
+
+    return codewords;
+  }
+
+  function createJoinQrSvg(value) {
+    const data = qrDataCodewords(value);
+    if (!data) {
+      return "";
+    }
+
+    const modules = Array.from({ length: JOIN_QR_SIZE }, () => new Array(JOIN_QR_SIZE).fill(false));
+    const reserved = Array.from({ length: JOIN_QR_SIZE }, () => new Array(JOIN_QR_SIZE).fill(false));
+
+    function setFunctionModule(x, y, isDark) {
+      if (x < 0 || y < 0 || x >= JOIN_QR_SIZE || y >= JOIN_QR_SIZE) {
+        return;
+      }
+      modules[y][x] = isDark;
+      reserved[y][x] = true;
+    }
+
+    function drawFinder(centerX, centerY) {
+      for (let dy = -4; dy <= 4; dy += 1) {
+        for (let dx = -4; dx <= 4; dx += 1) {
+          const distance = Math.max(Math.abs(dx), Math.abs(dy));
+          setFunctionModule(centerX + dx, centerY + dy, distance !== 2 && distance !== 4);
+        }
+      }
+    }
+
+    function drawAlignment(centerX, centerY) {
+      for (let dy = -2; dy <= 2; dy += 1) {
+        for (let dx = -2; dx <= 2; dx += 1) {
+          setFunctionModule(centerX + dx, centerY + dy, Math.max(Math.abs(dx), Math.abs(dy)) !== 1);
+        }
+      }
+    }
+
+    function drawFormat(mask) {
+      const bits = qrFormatBits(mask);
+      const bit = (index) => ((bits >>> index) & 1) !== 0;
+
+      for (let index = 0; index <= 5; index += 1) {
+        setFunctionModule(8, index, bit(index));
+      }
+      setFunctionModule(8, 7, bit(6));
+      setFunctionModule(8, 8, bit(7));
+      setFunctionModule(7, 8, bit(8));
+      for (let index = 9; index < 15; index += 1) {
+        setFunctionModule(14 - index, 8, bit(index));
+      }
+
+      for (let index = 0; index < 8; index += 1) {
+        setFunctionModule(JOIN_QR_SIZE - 1 - index, 8, bit(index));
+      }
+      for (let index = 8; index < 15; index += 1) {
+        setFunctionModule(8, JOIN_QR_SIZE - 15 + index, bit(index));
+      }
+    }
+
+    drawFinder(3, 3);
+    drawFinder(JOIN_QR_SIZE - 4, 3);
+    drawFinder(3, JOIN_QR_SIZE - 4);
+    drawAlignment(JOIN_QR_ALIGNMENT_CENTER, JOIN_QR_ALIGNMENT_CENTER);
+    for (let index = 0; index < JOIN_QR_SIZE; index += 1) {
+      if (!reserved[6][index]) {
+        setFunctionModule(index, 6, index % 2 === 0);
+      }
+      if (!reserved[index][6]) {
+        setFunctionModule(6, index, index % 2 === 0);
+      }
+    }
+    setFunctionModule(8, JOIN_QR_SIZE - 8, true);
+    drawFormat(0);
+
+    const divisor = qrReedSolomonDivisor(JOIN_QR_EC_CODEWORDS);
+    const codewords = [...data, ...qrReedSolomonRemainder(data, divisor)];
+    const dataBits = [];
+    for (const codeword of codewords) {
+      appendQrBits(dataBits, codeword, 8);
+    }
+
+    let bitIndex = 0;
+    let upward = true;
+    for (let right = JOIN_QR_SIZE - 1; right >= 1; right -= 2) {
+      if (right === 6) {
+        right -= 1;
+      }
+
+      for (let vertical = 0; vertical < JOIN_QR_SIZE; vertical += 1) {
+        const y = upward ? JOIN_QR_SIZE - 1 - vertical : vertical;
+        for (let dx = 0; dx < 2; dx += 1) {
+          const x = right - dx;
+          if (reserved[y][x]) {
+            continue;
+          }
+          let isDark = bitIndex < dataBits.length ? dataBits[bitIndex] : false;
+          bitIndex += 1;
+          if ((x + y) % 2 === 0) {
+            isDark = !isDark;
+          }
+          modules[y][x] = isDark;
+        }
+      }
+      upward = !upward;
+    }
+
+    const quiet = 4;
+    const viewBoxSize = JOIN_QR_SIZE + quiet * 2;
+    let path = "";
+    for (let y = 0; y < JOIN_QR_SIZE; y += 1) {
+      for (let x = 0; x < JOIN_QR_SIZE; x += 1) {
+        if (modules[y][x]) {
+          path += `M${x + quiet} ${y + quiet}h1v1h-1z`;
+        }
+      }
+    }
+
+    const label = escapeHtml(`Join QR code for ${value}`);
+    return `<svg data-ui="join-qr-svg" viewBox="0 0 ${viewBoxSize} ${viewBoxSize}" role="img" aria-label="${label}" xmlns="http://www.w3.org/2000/svg"><rect width="100%" height="100%" fill="#fff"/><path d="${path}" fill="#111"/></svg>`;
+  }
+
+  function renderJoinQrCode(container, joinUrl) {
+    if (!(container instanceof HTMLElement)) {
+      return;
+    }
+
+    const svg = createJoinQrSvg(joinUrl);
+    container.innerHTML = svg || "QR unavailable";
+  }
+
   function encodeStablePartForStorage(stablePart) {
     try {
       return encodeURIComponent(stablePart);
@@ -1093,6 +1360,7 @@
     const gameIdValue = document.getElementById("game-id-value");
     const gameJoinCodeValue = document.getElementById("game-join-code-value");
     const gameJoinLink = document.getElementById("game-join-link");
+    const gameJoinQr = document.getElementById("game-join-qr");
     const gameLeagueId = document.getElementById("game-league-id");
     const gameSeasonId = document.getElementById("game-season-id");
 
@@ -2145,11 +2413,16 @@
       if (gameJoinLink instanceof HTMLAnchorElement) {
         if (typeof game.joinCode === "string" && game.joinCode.length > 0) {
           const joinPath = `/join/${encodeURIComponent(game.joinCode)}`;
-          gameJoinLink.href = joinPath;
-          gameJoinLink.textContent = joinPath;
+          const joinUrl = new URL(joinPath, window.location.origin).toString();
+          gameJoinLink.href = joinUrl;
+          gameJoinLink.textContent = joinUrl;
+          renderJoinQrCode(gameJoinQr, joinUrl);
         } else {
           gameJoinLink.href = "/join";
           gameJoinLink.textContent = "Unavailable";
+          if (gameJoinQr instanceof HTMLElement) {
+            gameJoinQr.textContent = "Unavailable";
+          }
         }
       }
       if (gameLeagueId) {

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -192,9 +192,20 @@
     return `${prefix}-${safeStable}-${Date.now().toString(36)}-${nonce}`;
   }
 
+  function encodeStablePartForStorage(stablePart) {
+    try {
+      return encodeURIComponent(stablePart);
+    } catch {
+      let encoded = "";
+      for (let index = 0; index < stablePart.length; index += 1) {
+        encoded += stablePart.charCodeAt(index).toString(16).padStart(4, "0");
+      }
+      return `utf16-${encoded}`;
+    }
+  }
+
   function idempotencyStorageKey(prefix, stablePart) {
-    const safeStable = stablePart.replace(/[^a-zA-Z0-9-]+/g, "-").slice(0, 96);
-    return `threefc-idempotency:${prefix}:${safeStable}`;
+    return `threefc-idempotency:${prefix}:${encodeStablePartForStorage(stablePart)}`;
   }
 
   function cachedIdempotencyKey(prefix, stablePart) {

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -1035,6 +1035,7 @@
     const gameSeasonLink = document.getElementById("game-season-link");
 
     const gameIdValue = document.getElementById("game-id-value");
+    const gameJoinCodeValue = document.getElementById("game-join-code-value");
     const gameLeagueId = document.getElementById("game-league-id");
     const gameSeasonId = document.getElementById("game-season-id");
 
@@ -2078,6 +2079,10 @@
 
       if (gameIdValue) {
         gameIdValue.textContent = game.gameId;
+      }
+      if (gameJoinCodeValue) {
+        gameJoinCodeValue.textContent =
+          typeof game.joinCode === "string" && game.joinCode.length > 0 ? game.joinCode : "Unavailable";
       }
       if (gameLeagueId) {
         gameLeagueId.textContent = game.leagueId;

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -186,12 +186,19 @@
 
   function createIdempotencyKey(prefix, stablePart) {
     const safeStable = stablePart.replace(/[^a-zA-Z0-9-]+/g, "-").slice(0, 56);
-    return `${prefix}-${safeStable}-${Date.now().toString(36)}`;
+    const nonce =
+      window.crypto?.randomUUID?.().replace(/-/g, "").slice(0, 8) ??
+      Math.random().toString(36).slice(2, 10);
+    return `${prefix}-${safeStable}-${Date.now().toString(36)}-${nonce}`;
+  }
+
+  function idempotencyStorageKey(prefix, stablePart) {
+    const safeStable = stablePart.replace(/[^a-zA-Z0-9-]+/g, "-").slice(0, 96);
+    return `threefc-idempotency:${prefix}:${safeStable}`;
   }
 
   function cachedIdempotencyKey(prefix, stablePart) {
-    const safeStable = stablePart.replace(/[^a-zA-Z0-9-]+/g, "-").slice(0, 96);
-    const storageKey = `threefc-idempotency:${prefix}:${safeStable}`;
+    const storageKey = idempotencyStorageKey(prefix, stablePart);
 
     try {
       const existing = window.localStorage?.getItem(storageKey);
@@ -207,11 +214,24 @@
     }
   }
 
+  function clearCachedIdempotencyKey(prefix, stablePart) {
+    try {
+      window.localStorage?.removeItem(idempotencyStorageKey(prefix, stablePart));
+    } catch {
+      // Ignore storage failures; the next uncached request still gets a fresh key.
+    }
+  }
+
+  function publicJoinIdempotencyStablePart(joinCode, nickname) {
+    return `${joinCode.trim().toUpperCase()}-${nickname.trim()}`;
+  }
+
   function idempotencyKeyForPublicJoin(joinCode, nickname) {
-    return cachedIdempotencyKey(
-      "join-player",
-      `${joinCode.trim().toUpperCase()}-${nickname.trim()}`,
-    );
+    return cachedIdempotencyKey("join-player", publicJoinIdempotencyStablePart(joinCode, nickname));
+  }
+
+  function clearIdempotencyKeyForPublicJoin(joinCode, nickname) {
+    clearCachedIdempotencyKey("join-player", publicJoinIdempotencyStablePart(joinCode, nickname));
   }
 
   async function requestJson(path, init = {}) {
@@ -2758,6 +2778,7 @@
           }),
         });
 
+        clearIdempotencyKeyForPublicJoin(joinCode, nickname);
         setFieldMessage("join-player-nickname", "valid", "Joined.");
         setStatus("Joined game.", "success");
         if (resultPlayer) {

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -189,6 +189,31 @@
     return `${prefix}-${safeStable}-${Date.now().toString(36)}`;
   }
 
+  function cachedIdempotencyKey(prefix, stablePart) {
+    const safeStable = stablePart.replace(/[^a-zA-Z0-9-]+/g, "-").slice(0, 96);
+    const storageKey = `threefc-idempotency:${prefix}:${safeStable}`;
+
+    try {
+      const existing = window.localStorage?.getItem(storageKey);
+      if (existing) {
+        return existing;
+      }
+
+      const next = createIdempotencyKey(prefix, stablePart);
+      window.localStorage?.setItem(storageKey, next);
+      return next;
+    } catch {
+      return createIdempotencyKey(prefix, stablePart);
+    }
+  }
+
+  function idempotencyKeyForPublicJoin(joinCode, nickname) {
+    return cachedIdempotencyKey(
+      "join-player",
+      `${joinCode.trim().toUpperCase()}-${nickname.trim()}`,
+    );
+  }
+
   async function requestJson(path, init = {}) {
     const response = await fetch(buildApiUrl(path), {
       credentials: "include",
@@ -2722,14 +2747,13 @@
       setStatus("Joining game...", "default");
 
       try {
-        const playerId = createIdempotencyKey("join-player", `${joinCode}-${nickname}`);
         const result = await requestJsonOrThrow(`/v1/join/${encodeURIComponent(joinCode)}`, {
           method: "POST",
           headers: {
             "content-type": "application/json",
+            "Idempotency-Key": idempotencyKeyForPublicJoin(joinCode, nickname),
           },
           body: JSON.stringify({
-            playerId,
             nickname,
           }),
         });

--- a/app/src/ui/styles.css
+++ b/app/src/ui/styles.css
@@ -1155,6 +1155,23 @@ body {
   }
 }
 
+[data-ui="join-qr"] {
+  inline-size: min(11rem, 100%);
+  aspect-ratio: 1;
+  background: #fff;
+  border: 1px solid #d6e3df;
+  border-radius: 6px;
+  padding: 0.5rem;
+  display: grid;
+  place-items: center;
+
+  svg {
+    inline-size: 100%;
+    block-size: 100%;
+    display: block;
+  }
+}
+
 code {
   font-family: "SF Mono", "Menlo", "Monaco", monospace;
   background: #e8f0ec;

--- a/docs/dynamodb-single-table.md
+++ b/docs/dynamodb-single-table.md
@@ -33,7 +33,7 @@ This document defines the baseline key structure and access patterns for the
 - Game metadata:
   - `pk=GAME#{gameId}`
   - `sk=METADATA`
-  - stores deterministic `joinCode`, game status, timer segments, `finishedAt`, and final `result`
+  - stores generated or custom `joinCode`, game status, timer segments, `finishedAt`, and final `result`
 - Join code lookup:
   - `pk=JOIN_CODE#{joinCode}`
   - `sk=METADATA`
@@ -67,6 +67,11 @@ This document defines the baseline key structure and access patterns for the
   - `sk=PROFILE`
 
 `gameMinuteSortable` is zero-padded to preserve lexical ordering.
+
+Persisted join codes are bearer codes generated randomly at game creation unless
+an organizer supplies a validated custom code. Deterministic join-code fallback
+exists only to normalize legacy game records before repair replaces missing
+lookup ownership.
 
 ## Item Envelope
 

--- a/docs/dynamodb-single-table.md
+++ b/docs/dynamodb-single-table.md
@@ -33,7 +33,11 @@ This document defines the baseline key structure and access patterns for the
 - Game metadata:
   - `pk=GAME#{gameId}`
   - `sk=METADATA`
-  - stores game status, timer segments, `finishedAt`, and final `result`
+  - stores deterministic `joinCode`, game status, timer segments, `finishedAt`, and final `result`
+- Join code lookup:
+  - `pk=JOIN_CODE#{joinCode}`
+  - `sk=METADATA`
+  - maps an active QR/join code to its `gameId`
 - Goal event timeline:
   - `pk=GAME#{gameId}`
   - `sk=GOAL#{third}#{gameMinuteSortable}#{elapsedSecondsSortable}#{eventId}`
@@ -85,6 +89,7 @@ without schema rewrites at this stage.
 - Create/list teams for a season.
 - Create/list sessions for a season.
 - Create/read game metadata.
+- Resolve join code to game for player self-registration.
 - Finish game and store deterministic winner/draw result on game metadata.
 - Link/list games for a session (`SESSION#{sessionId}` query).
 - Create/read player profile.

--- a/docs/openapi/v1-core-write.yaml
+++ b/docs/openapi/v1-core-write.yaml
@@ -874,6 +874,7 @@ components:
         nickname:
           type: string
           minLength: 1
+          maxLength: 80
     AssignRosterPlayerRequest:
       type: object
       additionalProperties: false

--- a/docs/openapi/v1-core-write.yaml
+++ b/docs/openapi/v1-core-write.yaml
@@ -182,7 +182,7 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
         "409":
-          $ref: "#/components/responses/IdempotencyConflict"
+          $ref: "#/components/responses/Conflict"
   /v1/games/{gameId}/thirds/{third}/start:
     post:
       summary: Start a game third timer

--- a/docs/openapi/v1-core-write.yaml
+++ b/docs/openapi/v1-core-write.yaml
@@ -3,14 +3,57 @@ info:
   title: 3FC Core API
   version: 0.1.0
   description: |
-    Authenticated core routes for league/season/session/game creation, M2 roster setup,
-    third timer control, goal scoring reads and writes, and game finish.
+    Core routes for public join-code registration plus authenticated league/season/session/game creation,
+    M2 roster setup, third timer control, goal scoring reads and writes, and game finish.
 servers:
   - url: https://qa-api.3fc.football
     description: QA
   - url: https://api.3fc.football
     description: Production
 paths:
+  /v1/join:
+    post:
+      summary: Reject join registration without a join code
+      operationId: rejectMissingJoinCode
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/JoinGameRequest"
+      responses:
+        "400":
+          $ref: "#/components/responses/BadRequest"
+  /v1/join/{joinCode}:
+    post:
+      summary: Register a nickname player into a game by join code
+      operationId: joinGameByCode
+      parameters:
+        - name: joinCode
+          in: path
+          required: true
+          schema:
+            type: string
+            minLength: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/JoinGameRequest"
+      responses:
+        "201":
+          description: Player registered for the game
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/JoinGameResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
   /v1/leagues:
     post:
       summary: Create league
@@ -814,6 +857,15 @@ components:
         nickname:
           type: string
           minLength: 1
+    JoinGameRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - nickname
+      properties:
+        nickname:
+          type: string
+          minLength: 1
     AssignRosterPlayerRequest:
       type: object
       additionalProperties: false
@@ -1001,6 +1053,7 @@ components:
       type: object
       required:
         - gameId
+        - joinCode
         - leagueId
         - seasonId
         - sessionId
@@ -1015,6 +1068,8 @@ components:
         - updatedAt
       properties:
         gameId:
+          type: string
+        joinCode:
           type: string
         leagueId:
           type: string
@@ -1291,6 +1346,19 @@ components:
         updatedAt:
           type: string
           format: date-time
+    JoinGameResponse:
+      type: object
+      required:
+        - gameId
+        - joinCode
+        - player
+      properties:
+        gameId:
+          type: string
+        joinCode:
+          type: string
+        player:
+          $ref: "#/components/schemas/Player"
     RosterAssignment:
       type: object
       required:

--- a/docs/openapi/v1-core-write.yaml
+++ b/docs/openapi/v1-core-write.yaml
@@ -34,7 +34,9 @@ paths:
           required: true
           schema:
             type: string
-            minLength: 1
+            minLength: 8
+            maxLength: 8
+            pattern: "^[A-Za-z0-9]{8}$"
       requestBody:
         required: true
         content:
@@ -53,7 +55,7 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
         "409":
-          $ref: "#/components/responses/CreateGameConflict"
+          $ref: "#/components/responses/JoinGameConflict"
   /v1/leagues:
     post:
       summary: Create league
@@ -182,7 +184,7 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
         "409":
-          $ref: "#/components/responses/Conflict"
+          $ref: "#/components/responses/CreateGameConflict"
   /v1/games/{gameId}/thirds/{third}/start:
     post:
       summary: Start a game third timer
@@ -747,6 +749,12 @@ components:
             $ref: "#/components/schemas/ErrorResponse"
     CreateGameConflict:
       description: Idempotency key was reused with a different request payload, or the game/join code already exists
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    JoinGameConflict:
+      description: Join registration is closed or the join state changed while registering
       content:
         application/json:
           schema:

--- a/docs/openapi/v1-core-write.yaml
+++ b/docs/openapi/v1-core-write.yaml
@@ -30,7 +30,7 @@ paths:
             type: string
             minLength: 8
             maxLength: 8
-            pattern: "^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{8}$"
+            pattern: "^[ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjklmnpqrstuvwxyz23456789]{8}$"
       requestBody:
         required: true
         content:

--- a/docs/openapi/v1-core-write.yaml
+++ b/docs/openapi/v1-core-write.yaml
@@ -53,7 +53,7 @@ paths:
         "404":
           $ref: "#/components/responses/NotFound"
         "409":
-          $ref: "#/components/responses/Conflict"
+          $ref: "#/components/responses/CreateGameConflict"
   /v1/leagues:
     post:
       summary: Create league
@@ -741,6 +741,12 @@ components:
             $ref: "#/components/schemas/ErrorResponse"
     Conflict:
       description: State transition rejected
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    CreateGameConflict:
+      description: Idempotency key was reused with a different request payload, or the game/join code already exists
       content:
         application/json:
           schema:

--- a/docs/openapi/v1-core-write.yaml
+++ b/docs/openapi/v1-core-write.yaml
@@ -15,12 +15,6 @@ paths:
     post:
       summary: Reject join registration without a join code
       operationId: rejectMissingJoinCode
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/JoinGameRequest"
       responses:
         "400":
           $ref: "#/components/responses/BadRequest"
@@ -36,7 +30,7 @@ paths:
             type: string
             minLength: 8
             maxLength: 8
-            pattern: "^[A-Za-z0-9]{8}$"
+            pattern: "^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{8}$"
       requestBody:
         required: true
         content:

--- a/docs/openapi/v1-core-write.yaml
+++ b/docs/openapi/v1-core-write.yaml
@@ -31,6 +31,7 @@ paths:
             minLength: 8
             maxLength: 8
             pattern: "^[ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjklmnpqrstuvwxyz23456789]{8}$"
+        - $ref: "#/components/parameters/IdempotencyKey"
       requestBody:
         required: true
         content:
@@ -748,7 +749,7 @@ components:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
     JoinGameConflict:
-      description: Join registration is closed or the join state changed while registering
+      description: Idempotency key was reused with a different request payload, join registration is closed, or the join state changed while registering
       content:
         application/json:
           schema:

--- a/infra/application/cloudfront-site-router.js
+++ b/infra/application/cloudfront-site-router.js
@@ -35,6 +35,10 @@ function rewriteToShell(uri) {
     return "/games/index.html";
   }
 
+  if (uri === "/join" || uri.indexOf("/join/") === 0) {
+    return "/join/index.html";
+  }
+
   return uri;
 }
 

--- a/serverless.api-core.yml
+++ b/serverless.api-core.yml
@@ -89,6 +89,18 @@ functions:
           method: OPTIONS
           path: /v1/auth/session
       - httpApi:
+          method: POST
+          path: /v1/join
+      - httpApi:
+          method: OPTIONS
+          path: /v1/join
+      - httpApi:
+          method: POST
+          path: /v1/join/{joinCode}
+      - httpApi:
+          method: OPTIONS
+          path: /v1/join/{joinCode}
+      - httpApi:
           method: GET
           path: /v1/leagues
       - httpApi:

--- a/tests/e2e/m2-smoke.spec.ts
+++ b/tests/e2e/m2-smoke.spec.ts
@@ -966,7 +966,7 @@ test.describe("M2 local-stack smoke", () => {
       await expect(page.getByTestId("game-shell")).toBeVisible();
       await expect(page.locator("#game-id-value")).toHaveText(gameId);
       const joinCode = (await page.getByTestId("game-join-code-value").innerText()).trim();
-      expect(joinCode).toMatch(/^[A-Z2-9]{8}$/);
+      expect(joinCode).toMatch(/^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{8}$/);
 
       const joinResult = await page.evaluate(
         async ({ apiBaseUrl: browserApiBaseUrl, joinCode: browserJoinCode }) => {
@@ -977,11 +977,21 @@ test.describe("M2 local-stack smoke", () => {
             },
             body: JSON.stringify({ nickname: "Cy" }),
           });
-          const body = (await response.json()) as {
+          const responseText = await response.text();
+          type JoinRegistrationSmokeBody = {
             gameId?: string;
             joinCode?: string;
             player?: { nickname?: string; playerId?: string };
+            rawBody?: string;
           };
+          let body: JoinRegistrationSmokeBody;
+          try {
+            body = responseText
+              ? (JSON.parse(responseText) as JoinRegistrationSmokeBody)
+              : {};
+          } catch {
+            body = { rawBody: responseText };
+          }
           return {
             status: response.status,
             body,

--- a/tests/e2e/m2-smoke.spec.ts
+++ b/tests/e2e/m2-smoke.spec.ts
@@ -965,7 +965,9 @@ test.describe("M2 local-stack smoke", () => {
       ]);
       await expect(page.getByTestId("game-shell")).toBeVisible();
       await expect(page.locator("#game-id-value")).toHaveText(gameId);
-      const joinCode = (await page.getByTestId("game-join-code-value").innerText()).trim();
+      const joinCodeValue = page.getByTestId("game-join-code-value");
+      await expect(joinCodeValue).toHaveText(/^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{8}$/);
+      const joinCode = (await joinCodeValue.innerText()).trim();
       expect(joinCode).toMatch(/^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{8}$/);
 
       const joinResult = await page.evaluate(

--- a/tests/e2e/m2-smoke.spec.ts
+++ b/tests/e2e/m2-smoke.spec.ts
@@ -965,6 +965,41 @@ test.describe("M2 local-stack smoke", () => {
       ]);
       await expect(page.getByTestId("game-shell")).toBeVisible();
       await expect(page.locator("#game-id-value")).toHaveText(gameId);
+      const joinCode = (await page.getByTestId("game-join-code-value").innerText()).trim();
+      expect(joinCode).toMatch(/^[A-Z2-9]{8}$/);
+
+      const joinResult = await page.evaluate(
+        async ({ apiBaseUrl: browserApiBaseUrl, joinCode: browserJoinCode }) => {
+          const response = await fetch(`${browserApiBaseUrl}/v1/join/${encodeURIComponent(browserJoinCode)}`, {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({ nickname: "Cy" }),
+          });
+          const body = (await response.json()) as {
+            gameId?: string;
+            joinCode?: string;
+            player?: { nickname?: string; playerId?: string };
+          };
+          return {
+            status: response.status,
+            body,
+          };
+        },
+        { apiBaseUrl, joinCode },
+      );
+      expect(joinResult.status).toBe(201);
+      expect(joinResult.body.gameId).toBe(gameId);
+      expect(joinResult.body.joinCode).toBe(joinCode);
+      expect(joinResult.body.player?.nickname).toBe("Cy");
+      if (joinResult.body.player?.playerId) {
+        playerIds.push(joinResult.body.player.playerId);
+      }
+
+      await page.locator("#player-search").fill("Cy");
+      await expect(page.locator('[data-ui="roster-player"]').filter({ hasText: "Cy" })).toBeVisible();
+      await page.locator("#player-search").fill("");
 
       const ariPlayerId = await createAndAssignPlayer(page, ariNickname, "red", (playerId) => {
         playerIds.push(playerId);


### PR DESCRIPTION
<!-- review-packet-version:1 -->

## Behavioural claim

Adds M2 join-code registration so players can join through a league/game code, create or assign player records, and become available to the scoring flow, while ensuring closed-game join conflicts do not create stale retry records.

## Specification and acceptance evidence

| Acceptance criterion | Evidence | Result |
| --- | --- | --- |
| Join-code lookup and registration validate custom codes, uniqueness, race conditions, and transaction cancellation paths. | `npm test` on rebased branch `codex/m2-08-join-code-registration` at `2072bff` | PASS |
| Player registration integrates with the existing setup/live scoring UI and preserves response privacy boundaries. | `npm test` on rebased branch `codex/m2-08-join-code-registration` at `2072bff` | PASS |
| Public join attempts against finished games return repeatable `game_finished` conflicts without persisting closed-game idempotency records. | `npm test` on rebased branch `codex/m2-08-join-code-registration` at `2072bff` | PASS |
| Public join retry identities remain distinct for distinct nicknames after a failed response. | `npm test`; fresh-stack `npm run smoke:m2:playwright -- -g "scorekeeper can set up and finish a live game" --project=chromium-mobile` on rebased branch `codex/m2-08-join-code-registration` at `2072bff` | PASS |
| Organizer game pages expose a scannable QR code for the complete public join URL. | `npm run smoke:m2:playwright -- --list` showing four smoke tests; `THREEFC_SKIP_WEB_SERVER=1 npm run smoke:m2:playwright -- -g "smoke cleanup" --project=chromium-mobile`; fresh-stack `npm run smoke:m2:playwright -- -g "scorekeeper can set up and finish a live game" --project=chromium-mobile`; `npm test` on rebased branch `codex/m2-08-join-code-registration` at `2072bff` | PASS |

## Scope boundaries

Included: join-code API/contracts/storage, player registration UI integration, lookup/race validation, finished-game public join conflict handling, OpenAPI/serverless documentation, and API/app/e2e regression tests.

Excluded: authentication-provider changes, season standings UX, production infrastructure changes, and 3FC rule-review refinements beyond join/register availability.

## Change classification

- Declared risk: `high`
- [ ] `documentation-only` - Documentation only
- [ ] `tests-only` - Tests only
- [x] `application-behaviour` - Application or API behaviour
- [ ] `backlog-maintenance` - Canonical backlog maintenance
- [ ] `dependency-tooling` - Dependency or tooling
- [x] `public-contract` - Public API or repository contract
- [ ] `data-migration` - Database schema or data migration
- [x] `permission-trust-boundary` - Permission or trust boundary
- [x] `durable-state-ownership` - Durable state or ownership
- [ ] `destructive-behaviour` - Destructive or difficult-to-reverse behaviour
- [ ] `new-production-dependency` - New production dependency
- [ ] `authentication-authorisation` - Authentication or authorisation
- [ ] `privacy-regulated-data` - Privacy or regulated data
- [ ] `infrastructure-production-configuration` - Infrastructure or deployment control
- [ ] `review-policy` - Review policy, packet, or workflow

## Architecture and invariants

- [ ] `architecture:none`
- [x] `architecture:documented`
- [ ] `architecture:judgement-required`

### Affected invariants

| Invariant | How this PR affects it | Why it remains valid | Evidence |
| --- | --- | --- | --- |
| INV-001 | Adds public join-code lookup and registration response shapes. | Public responses expose nickname/game availability data only, organizer QR/link rendering encodes the public join URL only, and private email fields are not exposed. | `npm test`; `api/src/tests/lambda-core.test.ts`; `app/src/tests/setup-flow-e2e.test.ts` |
| INV-002 | Adds a join-code-scoped registration write path that is intentionally not a league admin/scorekeeper protected write. | The route grants only player registration through a valid active code, and the QR is a bearer-code presentation path rather than a new write permission; existing protected league or scorekeeper write ACLs are not weakened. Finished-game joins are rejected before any public registration write, and client retry identity preserves distinct nickname payloads instead of collapsing storage keys. | `npm test`; invalid/expired/finished code and ACL regression coverage in `api/src/tests/lambda-core.test.ts`; retry-key regression coverage in `app/src/tests/setup-flow-e2e.test.ts` |
| INV-003 | Adds transactional player registration writes adjacent to existing idempotent write infrastructure and avoids persisting retry records for closed-game join conflicts. | The PR does not mark join registration as a general protected `Idempotency-Key` endpoint; replay state is bounded to successful/eligible public join mutations, and `game_finished` conflicts are returned without stale idempotency records. | `npm test`; `docs/openapi/v1-core-write.yaml`; transaction cancellation and closed-game replay tests in `api/src/tests/repository.test.ts` and `api/src/tests/lambda-core.test.ts` |
| INV-004 | Adds join-code and player-game registration records to the documented single-table ownership model. | Registration state remains league/game scoped, assigned players stay addressable through the documented game/player access patterns, and finished-game conflicts do not create orphan public join retry state. | `npm test`; `docs/dynamodb-single-table.md`; `api/src/tests/repository.test.ts`; `api/src/tests/lambda-core.test.ts` |
| INV-008 | Makes joined or newly created players available to the scoring flow as rostered game players. | Goal validation remains responsible for assist limits/scorer exclusion, while registration only controls whether a player is eligible to appear in the roster pool for active games. | `npm test`; `app/src/tests/setup-flow-e2e.test.ts`; goal validation coverage from stacked API PRs |

### Architecture or decision record

Join-code registration extends the documented player/game ownership model in `docs/spec.md`, `docs/dynamodb-single-table.md`, `docs/openapi/v1-core-write.yaml`, and `docs/architecture/invariants.md`. Closed-game public join conflicts are treated as non-persisted public conflicts so stale retry state cannot outlive a finished game. Organizer game pages now render both the complete join URL and an inline QR code for that URL.

## Failure and rollback

### Failure behaviour

Invalid or unavailable join codes fail validation, duplicate/custom-code races fail without partially assigning players, finished games return repeatable non-persisted `game_finished` conflicts, public join retry keys remain distinct for distinct nicknames after failed responses, QR rendering falls back when the join URL exceeds the supported payload size, and public responses avoid exposing private email data.

### Rollback approach

Revert the merge commit for this PR and redeploy the previous main release; no migration or destructive state rewrite is introduced.

### Rollback evidence

The PR adds join-code registration paths and QR rendering without schema migration; `npm run smoke:m2:playwright -- --list`, `THREEFC_SKIP_WEB_SERVER=1 npm run smoke:m2:playwright -- -g "smoke cleanup" --project=chromium-mobile`, fresh-stack `npm run smoke:m2:playwright -- -g "scorekeeper can set up and finish a live game" --project=chromium-mobile`, and `npm test` pass on branch `codex/m2-08-join-code-registration` at `2072bff`.

## Automated and agent review disposition

### Unresolved blocking findings

None.

### Rejected findings and evidence

None.

## Human judgement

- [x] `human-judgement:none`
- [ ] `human-judgement:required`

### Decision requiring judgement

None.

### Options considered

None.

### Reason selected

None.

### Reversal cost

None.

## Review focus

Please inspect join-code race handling, QR/link join-code presentation, public response privacy, closed-game join conflict replay behaviour, registration-to-roster ownership, and whether newly joined players are immediately usable by the live scoring flow.

Fixes #24
