### PR TITLE
[codex] Require invariant impact details in review packets

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -45,7 +45,11 @@ Excluded:
 
 ### Affected invariants
 
-<!-- Use IDs from docs/architecture/invariants.md, or write "None". -->
+<!-- Use IDs from docs/architecture/invariants.md. For no impact, replace the table with "None.". -->
+
+| Invariant | How this PR affects it | Why it remains valid | Evidence |
+| --- | --- | --- | --- |
+| <!-- INV-000 --> | <!-- route, state, contract, permission, data, or operational path changed --> | <!-- why the invariant still holds after this PR --> | <!-- test, check, QA note, or review evidence --> |
 
 ### Architecture or decision record
 

--- a/docs/architecture/invariants.md
+++ b/docs/architecture/invariants.md
@@ -1,8 +1,8 @@
 # Review invariants
 
 These identifiers turn 3FC's durable product and system rules into reviewable
-constraints. Pull requests name every invariant they affect and provide evidence
-proportionate to the failure consequence.
+constraints. Pull requests explain every invariant they affect and provide
+evidence proportionate to the failure consequence.
 
 | ID | Invariant and failure consequence | Evidence expected | Canonical source |
 | --- | --- | --- | --- |
@@ -19,3 +19,9 @@ proportionate to the failure consequence.
 Adding, changing, or removing an invariant is a high-risk architecture change.
 Update the canonical source, record the decision in `docs/decisions/`, and cite
 the invariant ID in the pull-request packet.
+
+For every affected invariant, the pull-request packet must state:
+
+- how the PR affects the invariant
+- why the invariant remains valid after the change
+- the evidence reviewers should use to verify that claim

--- a/scripts/review-gate/evaluate.mjs
+++ b/scripts/review-gate/evaluate.mjs
@@ -225,6 +225,19 @@ function architectureLabel(packet) {
     : "architecture:none";
 }
 
