### PR TITLE
fix(review): restore review gate thread evaluation

### DIFF
--- a/scripts/review-gate/github.mjs
+++ b/scripts/review-gate/github.mjs
@@ -116,11 +116,7 @@ export class GitHubClient {
             reviewThreads(first: 100, after: $cursor) {
               nodes {
                 isResolved
-                comments(first: 100) {
-                  nodes {
-                    isOutdated
-                  }
-                }
+                isOutdated
               }
               pageInfo {
                 hasNextPage
@@ -145,10 +141,9 @@ export class GitHubClient {
         throw new Error(`GitHub GraphQL response did not contain review threads for PR #${number}`);
       }
       for (const thread of connection.nodes) {
-        const comments = thread.comments?.nodes ?? [];
         threads.push({
           isResolved: thread.isResolved,
-          isOutdated: comments.length > 0 && comments.every((comment) => comment.isOutdated),
+          isOutdated: thread.isOutdated,
         });
       }
       cursor = connection.pageInfo.hasNextPage ? connection.pageInfo.endCursor : null;

--- a/scripts/review-gate/tests/github.test.mjs
+++ b/scripts/review-gate/tests/github.test.mjs
@@ -56,6 +56,54 @@ test("GraphQL errors are surfaced with their server diagnostics", async () => {
   );
 });
 
+test("review threads use thread-level outdated state", async () => {
+  const requests = [];
+  const client = new GitHubClient({
+    token: "token",
+    repository: "ajfisher/3fc",
+    async fetchImpl(url, options) {
+      requests.push({ url, options });
+      return jsonResponse({
+        data: {
+          repository: {
+            pullRequest: {
+              reviewThreads: {
+                nodes: [
+                  { isResolved: false, isOutdated: true },
+                  { isResolved: false, isOutdated: false },
+                ],
+                pageInfo: {
+                  hasNextPage: false,
+                  endCursor: null,
+                },
+              },
+            },
+          },
+        },
+      });
+    },
+  });
+
+  assert.deepEqual(
+    await client.getReviewThreads(91),
+    [
+      { isResolved: false, isOutdated: true },
+      { isResolved: false, isOutdated: false },
+    ],
+  );
+
+  const payload = JSON.parse(requests[0].options.body);
+  assert.match(payload.query, /reviewThreads/);
+  assert.match(payload.query, /isOutdated/);
+  assert.doesNotMatch(payload.query, /comments\(first: 100\)/);
+  assert.deepEqual(payload.variables, {
+    owner: "ajfisher",
+    repo: "3fc",
+    number: 91,
+    cursor: null,
+  });
+});
+
 test("publishing updates the one existing review-gate check", async () => {
   const requests = [];
   const client = new GitHubClient({


### PR DESCRIPTION
<!-- review-packet-version:1 -->

## Behavioural claim

Restores review-gate evaluation by querying GitHub's supported thread-level `PullRequestReviewThread.isOutdated` field instead of the unsupported `PullRequestReviewComment.isOutdated` field.

## Specification and acceptance evidence

| Acceptance criterion | Evidence | Result |
| --- | --- | --- |
| Review-gate no longer asks GitHub GraphQL for `PullRequestReviewComment.isOutdated`. | `npm run test:review-gate` | PASS |
| Review thread normalization still returns `{ isResolved, isOutdated }` for unresolved-thread evaluation. | `npm run test:review-gate` | PASS |
| Live GitHub schema supports thread-level `isOutdated` and not comment-level `isOutdated`. | `gh api graphql` schema introspection on `PullRequestReviewThread` and `PullRequestReviewComment` | PASS |

## Scope boundaries

Included: review-gate GitHub GraphQL review-thread query and regression coverage for the query shape.

Excluded: review policy thresholds, PR packet rules, QA deployment policy, label definitions, and product/application behaviour.

## Change classification

- Declared risk: `high`
- [ ] `documentation-only` - Documentation only
- [ ] `tests-only` - Tests only
- [ ] `application-behaviour` - Application or API behaviour
- [ ] `backlog-maintenance` - Canonical backlog maintenance
- [ ] `dependency-tooling` - Dependency or tooling
- [ ] `public-contract` - Public API or repository contract
- [ ] `data-migration` - Database schema or data migration
- [ ] `permission-trust-boundary` - Permission or trust boundary
- [ ] `durable-state-ownership` - Durable state or ownership
- [ ] `destructive-behaviour` - Destructive or difficult-to-reverse behaviour
- [ ] `new-production-dependency` - New production dependency
- [ ] `authentication-authorisation` - Authentication or authorisation
- [ ] `privacy-regulated-data` - Privacy or regulated data
- [ ] `infrastructure-production-configuration` - Infrastructure or deployment control
- [x] `review-policy` - Review policy, packet, or workflow

## Architecture and invariants

- [ ] `architecture:none`
- [x] `architecture:documented`
- [ ] `architecture:judgement-required`

### Affected invariants

None.

### Architecture or decision record

The review-gate workflow remains the trusted default-branch evaluator documented in `docs/review-process.md`, `.github/review-policy.yml`, and `docs/decisions/0001-risk-based-pull-request-review.md`; this PR only corrects the GitHub review-thread API field used by that evaluator.

## Failure and rollback

### Failure behaviour

If GitHub changes the review-thread schema again, review-gate may publish no updated check and the Actions job will fail visibly instead of silently marking PRs ready.

### Rollback approach

Revert this PR and rerun review-gate; this has no production runtime or data migration effect.

### Rollback evidence

The change is isolated to `scripts/review-gate/github.mjs` plus a regression test, and `npm run test:review-gate` passes.

## Automated and agent review disposition

### Unresolved blocking findings

None.

### Rejected findings and evidence

None.

## Human judgement

- [x] `human-judgement:none`
- [ ] `human-judgement:required`

### Decision requiring judgement

None.

### Options considered

None.

### Reason selected

None.

### Reversal cost

None.

## Review focus

Please inspect the GraphQL field move from comment-level to thread-level outdated state and the regression assertion that prevents reintroducing the unsupported nested query.

Fixes #103
