### PR TITLE
[codex] Fix review gate PR label permission

### DIFF
--- a/.github/workflows/review-gate.yml
+++ b/.github/workflows/review-gate.yml
@@ -43,7 +43,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
+  pull-requests: write
   checks: write
   issues: write
 

--- a/scripts/review-gate/tests/workflow.test.mjs
+++ b/scripts/review-gate/tests/workflow.test.mjs
@@ -50,7 +50,7 @@ test("privileged evaluation uses pinned Actions and trusted default-branch code"
 test("workflow permissions and refresh authorisation are explicit", () => {
   assert.match(
     workflow,
-    /permissions:\s*\n\s+contents: read\s*\n\s+pull-requests: read\s*\n\s+checks: write\s*\n\s+issues: write/,
+    /permissions:\s*\n\s+contents: read\s*\n\s+pull-requests: write\s*\n\s+checks: write\s*\n\s+issues: write/,
   );
   assert.doesNotMatch(workflow, /contents: write/);
   assert.doesNotMatch(workflow, /actions: write/);


### PR DESCRIPTION
<!-- review-packet-version:1 -->

## Behavioural claim

Review gate workflows can mutate managed labels on pull requests while continuing to execute trusted default-branch code with read-only repository contents access.

Fixes #105

## Specification and acceptance evidence

| Acceptance criterion | Evidence | Result |
| --- | --- | --- |
| Workflow grants the token permission needed for PR label mutation. | `.github/workflows/review-gate.yml` sets `pull-requests: write` and keeps `issues: write` for the labels API path. | PASS |
| Repository contents remain read-only for the privileged workflow. | `scripts/review-gate/tests/workflow.test.mjs` still asserts `contents: read` and rejects `contents: write`. | PASS |
| Review-gate policy and workflow tests pass locally. | `npm run test:review-gate` | PASS |

## Scope boundaries

Included:

- Review gate workflow token permission for pull request operations.
- The deterministic workflow-permission guard test.

Excluded:

- Review policy rule changes.
- Application, API, deployment, or runtime behaviour.
- Changes to the M2 feature stack branches.

## Change classification

- Declared risk: `high`
- [ ] `documentation-only` — Documentation only
- [ ] `tests-only` — Tests only
- [ ] `application-behaviour` — Application or API behaviour
- [ ] `backlog-maintenance` — Canonical backlog maintenance
- [ ] `dependency-tooling` — Dependency or tooling
- [ ] `public-contract` — Public API or repository contract
- [ ] `data-migration` — Database schema or data migration
- [x] `permission-trust-boundary` — Permission or trust boundary
- [ ] `durable-state-ownership` — Durable state or ownership
- [ ] `destructive-behaviour` — Destructive or difficult-to-reverse behaviour
- [ ] `new-production-dependency` — New production dependency
- [ ] `authentication-authorisation` — Authentication or authorisation
- [ ] `privacy-regulated-data` — Privacy or regulated data
- [ ] `infrastructure-production-configuration` — Infrastructure or deployment control
- [x] `review-policy` — Review policy, packet, or workflow

## Architecture and invariants

- [ ] `architecture:none`
- [x] `architecture:documented`
- [ ] `architecture:judgement-required`

### Affected invariants

None.

### Architecture or decision record

No ADR required. This changes the CI review workflow permission boundary only; the workflow still checks out and evaluates trusted default-branch code, uses pinned Actions, and keeps repository contents read-only.

## Failure and rollback

### Failure behaviour

If this remains broken, review-gate runs fail with `403 Resource not accessible by integration` before publishing managed labels or the synthetic `review-gate` check, leaving PRs unable to be re-evaluated cleanly.

### Rollback approach

Revert this commit to return the workflow token to `pull-requests: read`.

### Rollback evidence

Rollback is a single workflow/test commit revert; no durable state or production data is changed.

## Automated and agent review disposition

### Unresolved blocking findings

None.

### Rejected findings and evidence

None.

## Human judgement

- [ ] `human-judgement:none`
- [x] `human-judgement:required`

### Decision requiring judgement

Confirm that granting `pull-requests: write` to the trusted default-branch review-gate workflow is acceptable to restore managed label updates.

### Options considered

- Grant `pull-requests: write` to the existing trusted workflow.
- Stop mutating managed labels and only publish check runs.
- Change repository-level default workflow token permissions.

### Reason selected

The first option is the narrowest repo-contained fix for the observed failure. It grants only the PR permission needed for the labels API on pull requests while keeping contents read-only and avoiding a broader repository-level Actions setting change.

### Reversal cost

Low. Reverting restores the previous read-only pull request token behaviour, with the known consequence that managed review labels cannot be updated by the gate.

## Review focus

- `.github/workflows/review-gate.yml`
- `scripts/review-gate/tests/workflow.test.mjs`
- Whether the permission change is acceptable for a `pull_request_target` workflow that checks out trusted default-branch code.