+function hasExplicitNoInvariantImpact(value) {
+  return /^none\.?$/i.test((value ?? "").trim());
+}
+
+function hasCompleteInvariantImpactRows(rows) {
+  return rows.length > 0 && rows.every((row) =>
+    row.invariantIds.length === 1
+    && /^INV-\d{3}$/.test(row.invariant)
+    && row.affected
+    && row.valid
+    && row.evidence);
+}
+
 function configurationError(error, mode = "observe") {
   return {
     state: "configuration-error",
@@ -309,9 +322,16 @@ export function evaluateReview(rawPolicy, rawInput) {
   }
   if (
     requirements.invariant_declaration === "required"
-    && !/^(none\.?|INV-\d{3}(?:[\s,;]+INV-\d{3})*)$/i.test(packet.affectedInvariants)
+    && !hasExplicitNoInvariantImpact(packet.affectedInvariants)
+    && !hasCompleteInvariantImpactRows(packet.affectedInvariantRows)
   ) {
-    packetBlockers.push(`${effectiveRisk} risk requires invariant identifiers or explicit none.`);
+    packetBlockers.push(`${effectiveRisk} risk requires affected invariant impact rows or explicit none.`);
+  }
+  if (
+    packet.affectedInvariantRows.length > 0
+    && !hasCompleteInvariantImpactRows(packet.affectedInvariantRows)
+  ) {
+    packetBlockers.push("Affected invariant rows require invariant ID, how affected, why it remains valid, and evidence.");
   }
   if (
     packet.rejectedFindings

--- a/scripts/review-gate/packet.mjs
+++ b/scripts/review-gate/packet.mjs
@@ -111,25 +111,115 @@ function readField(section, label) {
   return "";
 }
 
+function parseMarkdownTable(section) {
+  const lines = section.split("\n");
+  const splitTableCells = (line) => {
+    const cells = [];
+    let cell = "";
+    let codeDelimiterLength = 0;
+    for (let index = 0; index < line.length; index += 1) {
+      const character = line[index];
+      if (character === "\\" && index + 1 < line.length) {
+        cell += character + line[index + 1];
+        index += 1;
+        continue;
+      }
+      if (character === "`") {
+        const start = index;
+        while (line[index + 1] === "`") {
+          index += 1;
+        }
+        const delimiterLength = index - start + 1;
+        if (codeDelimiterLength === 0) {
+          codeDelimiterLength = delimiterLength;
+        } else if (delimiterLength === codeDelimiterLength) {
+          codeDelimiterLength = 0;
+        }
+        cell += "`".repeat(delimiterLength);
+        continue;
+      }
+      if (character === "|" && codeDelimiterLength === 0) {
+        cells.push(cell);
+        cell = "";
+        continue;
+      }
+      cell += character;
+    }
+    cells.push(cell);
+    return cells;
+  };
+  const readRow = (line) => {
+    const trimmed = line.trim();
+    if (!trimmed.includes("|")) {
+      return null;
+    }
+    const cells = splitTableCells(trimmed);
+    if (trimmed.startsWith("|")) {
+      cells.shift();
+    }
+    if (cells.at(-1)?.trim() === "") {
+      cells.pop();
+    }
+    return cells.map((cell) => clean(cell));
+  };
+  const isDelimiter = (row, width) =>
+    row?.length === width && row.every((cell) => /^:?-+:?$/.test(cell));
+
+  const bodyRows = [];
+  for (let index = 0; index < lines.length - 1; index += 1) {
+    const header = readRow(lines[index]);
+    if (!header || header.length < 2 || !header.some(Boolean)) {
+      continue;
+    }
+    if (!isDelimiter(readRow(lines[index + 1]), header.length)) {
+      continue;
+    }
+    let cursor = index + 2;
+    for (; cursor < lines.length; cursor += 1) {
+      const row = readRow(lines[cursor]);
+      if (!row || row.length !== header.length || isDelimiter(row, header.length)) {
+        break;
+      }
+      if (row.some(Boolean)) {
+        bodyRows.push(row);
+      }
+    }
+    index = cursor - 1;
+  }
+  return bodyRows;
+}
+
 function parseEvidence(section) {
-  const rows = section
-    .split("\n")
-    .filter((line) => /^\s*\|/.test(line))
-    .map((line) =>
-      line
-        .split("|")
-        .slice(1, -1)
-        .map((cell) => clean(cell)),
-    )
-    .filter((row) => !row.every((cell) => /^:?-{3,}:?$/.test(cell)));
+  const rows = parseMarkdownTable(section);
   return rows
-    .slice(1)
-    .filter((row) => row.some(Boolean))
     .map(([criterion = "", evidence = "", result = ""]) => ({
       criterion,
       evidence,
       result: result.toUpperCase(),
     }));
+}
+
+function parseInvariantImpacts(section) {
+  return parseMarkdownTable(section)
+    .map(([
+      invariant = "",
+      affected = "",
+      valid = "",
+      evidence = "",
+    ]) => {
+      const invariantIds = [...invariant.matchAll(/\bINV-\d{3}\b/ig)]
+        .map((match) => match[0].toUpperCase());
+      return {
+        invariant: invariantIds.length === 1
+          ? invariantIds[0]
+          : invariant.toUpperCase(),
+        invariantIds,
+        affected,
+        valid,
+        evidence,
+      };
+    })
+    .filter((row) => row.invariant || row.affected || row.valid || row.evidence);
 }
 
 export function parseReviewPacket(body = "") {
@@ -198,6 +288,8 @@ export function parseReviewPacket(body = "") {
   const acceptanceRows = parseEvidence(
     sections.get("Specification and acceptance evidence") ?? "",
   );
+  const affectedInvariantSection = subsections.get("Affected invariants") ?? "";
+  const affectedInvariantRows = parseInvariantImpacts(affectedInvariantSection);
 
   return {
     errors,
@@ -215,10 +307,8 @@ export function parseReviewPacket(body = "") {
     architecture: architectureSelections.length === 1
       ? architectureSelections[0]
       : null,
-    affectedInvariants: clean(
-      subsections.get("Affected invariants") ?? "",
-      { emptyNone: false },
-    ),
+    affectedInvariants: clean(affectedInvariantSection, { emptyNone: false }),
+    affectedInvariantRows,
     architectureRecord: clean(
       subsections.get("Architecture or decision record") ?? "",
     ),

--- a/scripts/review-gate/render.mjs
+++ b/scripts/review-gate/render.mjs
@@ -4,6 +4,13 @@ function bullets(items, emptyMessage) {
     : [`- ${emptyMessage}`];
 }
 
+function invariantSummary(packet) {
+  if (packet.affectedInvariantRows?.length > 0) {
+    return packet.affectedInvariantRows.map((row) => row.invariant).join(" ");
+  }
+  return packet.affectedInvariants || "missing";
+}
+
 export function renderSummary(result, headSha) {
   if (result.state === "configuration-error") {
     return [
@@ -67,7 +74,7 @@ export function renderSummary(result, headSha) {
     `| Unresolved current threads | ${result.unresolvedThreads} |`,
     `| Human approvals | ${result.approvals} / ${result.requirements.human_approvals} |`,
     `| Architecture | ${result.packet.architecture ?? "invalid"} |`,
-    `| Affected invariants | ${result.packet.affectedInvariants || "missing"} |`,
+    `| Affected invariants | ${invariantSummary(result.packet)} |`,
     `| Human judgement | ${result.packet.humanJudgement ?? "invalid"} |`,
     "",
     "### Blocking findings",

--- a/scripts/review-gate/tests/evaluate.test.mjs
+++ b/scripts/review-gate/tests/evaluate.test.mjs
@@ -162,6 +162,19 @@ function completedCheck(name, conclusion = "success") {
   };
 }
 
+function invariantTable(
+  invariant = "INV-002",
+  affected = "Changes protected write routing.",
+  valid = "The route still requires a scoped authenticated session.",
+  evidence = "`npm run test -w @3fc/api`",
+) {
+  return [
+    "| Invariant | How this PR affects it | Why it remains valid | Evidence |",
+    "| --- | --- | --- | --- |",
+    `| ${invariant} | ${affected} | ${valid} | ${evidence} |`,
+  ].join("\n");
+}
+
 function highRiskState(overrides = {}) {
   return state({
     body: packet({
@@ -254,7 +267,7 @@ test("missing acceptance evidence blocks high risk", () => {
     risk: "high",
     acceptance: false,
     architecture: "documented",
-    invariants: "INV-002",
+    invariants: invariantTable(),
     architectureRecord: "docs/decisions/001-auth.md",
     failureBehaviour: "Fail closed.",
     rollbackApproach: "Revert.",
@@ -268,7 +281,7 @@ test("missing rollback evidence blocks high risk", () => {
   high.body = packet({
     risk: "high",
     architecture: "documented",
-    invariants: "INV-002",
+    invariants: invariantTable(),
     architectureRecord: "docs/decisions/001-auth.md",
     failureBehaviour: "Fail closed.",
     rollbackApproach: "Revert the pull request.",
@@ -484,6 +497,279 @@ test("architecture trigger cannot be declared as no impact", () => {
     }),
   }));
   assert.match(result.blockers.join("\n"), /Architecture-sensitive paths/);
+});
+
+test("listed invariants require impact details", () => {
+  const result = evaluateReview(policy, highRiskState({
+    body: packet({
+      risk: "high",
+      architecture: "documented",
+      invariants: "INV-002 INV-003",
+      architectureRecord: "docs/decisions/001-auth.md",
+      failureBehaviour: "Fail closed.",
+      rollbackApproach: "Revert.",
+      rollbackEvidence: "Revert is sufficient because no data migration runs.",
+    }),
+  }));
+  assert.equal(result.state, "blocked");
+  assert.match(result.blockers.join("\n"), /invariant impact rows/);
+});
+
+test("complete invariant impact rows satisfy high-risk invariant declaration", () => {
+  const result = evaluateReview(policy, highRiskState({
+    body: packet({
+      risk: "high",
+      architecture: "documented",
+      invariants: invariantTable(
+        "INV-003",
+        "Adds an idempotent write endpoint.",
+        "Stored results are replayed for matching operation keys.",
+        "`npm run test -w @3fc/api`",
+      ),
+      architectureRecord: "docs/decisions/001-idempotent-write.md",
+      failureBehaviour: "The endpoint fails closed on conflicting idempotency keys.",
+      rollbackApproach: "Revert the endpoint and contract change.",
+      rollbackEvidence: "No migration is required.",
+    }),
+  }));
+  assert.equal(result.state, "pass", result.blockers.join("\n"));
+  assert.deepEqual(result.packet.affectedInvariantRows, [{
+    invariant: "INV-003",
+    invariantIds: ["INV-003"],
+    affected: "Adds an idempotent write endpoint.",
+    valid: "Stored results are replayed for matching operation keys.",
+    evidence: "`npm run test -w @3fc/api`",
+  }]);
+});
+
+test("invariant impact rows accept tables without outer pipes", () => {
+  const result = evaluateReview(policy, highRiskState({
+    body: packet({
+      risk: "high",
+      architecture: "documented",
+      invariants: [
+        "Invariant | How this PR affects it | Why it remains valid | Evidence",
+        "--- | --- | --- | ---",
+        "INV-004 | Changes a repository access path. | Keys remain owned by the documented entity. | `npm run test -w @3fc/api`",
+      ].join("\n"),
+      architectureRecord: "docs/architecture/invariants.md",
+      failureBehaviour: "Invalid access paths fail closed.",
+      rollbackApproach: "Revert the repository change.",
+      rollbackEvidence: "No migration is required.",
+    }),
+  }));
+  assert.equal(result.state, "pass", result.blockers.join("\n"));
+  assert.deepEqual(result.packet.affectedInvariantRows, [{
+    invariant: "INV-004",
+    invariantIds: ["INV-004"],
+    affected: "Changes a repository access path.",
+    valid: "Keys remain owned by the documented entity.",
+    evidence: "`npm run test -w @3fc/api`",
+  }]);
+});
+
+test("invariant impact rows accept escaped pipes and code-span pipes in cells", () => {
+  const result = evaluateReview(policy, highRiskState({
+    body: packet({
+      risk: "high",
+      architecture: "documented",
+      invariants: [
+        "| Invariant | How this PR affects it | Why it remains valid | Evidence |",
+        "| --- | --- | --- | --- |",
+        "| INV-004 | Changes a parser path. | Table cells still parse deterministically. | `npm test \\| tee evidence.log` and `a|b` |",
+      ].join("\n"),
+      architectureRecord: "docs/architecture/invariants.md",
+      failureBehaviour: "Malformed packets fail closed.",
+      rollbackApproach: "Revert the parser change.",
+      rollbackEvidence: "No migration is required.",
+    }),
+  }));
+  assert.equal(result.state, "pass", result.blockers.join("\n"));
+  assert.deepEqual(result.packet.affectedInvariantRows, [{
+    invariant: "INV-004",
+    invariantIds: ["INV-004"],
+    affected: "Changes a parser path.",
+    valid: "Table cells still parse deterministically.",
+    evidence: "`npm test \\| tee evidence.log` and `a|b`",
+  }]);
+});
+
+test("invariant impact rows accept multi-backtick code-span pipes in cells", () => {
+  const result = evaluateReview(policy, highRiskState({
+    body: packet({
+      risk: "high",
+      architecture: "documented",
+      invariants: [
+        "| Invariant | How this PR affects it | Why it remains valid | Evidence |",
+        "| --- | --- | --- | --- |",
+        "| INV-004 | Changes a parser path. | Table cells still parse deterministically. | ``command a|b`` |",
+      ].join("\n"),
+      architectureRecord: "docs/architecture/invariants.md",
+      failureBehaviour: "Malformed packets fail closed.",
+      rollbackApproach: "Revert the parser change.",
+      rollbackEvidence: "No migration is required.",
+    }),
+  }));
+  assert.equal(result.state, "pass", result.blockers.join("\n"));
+  assert.deepEqual(result.packet.affectedInvariantRows, [{
+    invariant: "INV-004",
+    invariantIds: ["INV-004"],
+    affected: "Changes a parser path.",
+    valid: "Table cells still parse deterministically.",
+    evidence: "``command a|b``",
+  }]);
+});
+
+test("invariant impact rows accept single-hyphen GFM delimiters", () => {
+  const result = evaluateReview(policy, highRiskState({
+    body: packet({
+      risk: "high",
+      architecture: "documented",
+      invariants: [
+        "| Invariant | How this PR affects it | Why it remains valid | Evidence |",
+        "| - | - | - | - |",
+        "| INV-004 | Changes a parser path. | Table delimiter parsing still follows GFM. | `npm run test:review-gate` |",
+      ].join("\n"),
+      architectureRecord: "docs/architecture/invariants.md",
+      failureBehaviour: "Malformed packets fail closed.",
+      rollbackApproach: "Revert the parser change.",
+      rollbackEvidence: "No migration is required.",
+    }),
+  }));
+  assert.equal(result.state, "pass", result.blockers.join("\n"));
+  assert.deepEqual(result.packet.affectedInvariantRows, [{
+    invariant: "INV-004",
+    invariantIds: ["INV-004"],
+    affected: "Changes a parser path.",
+    valid: "Table delimiter parsing still follows GFM.",
+    evidence: "`npm run test:review-gate`",
+  }]);
+});
+
+test("invariant impact rows require a Markdown table delimiter", () => {
+  const result = evaluateReview(policy, highRiskState({
+    body: packet({
+      risk: "high",
+      architecture: "documented",
+      invariants: [
+        "Notes | context",
+        "INV-002 | Changes protected writes. | ACL remains enforced. | `npm run test -w @3fc/api`",
+      ].join("\n"),
+      architectureRecord: "docs/architecture/invariants.md",
+      failureBehaviour: "Invalid access fails closed.",
+      rollbackApproach: "Revert the change.",
+      rollbackEvidence: "No migration is required.",
+    }),
+  }));
+  assert.equal(result.state, "blocked");
+  assert.match(result.blockers.join("\n"), /invariant impact rows/);
+  assert.deepEqual(result.packet.affectedInvariantRows, []);
+});
+
+test("invariant impact rows require a delimiter matching the header width", () => {
+  const result = evaluateReview(policy, highRiskState({
+    body: packet({
+      risk: "high",
+      architecture: "documented",
+      invariants: [
+        "Notes | context",
+        "--- | --- | --- | ---",
+        "INV-002 | Changes protected writes. | ACL remains enforced. | `npm run test -w @3fc/api`",
+      ].join("\n"),
+      architectureRecord: "docs/architecture/invariants.md",
+      failureBehaviour: "Invalid access fails closed.",
+      rollbackApproach: "Revert the change.",
+      rollbackEvidence: "No migration is required.",
+    }),
+  }));
+  assert.equal(result.state, "blocked");
+  assert.match(result.blockers.join("\n"), /invariant impact rows/);
+  assert.deepEqual(result.packet.affectedInvariantRows, []);
+});
+
+test("invariant impact rows must be contiguous table rows", () => {
+  const result = evaluateReview(policy, highRiskState({
+    body: packet({
+      risk: "high",
+      architecture: "documented",
+      invariants: [
+        "Invariant | How this PR affects it | Why it remains valid | Evidence",
+        "--- | --- | --- | ---",
+        "ordinary prose terminates the table",
+        "INV-002 | Changes protected writes. | ACL remains enforced. | `npm run test -w @3fc/api`",
+      ].join("\n"),
+      architectureRecord: "docs/architecture/invariants.md",
+      failureBehaviour: "Invalid access fails closed.",
+      rollbackApproach: "Revert the change.",
+      rollbackEvidence: "No migration is required.",
+    }),
+  }));
+  assert.equal(result.state, "blocked");
+  assert.match(result.blockers.join("\n"), /invariant impact rows/);
+  assert.deepEqual(result.packet.affectedInvariantRows, []);
+});
+
+test("invariant impact rows reject multiple invariant IDs in one row", () => {
+  const result = evaluateReview(policy, highRiskState({
+    body: packet({
+      risk: "high",
+      architecture: "documented",
+      invariants: invariantTable(
+        "INV-002, INV-003",
+        "Changes protected idempotent writes.",
+        "ACL and idempotency remain enforced.",
+        "`npm run test -w @3fc/api`",
+      ),
+      architectureRecord: "docs/architecture/invariants.md",
+      failureBehaviour: "Invalid writes fail closed.",
+      rollbackApproach: "Revert the change.",
+      rollbackEvidence: "No migration is required.",
+    }),
+  }));
+  assert.equal(result.state, "blocked");
+  assert.match(result.blockers.join("\n"), /Affected invariant rows require/);
+  assert.equal(result.packet.affectedInvariantRows[0].invariant, "INV-002, INV-003");
+  assert.deepEqual(result.packet.affectedInvariantRows[0].invariantIds, ["INV-002", "INV-003"]);
+});
+
+test("invariant impact rows parse every table in the section", () => {
+  const result = evaluateReview(policy, highRiskState({
+    body: packet({
+      risk: "high",
+      architecture: "documented",
+      invariants: [
+        "| Invariant | How this PR affects it | Why it remains valid | Evidence |",
+        "| --- | --- | --- | --- |",
+        "| INV-002 | Changes protected writes. | ACL remains enforced. | `npm run test:review-gate` |",
+        "",
+        "| Invariant | How this PR affects it | Why it remains valid | Evidence |",
+        "| --- | --- | --- | --- |",
+        "| INV-003 | Changes idempotent write handling. |  |  |",
+      ].join("\n"),
+      architectureRecord: "docs/architecture/invariants.md",
+      failureBehaviour: "Invalid writes fail closed.",
+      rollbackApproach: "Revert the change.",
+      rollbackEvidence: "No migration is required.",
+    }),
+  }));
+  assert.equal(result.state, "blocked");
+  assert.match(result.blockers.join("\n"), /Affected invariant rows require/);
+  assert.deepEqual(result.packet.affectedInvariantRows, [
+    {
+      invariant: "INV-002",
+      invariantIds: ["INV-002"],
+      affected: "Changes protected writes.",
+      valid: "ACL remains enforced.",
+      evidence: "`npm run test:review-gate`",
+    },
+    {
+      invariant: "INV-003",
+      invariantIds: ["INV-003"],
+      affected: "Changes idempotent write handling.",
+      valid: "",
+      evidence: "",
+    },
+  ]);
 });
 
 test("packet parser rejects placeholder declared risk", () => {


### PR DESCRIPTION
<!-- review-packet-version:1 -->

## Behavioural claim

Review gate requires PR packets that list affected invariants to explain how each invariant is affected, why it remains valid, and what evidence supports that claim.

## Specification and acceptance evidence

| Acceptance criterion | Evidence | Result |
| --- | --- | --- |
| New PRs prompt authors for per-invariant impact detail. | `.github/pull_request_template.md` replaces the flat affected-invariant instruction with a four-column invariant impact table. | PASS |
| Review gate blocks high-risk PR packets that list invariant IDs without impact detail. | `npm run test:review-gate` includes `listed invariants require impact details`. | PASS |
| Review gate accepts complete invariant impact rows and keeps explicit `None` valid. | `npm run test:review-gate` includes `complete invariant impact rows satisfy high-risk invariant declaration`; existing high-risk `None` fixtures still pass. | PASS |
| Review gate accepts valid GitHub Markdown tables with or without outer pipes. | `npm run test:review-gate` includes `invariant impact rows accept tables without outer pipes`. | PASS |
| Review gate accepts escaped pipes and inline-code pipes inside table cells. | `npm run test:review-gate` includes `invariant impact rows accept escaped pipes and code-span pipes in cells`. | PASS |
| Review gate accepts multi-backtick inline-code pipes inside table cells. | `npm run test:review-gate` includes `invariant impact rows accept multi-backtick code-span pipes in cells`. | PASS |
| Review gate does not accept prose-with-pipes as an invariant impact table. | `npm run test:review-gate` includes `invariant impact rows require a Markdown table delimiter`. | PASS |
| Review gate requires the delimiter row to match the header width. | `npm run test:review-gate` includes `invariant impact rows require a delimiter matching the header width`. | PASS |
| Review gate only accepts rows that remain contiguous with the parsed Markdown table. | `npm run test:review-gate` includes `invariant impact rows must be contiguous table rows`. | PASS |
| Review gate requires each invariant impact row to name exactly one invariant. | `npm run test:review-gate` includes `invariant impact rows reject multiple invariant IDs in one row`. | PASS |
| Review gate accepts valid GFM delimiter cells with one-or-more hyphens. | `npm run test:review-gate` includes `invariant impact rows accept single-hyphen GFM delimiters`. | PASS |
| Review gate parses every invariant-impact table in the section. | `npm run test:review-gate` includes `invariant impact rows parse every table in the section`. | PASS |

## Scope boundaries

Included:

- Pull request template invariant-impact table.
- Review-gate packet parsing for invariant impact rows.
- Review-gate validation that requires complete impact rows or explicit `None`.
- Review-gate summary rendering for structured invariant rows.
- Invariant documentation guidance.

Excluded:

- Backfilling existing M2 PR packets.
- Changing product, API, app, data, or infrastructure behaviour.
- Changing the review risk tiers or required checks.

## Change classification

- Declared risk: `high`
- [ ] `documentation-only` — Documentation only
- [ ] `tests-only` — Tests only
- [ ] `application-behaviour` — Application or API behaviour
- [ ] `backlog-maintenance` — Canonical backlog maintenance
- [ ] `dependency-tooling` — Dependency or tooling
- [ ] `public-contract` — Public API or repository contract
- [ ] `data-migration` — Database schema or data migration
- [ ] `permission-trust-boundary` — Permission or trust boundary
- [ ] `durable-state-ownership` — Durable state or ownership
- [ ] `destructive-behaviour` — Destructive or difficult-to-reverse behaviour
- [ ] `new-production-dependency` — New production dependency
- [ ] `authentication-authorisation` — Authentication or authorisation
- [ ] `privacy-regulated-data` — Privacy or regulated data
- [ ] `infrastructure-production-configuration` — Infrastructure or deployment control
- [x] `review-policy` — Review policy, packet, or workflow

## Architecture and invariants

- [ ] `architecture:none`
- [x] `architecture:documented`
- [ ] `architecture:judgement-required`

### Affected invariants

None.

### Architecture or decision record

`docs/architecture/invariants.md` now documents the required per-invariant explanation and evidence fields. No ADR is needed because this changes review packet validation rather than product architecture.

## Failure and rollback

### Failure behaviour

If the rule is too strict or parses valid packets incorrectly, review gate will mark affected PRs as awaiting evidence until the packet is rewritten or this change is reverted.

### Rollback approach

Revert this PR to restore the previous flat invariant ID list acceptance.

### Rollback evidence

Rollback is a single review-gate/template commit revert. No durable state, production data, or deployed application behaviour changes.

## Automated and agent review disposition

### Unresolved blocking findings

None.

### Rejected findings and evidence

None.

## Human judgement

- [x] `human-judgement:none`
- [ ] `human-judgement:required`

### Decision requiring judgement

None.

### Options considered

None.

### Reason selected

None.

### Reversal cost

None.

## Review focus

- Whether the invariant table captures enough detail for reviewers without becoming heavy process.
- `scripts/review-gate/packet.mjs`
- `scripts/review-gate/evaluate.mjs`
- `.github/pull_request_template.md`
