### PR TITLE
[codex] Add mobile game workflow modes

### DIFF
--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -2419,6 +2419,7 @@ test("game page renders final team logs and aggregate player stats", async () =>
   assert.match(ownGoalStats.textContent ?? "", /Bea\s*1/);
   assert.equal(fullGoalLog.querySelectorAll('[data-ui="final-goal-item"]').length, 3);
   assert.match(fullGoalLog.textContent ?? "", /43"/);
+  assert.match(fullGoalLog.textContent ?? "", /Third 2/);
 });
 
 test("game page remains usable when goal timeline load fails", async () => {

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -2009,6 +2009,150 @@ test("game page quick-creates and assigns roster players", async () => {
   assert.match(goalFormNote.textContent ?? "", /third 2/);
 });
 
+test("game page mode panels switch without resetting a goal draft", async () => {
+  const apiState = createMockApiState();
+  const runningThirds = createDefaultThirdTimerSegments();
+  runningThirds[0] = {
+    ...runningThirds[0],
+    startedAt: "2026-03-28T11:00:10.000Z",
+  };
+  seedGoalScoringGame(apiState, {
+    gameId: "game-mode-draft",
+    status: "live",
+    thirds: runningThirds,
+  });
+
+  const page = await bootPage({
+    html: renderGamePage("http://localhost:3001", { gameId: "game-mode-draft" }),
+    url: "http://localhost:3000/games/game-mode-draft",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+
+  const runMode = page.document.getElementById("game-mode-run");
+  const playersMode = page.document.getElementById("game-mode-players");
+  const playersTab = page.document.querySelector('[data-action="select-game-mode"][data-game-mode="players"]');
+  const runTab = page.document.querySelector('[data-action="select-game-mode"][data-game-mode="run"]');
+  const scoringTeamInput = page.document.getElementById("goal-scoring-team");
+  const concedingTeamInput = page.document.getElementById("goal-conceding-team");
+  const scorerInput = page.document.getElementById("goal-scorer");
+  const assistsElement = page.document.getElementById("goal-assists");
+
+  assert(runMode instanceof page.window.HTMLElement);
+  assert(playersMode instanceof page.window.HTMLElement);
+  assert(playersTab instanceof page.window.HTMLButtonElement);
+  assert(runTab instanceof page.window.HTMLButtonElement);
+  assert(scoringTeamInput instanceof page.window.HTMLSelectElement);
+  assert(concedingTeamInput instanceof page.window.HTMLSelectElement);
+  assert(scorerInput instanceof page.window.HTMLSelectElement);
+  assert(assistsElement instanceof page.window.HTMLElement);
+  assert.equal(runMode.hidden, false);
+
+  scoringTeamInput.value = "red";
+  scoringTeamInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+  concedingTeamInput.value = "blue";
+  concedingTeamInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+  scorerInput.value = "player-ari";
+  scorerInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+  const beaAssist = assistsElement.querySelector('input[value="player-bea"]');
+  assert(beaAssist instanceof page.window.HTMLInputElement);
+  beaAssist.checked = true;
+  beaAssist.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+
+  dispatchClick(playersTab);
+  await flushAsync();
+  assert.equal(playersMode.hidden, false);
+  assert.equal(runMode.hidden, true);
+
+  dispatchClick(runTab);
+  await flushAsync();
+  assert.equal(runMode.hidden, false);
+  assert.equal(scoringTeamInput.value, "red");
+  assert.equal(concedingTeamInput.value, "blue");
+  assert.equal(scorerInput.value, "player-ari");
+  const preservedAssist = assistsElement.querySelector('input[value="player-bea"]');
+  assert(preservedAssist instanceof page.window.HTMLInputElement);
+  assert.equal(preservedAssist.checked, true);
+});
+
+test("game page mode panels advance from setup to run and finalisation", async () => {
+  const apiState = createMockApiState();
+  seedGoalScoringGame(apiState, {
+    gameId: "game-mode-advance",
+  });
+  apiState.roster.clear();
+
+  const page = await bootPage({
+    html: renderGamePage("http://localhost:3001", { gameId: "game-mode-advance" }),
+    url: "http://localhost:3000/games/game-mode-advance",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+
+  const structureMode = page.document.getElementById("game-mode-structure");
+  const playersMode = page.document.getElementById("game-mode-players");
+  const runMode = page.document.getElementById("game-mode-run");
+  const finalMode = page.document.getElementById("game-mode-final");
+  const playersTab = page.document.querySelector('[data-action="select-game-mode"][data-game-mode="players"]');
+  const runTab = page.document.querySelector('[data-action="select-game-mode"][data-game-mode="run"]');
+  const startThirdButton = page.document.querySelector('[data-action="start-active-third"]');
+  const finishThirdButton = page.document.querySelector('[data-action="finish-active-third"]');
+  const finishGameButton = page.document.querySelector('[data-action="finish-game"]');
+  const resultSummary = page.document.getElementById("game-result-summary");
+  const finalReadiness = page.document.getElementById("final-game-readiness");
+
+  assert(structureMode instanceof page.window.HTMLElement);
+  assert(playersMode instanceof page.window.HTMLElement);
+  assert(runMode instanceof page.window.HTMLElement);
+  assert(finalMode instanceof page.window.HTMLElement);
+  assert(playersTab instanceof page.window.HTMLButtonElement);
+  assert(runTab instanceof page.window.HTMLButtonElement);
+  assert(startThirdButton instanceof page.window.HTMLButtonElement);
+  assert(finishThirdButton instanceof page.window.HTMLButtonElement);
+  assert(finishGameButton instanceof page.window.HTMLButtonElement);
+  assert(resultSummary instanceof page.window.HTMLElement);
+  assert(finalReadiness instanceof page.window.HTMLElement);
+  assert.equal(structureMode.hidden, false);
+  assert.equal(playersMode.hidden, true);
+
+  dispatchClick(playersTab);
+  await flushAsync();
+  assert.equal(structureMode.hidden, true);
+  assert.equal(playersMode.hidden, false);
+
+  dispatchClick(runTab);
+  await flushAsync();
+  assert.equal(runMode.hidden, false);
+
+  dispatchClick(startThirdButton);
+  await flushAsync();
+  assert.equal(runMode.hidden, false);
+  assert.match(finalReadiness.textContent ?? "", /Running/);
+
+  dispatchClick(finishThirdButton);
+  await flushAsync();
+  dispatchClick(startThirdButton);
+  await flushAsync();
+  dispatchClick(finishThirdButton);
+  await flushAsync();
+  dispatchClick(startThirdButton);
+  await flushAsync();
+  dispatchClick(finishThirdButton);
+  await flushAsync();
+
+  assert.equal(finalMode.hidden, false);
+  assert.match(finalReadiness.textContent ?? "", /Ready to finish/);
+  assert.equal(finishGameButton.disabled, false);
+
+  dispatchClick(finishGameButton);
+  await flushAsync();
+
+  assert.equal(apiState.games.get("game-mode-advance")?.status, "finished");
+  assert.equal(finalMode.hidden, false);
+  assert.equal(resultSummary.hidden, false);
+  assert.match(resultSummary.textContent ?? "", /Draw/);
+});
+
 test("game page remains usable when goal timeline load fails", async () => {
   const apiState = createMockApiState();
   apiState.session = {

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -3154,7 +3154,7 @@ test("game page reconciles current goals after stale correction replay", async (
   assert.match(timeline.textContent ?? "", /Cy for Blue/);
 });
 
-test("game page keeps current goals when correction replay refresh fails", async () => {
+test("game page invalidates current goals when correction replay refresh fails", async () => {
   const apiState = createMockApiState();
   const thirds = createDefaultThirdTimerSegments();
   thirds[0] = {
@@ -3243,10 +3243,12 @@ test("game page keeps current goals when correction replay refresh fails", async
 
   const editGoalButton = page.document.querySelector('[data-action="edit-goal"][data-event-id="goal-1"]');
   const saveGoalButton = page.document.querySelector('[data-action="save-goal"]');
+  const undoLastGoalButton = page.document.querySelector('[data-action="undo-last-goal"]');
   const timeline = page.document.getElementById("goal-timeline");
   const status = page.document.getElementById("setup-status");
   assert(editGoalButton instanceof page.window.HTMLButtonElement);
   assert(saveGoalButton instanceof page.window.HTMLButtonElement);
+  assert(undoLastGoalButton instanceof page.window.HTMLButtonElement);
   assert(timeline instanceof page.window.HTMLElement);
   assert(status instanceof page.window.HTMLElement);
   assert.match(timeline.textContent ?? "", /Cy for Blue/);
@@ -3258,7 +3260,10 @@ test("game page keeps current goals when correction replay refresh fails", async
   await flushAsync();
 
   assert.match(status.textContent ?? "", /Goal save failed/);
-  assert.match(timeline.textContent ?? "", /Cy for Blue/);
+  assert.match(timeline.textContent ?? "", /Goal timeline unavailable/);
+  assert.doesNotMatch(timeline.textContent ?? "", /Cy for Blue/);
+  assert.equal(saveGoalButton.disabled, true);
+  assert.equal(undoLastGoalButton.disabled, true);
 });
 
 test("game page renders malformed result data without crashing", async () => {

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -1404,6 +1404,12 @@ async function flushAsync(): Promise<void> {
   await Promise.resolve();
 }
 
+function expectedLocalTimestamp(isoTimestamp: string): string {
+  const parsed = new Date(isoTimestamp);
+  const local = new Date(parsed.getTime() - parsed.getTimezoneOffset() * 60000);
+  return local.toISOString().slice(0, 16).replace("T", " ");
+}
+
 async function bootPage(input: {
   html: string;
   url: string;
@@ -1680,6 +1686,27 @@ test("setup flow shows inline validation for blank required fields", async () =>
   assert.equal(gameKickoffNotice.textContent, "Kickoff time must be valid.");
 });
 
+test("season page renders game kickoff times in the user local timezone", async () => {
+  const apiState = createMockApiState();
+  seedGoalScoringGame(apiState, {
+    gameId: "game-season-local-time",
+  });
+
+  const page = await bootPage({
+    html: renderSeasonPage("http://localhost:3001", "autumn-cup"),
+    url: "http://localhost:3000/seasons/autumn-cup",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+
+  const gamesBody = page.document.getElementById("season-games-body");
+  const game = apiState.games.get("game-season-local-time");
+  assert(gamesBody instanceof page.window.HTMLElement);
+  assert(game);
+  assert.match(gamesBody.textContent ?? "", new RegExp(expectedLocalTimestamp(game.gameStartTs)));
+  assert.doesNotMatch(gamesBody.textContent ?? "", /Z\b|UTC/);
+});
+
 test("setup happy path runs from sign-in to created game context", async () => {
   const apiState = createMockApiState();
 
@@ -1782,6 +1809,9 @@ test("setup happy path runs from sign-in to created game context", async () => {
   dispatchClick(createGameButton);
   await flushAsync();
 
+  const createdGame = apiState.games.get(gameId);
+  assert(createdGame);
+
   const gameNavigation = seasonPage.navigations.at(-1);
   assert(gameNavigation);
   assert.equal(gameNavigation.url, `/games/${gameId}`);
@@ -1794,11 +1824,14 @@ test("setup happy path runs from sign-in to created game context", async () => {
   });
 
   const title = gamePage.document.getElementById("game-title");
+  const subtitle = gamePage.document.getElementById("game-subtitle");
   const leagueId = gamePage.document.getElementById("game-league-id");
   const seasonId = gamePage.document.getElementById("game-season-id");
   const createAnotherLink = gamePage.document.getElementById("create-another-game-link");
 
   assert.equal(title?.textContent, gameId);
+  assert.match(subtitle?.textContent ?? "", new RegExp(expectedLocalTimestamp(createdGame.gameStartTs)));
+  assert.doesNotMatch(subtitle?.textContent ?? "", /Z\b|UTC/);
   assert.equal(leagueId?.textContent, "three-sided-football-club");
   assert.equal(seasonId?.textContent, "autumn-cup");
   assert.equal(createAnotherLink?.getAttribute("href"), "/seasons/autumn-cup");
@@ -2143,11 +2176,13 @@ test("game page mode panels advance from setup to run and finalisation", async (
   const finalMode = page.document.getElementById("game-mode-final");
   const playersTab = page.document.querySelector('[data-action="select-game-mode"][data-game-mode="players"]');
   const runTab = page.document.querySelector('[data-action="select-game-mode"][data-game-mode="run"]');
+  const gameStateTab = page.document.querySelector('[data-testid="game-mode-final-tab"]');
   const startThirdButton = page.document.querySelector('[data-action="start-active-third"]');
   const finishThirdButton = page.document.querySelector('[data-action="finish-active-third"]');
   const finishGameButton = page.document.querySelector('[data-action="finish-game"]');
   const resultSummary = page.document.getElementById("game-result-summary");
   const finalReadiness = page.document.getElementById("final-game-readiness");
+  const thirdStatusList = page.document.getElementById("third-status-list");
 
   assert(structureMode instanceof page.window.HTMLElement);
   assert(playersMode instanceof page.window.HTMLElement);
@@ -2155,13 +2190,23 @@ test("game page mode panels advance from setup to run and finalisation", async (
   assert(finalMode instanceof page.window.HTMLElement);
   assert(playersTab instanceof page.window.HTMLButtonElement);
   assert(runTab instanceof page.window.HTMLButtonElement);
+  assert(gameStateTab instanceof page.window.HTMLButtonElement);
   assert(startThirdButton instanceof page.window.HTMLButtonElement);
   assert(finishThirdButton instanceof page.window.HTMLButtonElement);
   assert(finishGameButton instanceof page.window.HTMLButtonElement);
   assert(resultSummary instanceof page.window.HTMLElement);
   assert(finalReadiness instanceof page.window.HTMLElement);
+  assert(thirdStatusList instanceof page.window.HTMLElement);
   assert.equal(structureMode.hidden, false);
   assert.equal(playersMode.hidden, true);
+  assert.match(gameStateTab.textContent ?? "", /Pregame/);
+  assert.match(gameStateTab.textContent ?? "", /Start clock/);
+  assert.equal(gameStateTab.getAttribute("data-game-state"), "pregame");
+
+  dispatchClick(gameStateTab);
+  await flushAsync();
+  assert.equal(runMode.hidden, false);
+  assert.equal(page.document.activeElement, startThirdButton);
 
   dispatchClick(playersTab);
   await flushAsync();
@@ -2176,9 +2221,27 @@ test("game page mode panels advance from setup to run and finalisation", async (
   await flushAsync();
   assert.equal(runMode.hidden, false);
   assert.match(finalReadiness.textContent ?? "", /Running/);
+  assert.match(gameStateTab.textContent ?? "", /Third 1/);
+  assert.equal(gameStateTab.getAttribute("data-game-state"), "running");
+
+  dispatchClick(gameStateTab);
+  await flushAsync();
+  assert.equal(runMode.hidden, false);
+  assert.equal(page.document.activeElement, finishThirdButton);
 
   dispatchClick(finishThirdButton);
   await flushAsync();
+  assert.match(thirdStatusList.textContent ?? "", new RegExp(expectedLocalTimestamp("2026-03-28T11:00:11.000Z")));
+  assert.doesNotMatch(thirdStatusList.textContent ?? "", /Z\b|UTC/);
+  assert.match(gameStateTab.textContent ?? "", /Break/);
+  assert.match(gameStateTab.textContent ?? "", /Start T2/);
+  assert.equal(gameStateTab.getAttribute("data-game-state"), "break");
+
+  dispatchClick(gameStateTab);
+  await flushAsync();
+  assert.equal(runMode.hidden, false);
+  assert.equal(page.document.activeElement, startThirdButton);
+
   dispatchClick(startThirdButton);
   await flushAsync();
   dispatchClick(finishThirdButton);
@@ -2190,13 +2253,23 @@ test("game page mode panels advance from setup to run and finalisation", async (
 
   assert.equal(finalMode.hidden, false);
   assert.match(finalReadiness.textContent ?? "", /Ready to finish/);
+  assert.match(gameStateTab.textContent ?? "", /Final/);
+  assert.match(gameStateTab.textContent ?? "", /Finish game/);
+  assert.equal(gameStateTab.getAttribute("data-game-state"), "ready");
   assert.equal(finishGameButton.disabled, false);
+
+  dispatchClick(gameStateTab);
+  await flushAsync();
+  assert.equal(finalMode.hidden, false);
+  assert.equal(page.document.activeElement, finishGameButton);
 
   dispatchClick(finishGameButton);
   await flushAsync();
 
   assert.equal(apiState.games.get("game-mode-advance")?.status, "finished");
   assert.equal(finalMode.hidden, false);
+  assert.match(gameStateTab.textContent ?? "", /Summary/);
+  assert.equal(gameStateTab.getAttribute("data-game-state"), "finished");
   assert.equal(resultSummary.hidden, false);
   assert.match(resultSummary.textContent ?? "", /Draw/);
 });
@@ -2270,12 +2343,12 @@ test("game page renders final team logs and aggregate player stats", async () =>
     {
       gameId: "game-final-stats",
       eventId: "goal-2",
-      third: 1,
-      thirdMinute: 2,
-      gameMinute: 2,
-      elapsedSeconds: 90,
+      third: 2,
+      thirdMinute: 18,
+      gameMinute: 43,
+      elapsedSeconds: 1080,
       stoppageMinute: null,
-      displayTime: "2'",
+      displayTime: "18:00",
       scoringTeamId: "blue",
       concedingTeamId: "yellow",
       scorerPlayerId: "player-cy",
@@ -2287,12 +2360,12 @@ test("game page renders final team logs and aggregate player stats", async () =>
     {
       gameId: "game-final-stats",
       eventId: "goal-3",
-      third: 2,
-      thirdMinute: 4,
-      gameMinute: 24,
-      elapsedSeconds: 240,
-      stoppageMinute: null,
-      displayTime: "4'",
+      third: 1,
+      thirdMinute: 25,
+      gameMinute: 25,
+      elapsedSeconds: 1680,
+      stoppageMinute: 3,
+      displayTime: "25+03",
       scoringTeamId: null,
       concedingTeamId: "red",
       scorerPlayerId: "player-bea",
@@ -2308,6 +2381,7 @@ test("game page renders final team logs and aggregate player stats", async () =>
 
   const seededGame = apiState.games.get("game-final-stats");
   assert(seededGame);
+  seededGame.thirdLengthMinutes = 25;
   refreshMockFinishedResult(apiState, seededGame, "2026-03-28T11:02:00.000Z");
 
   const page = await bootPage({
@@ -2331,15 +2405,20 @@ test("game page renders final team logs and aggregate player stats", async () =>
   assert(ownGoalStats instanceof page.window.HTMLElement);
   assert(fullGoalLog instanceof page.window.HTMLElement);
   assert.equal(resultSummary.hidden, false);
+  assert.match(resultSummary.textContent ?? "", new RegExp(expectedLocalTimestamp("2026-03-28T11:02:00.000Z")));
+  assert.doesNotMatch(resultSummary.textContent ?? "", /Z\b|UTC/);
   assert.match(redTeamLog.textContent ?? "", /Ari/);
+  assert.match(redTeamLog.textContent ?? "", /1"/);
   assert.match(redTeamLog.textContent ?? "", /Assisted by Bea/);
   assert.match(redTeamLog.textContent ?? "", /Bea own goal/);
+  assert.match(redTeamLog.textContent ?? "", /25\+3"/);
   assert.match(redTeamLog.textContent ?? "", /Conceded-only own goal/);
   assert.match(scorerStats.textContent ?? "", /Ari\s*1/);
   assert.match(scorerStats.textContent ?? "", /Cy\s*1/);
   assert.match(assistStats.textContent ?? "", /Bea\s*1/);
   assert.match(ownGoalStats.textContent ?? "", /Bea\s*1/);
   assert.equal(fullGoalLog.querySelectorAll('[data-ui="final-goal-item"]').length, 3);
+  assert.match(fullGoalLog.textContent ?? "", /43"/);
 });
 
 test("game page remains usable when goal timeline load fails", async () => {

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -2153,6 +2153,41 @@ test("game page mode panels advance from setup to run and finalisation", async (
   assert.match(resultSummary.textContent ?? "", /Draw/);
 });
 
+test("game page resumes completed live timers in finalisation mode", async () => {
+  const apiState = createMockApiState();
+  const completeThirds = createDefaultThirdTimerSegments().map((third) => ({
+    ...third,
+    startedAt: `2026-03-28T11:0${third.third}:00.000Z`,
+    finishedAt: `2026-03-28T11:1${third.third}:00.000Z`,
+  }));
+  seedGoalScoringGame(apiState, {
+    gameId: "game-mode-complete",
+    status: "live",
+    thirds: completeThirds,
+  });
+
+  const page = await bootPage({
+    html: renderGamePage("http://localhost:3001", { gameId: "game-mode-complete" }),
+    url: "http://localhost:3000/games/game-mode-complete",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+
+  const runMode = page.document.getElementById("game-mode-run");
+  const finalMode = page.document.getElementById("game-mode-final");
+  const finishGameButton = page.document.querySelector('[data-action="finish-game"]');
+  const finalReadiness = page.document.getElementById("final-game-readiness");
+
+  assert(runMode instanceof page.window.HTMLElement);
+  assert(finalMode instanceof page.window.HTMLElement);
+  assert(finishGameButton instanceof page.window.HTMLButtonElement);
+  assert(finalReadiness instanceof page.window.HTMLElement);
+  assert.equal(runMode.hidden, true);
+  assert.equal(finalMode.hidden, false);
+  assert.equal(finishGameButton.disabled, false);
+  assert.match(finalReadiness.textContent ?? "", /Ready to finish/);
+});
+
 test("game page remains usable when goal timeline load fails", async () => {
   const apiState = createMockApiState();
   apiState.session = {

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -2204,11 +2204,16 @@ test("game page mode panels advance from setup to run and finalisation", async (
   assert.equal(playersMode.hidden, true);
   assert.match(gameStateTab.textContent ?? "", /Pregame/);
   assert.match(gameStateTab.textContent ?? "", /Start clock/);
+  assert.equal(gameStateTab.getAttribute("role"), null);
+  assert.equal(gameStateTab.getAttribute("aria-controls"), null);
+  assert.equal(gameStateTab.getAttribute("aria-pressed"), "false");
   assert.equal(gameStateTab.getAttribute("data-game-state"), "pregame");
 
   dispatchClick(gameStateTab);
   await flushAsync();
   assert.equal(runMode.hidden, false);
+  assert.equal(runTab.getAttribute("aria-pressed"), "true");
+  assert.equal(gameStateTab.getAttribute("aria-pressed"), "false");
   assert.equal(page.document.activeElement, startThirdButton);
 
   dispatchClick(playersTab);
@@ -2259,6 +2264,7 @@ test("game page mode panels advance from setup to run and finalisation", async (
   assert.match(gameStateTab.textContent ?? "", /Final/);
   assert.match(gameStateTab.textContent ?? "", /Finish game/);
   assert.equal(gameStateTab.getAttribute("data-game-state"), "ready");
+  assert.equal(gameStateTab.getAttribute("aria-pressed"), "true");
   assert.equal(finishGameButton.disabled, false);
 
   dispatchClick(gameStateTab);

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -2075,6 +2075,54 @@ test("game page mode panels switch without resetting a goal draft", async () => 
   assert.equal(preservedAssist.checked, true);
 });
 
+test("game page preserves run mode after live game metadata save", async () => {
+  const apiState = createMockApiState();
+  const runningThirds = createDefaultThirdTimerSegments();
+  runningThirds[0] = {
+    ...runningThirds[0],
+    startedAt: "2026-03-28T11:00:10.000Z",
+  };
+  seedGoalScoringGame(apiState, {
+    gameId: "game-mode-save-running",
+    status: "live",
+    thirds: runningThirds,
+  });
+
+  const page = await bootPage({
+    html: renderGamePage("http://localhost:3001", { gameId: "game-mode-save-running" }),
+    url: "http://localhost:3000/games/game-mode-save-running",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+
+  const structureMode = page.document.getElementById("game-mode-structure");
+  const runMode = page.document.getElementById("game-mode-run");
+  const structureTab = page.document.querySelector('[data-action="select-game-mode"][data-game-mode="structure"]');
+  const kickoffInput = page.document.getElementById("game-edit-kickoff");
+  const saveGameButton = page.document.querySelector('[data-action="save-game"]');
+
+  assert(structureMode instanceof page.window.HTMLElement);
+  assert(runMode instanceof page.window.HTMLElement);
+  assert(structureTab instanceof page.window.HTMLButtonElement);
+  assert(kickoffInput instanceof page.window.HTMLInputElement);
+  assert(saveGameButton instanceof page.window.HTMLButtonElement);
+  assert.equal(runMode.hidden, false);
+
+  dispatchClick(structureTab);
+  await flushAsync();
+  assert.equal(structureMode.hidden, false);
+  assert.equal(runMode.hidden, true);
+
+  kickoffInput.value = "2026-03-28T10:30";
+  kickoffInput.dispatchEvent(new page.window.Event("input", { bubbles: true }));
+  dispatchClick(saveGameButton);
+  await flushAsync();
+
+  assert.equal(apiState.games.get("game-mode-save-running")?.gameStartTs, new Date("2026-03-28T10:30").toISOString());
+  assert.equal(structureMode.hidden, true);
+  assert.equal(runMode.hidden, false);
+});
+
 test("game page mode panels advance from setup to run and finalisation", async () => {
   const apiState = createMockApiState();
   seedGoalScoringGame(apiState, {
@@ -2186,6 +2234,112 @@ test("game page resumes completed live timers in finalisation mode", async () =>
   assert.equal(finalMode.hidden, false);
   assert.equal(finishGameButton.disabled, false);
   assert.match(finalReadiness.textContent ?? "", /Ready to finish/);
+});
+
+test("game page renders final team logs and aggregate player stats", async () => {
+  const apiState = createMockApiState();
+  const completeThirds = createDefaultThirdTimerSegments().map((third) => ({
+    ...third,
+    startedAt: `2026-03-28T11:0${third.third}:00.000Z`,
+    finishedAt: `2026-03-28T11:1${third.third}:00.000Z`,
+  }));
+  seedGoalScoringGame(apiState, {
+    gameId: "game-final-stats",
+    status: "finished",
+    thirds: completeThirds,
+  });
+
+  const goals: MockGoalEvent[] = [
+    {
+      gameId: "game-final-stats",
+      eventId: "goal-1",
+      third: 1,
+      thirdMinute: 1,
+      gameMinute: 1,
+      elapsedSeconds: 30,
+      stoppageMinute: null,
+      displayTime: "1'",
+      scoringTeamId: "red",
+      concedingTeamId: "blue",
+      scorerPlayerId: "player-ari",
+      assistPlayerIds: ["player-bea"],
+      ownGoal: false,
+      createdAt: "2026-03-28T11:01:01.000Z",
+      updatedAt: "2026-03-28T11:01:01.000Z",
+    },
+    {
+      gameId: "game-final-stats",
+      eventId: "goal-2",
+      third: 1,
+      thirdMinute: 2,
+      gameMinute: 2,
+      elapsedSeconds: 90,
+      stoppageMinute: null,
+      displayTime: "2'",
+      scoringTeamId: "blue",
+      concedingTeamId: "yellow",
+      scorerPlayerId: "player-cy",
+      assistPlayerIds: [],
+      ownGoal: false,
+      createdAt: "2026-03-28T11:01:02.000Z",
+      updatedAt: "2026-03-28T11:01:02.000Z",
+    },
+    {
+      gameId: "game-final-stats",
+      eventId: "goal-3",
+      third: 2,
+      thirdMinute: 4,
+      gameMinute: 24,
+      elapsedSeconds: 240,
+      stoppageMinute: null,
+      displayTime: "4'",
+      scoringTeamId: null,
+      concedingTeamId: "red",
+      scorerPlayerId: "player-bea",
+      assistPlayerIds: [],
+      ownGoal: true,
+      createdAt: "2026-03-28T11:01:03.000Z",
+      updatedAt: "2026-03-28T11:01:03.000Z",
+    },
+  ];
+  for (const goal of goals) {
+    apiState.goalEvents.set(goal.eventId, goal);
+  }
+
+  const seededGame = apiState.games.get("game-final-stats");
+  assert(seededGame);
+  refreshMockFinishedResult(apiState, seededGame, "2026-03-28T11:02:00.000Z");
+
+  const page = await bootPage({
+    html: renderGamePage("http://localhost:3001", { gameId: "game-final-stats" }),
+    url: "http://localhost:3000/games/game-final-stats",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+
+  const resultSummary = page.document.getElementById("game-result-summary");
+  const redTeamLog = page.document.querySelector('[data-testid="final-team-log-red"]');
+  const scorerStats = page.document.querySelector('[data-testid="final-scorer-stats"]');
+  const assistStats = page.document.querySelector('[data-testid="final-assist-stats"]');
+  const ownGoalStats = page.document.querySelector('[data-testid="final-own-goal-stats"]');
+  const fullGoalLog = page.document.querySelector('[data-testid="final-full-goal-log"]');
+
+  assert(resultSummary instanceof page.window.HTMLElement);
+  assert(redTeamLog instanceof page.window.HTMLElement);
+  assert(scorerStats instanceof page.window.HTMLElement);
+  assert(assistStats instanceof page.window.HTMLElement);
+  assert(ownGoalStats instanceof page.window.HTMLElement);
+  assert(fullGoalLog instanceof page.window.HTMLElement);
+  assert.equal(resultSummary.hidden, false);
+  assert.match(redTeamLog.textContent ?? "", /Ari/);
+  assert.match(redTeamLog.textContent ?? "", /Assisted by Bea/);
+  assert.match(redTeamLog.textContent ?? "", /Bea own goal/);
+  assert.match(redTeamLog.textContent ?? "", /Conceded-only own goal/);
+  assert.match(scorerStats.textContent ?? "", /Ari\s*1/);
+  assert.match(scorerStats.textContent ?? "", /Cy\s*1/);
+  assert.match(assistStats.textContent ?? "", /Bea\s*1/);
+  assert.match(ownGoalStats.textContent ?? "", /Bea\s*1/);
+  assert.equal(fullGoalLog.querySelectorAll('[data-ui="final-goal-item"]').length, 3);
 });
 
 test("game page remains usable when goal timeline load fails", async () => {

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -1416,6 +1416,7 @@ async function bootPage(input: {
   scriptFile: string;
   apiState: MockApiState;
   fetch?: ReturnType<typeof createMockFetch>;
+  flushOnBoot?: boolean;
 }) {
   const dom = new JSDOM(input.html, {
     url: input.url,
@@ -1469,7 +1470,9 @@ async function bootPage(input: {
   });
 
   window.eval(readUiScript(input.scriptFile));
-  await flushAsync();
+  if (input.flushOnBoot !== false) {
+    await flushAsync();
+  }
 
   return {
     dom,
@@ -2274,6 +2277,72 @@ test("game page mode panels advance from setup to run and finalisation", async (
   assert.match(resultSummary.textContent ?? "", /Draw/);
 });
 
+test("game page retries early game-state tab selection after initial game loading", async () => {
+  const apiState = createMockApiState();
+  const runningThirds = createDefaultThirdTimerSegments();
+  runningThirds[0] = {
+    ...runningThirds[0],
+    startedAt: "2026-03-28T11:00:10.000Z",
+  };
+  seedGoalScoringGame(apiState, {
+    gameId: "game-state-loading",
+    status: "live",
+    thirds: runningThirds,
+  });
+
+  const defaultFetch = createMockFetch(apiState);
+  let resolveGameResponse: (response: Response) => void = () => undefined;
+  const delayedGameResponse = new Promise<Response>((resolve) => {
+    resolveGameResponse = resolve;
+  });
+  let delayInitialGameRequest = true;
+  const delayedGameFetch: ReturnType<typeof createMockFetch> = async (input, init = {}) => {
+    const target =
+      typeof input === "string" || input instanceof URL
+        ? new URL(String(input))
+        : new URL(input.url);
+    const method = (init.method ?? "GET").toUpperCase();
+    if (delayInitialGameRequest && method === "GET" && target.pathname === "/v1/games/game-state-loading") {
+      delayInitialGameRequest = false;
+      return delayedGameResponse;
+    }
+
+    return defaultFetch(input, init);
+  };
+
+  const page = await bootPage({
+    html: renderGamePage("http://localhost:3001", { gameId: "game-state-loading" }),
+    url: "http://localhost:3000/games/game-state-loading",
+    scriptFile: "setup-flow.js",
+    apiState,
+    fetch: delayedGameFetch,
+    flushOnBoot: false,
+  });
+
+  const structureMode = page.document.getElementById("game-mode-structure");
+  const runMode = page.document.getElementById("game-mode-run");
+  const gameStateTab = page.document.querySelector('[data-testid="game-mode-final-tab"]');
+
+  assert(structureMode instanceof page.window.HTMLElement);
+  assert(runMode instanceof page.window.HTMLElement);
+  assert(gameStateTab instanceof page.window.HTMLButtonElement);
+
+  dispatchClick(gameStateTab);
+  await flushAsync();
+  assert.equal(structureMode.hidden, false);
+  assert.equal(runMode.hidden, true);
+  assert.equal(gameStateTab.getAttribute("data-game-state"), "loading");
+
+  const game = apiState.games.get("game-state-loading");
+  assert(game);
+  resolveGameResponse(createJsonResponse(200, game));
+  await flushAsync();
+
+  assert.equal(structureMode.hidden, true);
+  assert.equal(runMode.hidden, false);
+  assert.equal(gameStateTab.getAttribute("data-game-state"), "running");
+});
+
 test("game page resumes completed live timers in finalisation mode", async () => {
   const apiState = createMockApiState();
   const completeThirds = createDefaultThirdTimerSegments().map((third) => ({
@@ -2424,35 +2493,37 @@ test("game page renders final team logs and aggregate player stats", async () =>
 
 test("game page remains usable when goal timeline load fails", async () => {
   const apiState = createMockApiState();
-  apiState.session = {
-    sessionId: "session-1",
-    email: "scorekeeper@3fc.football",
-    createdAt: "2026-03-28T11:00:00.000Z",
-    expiresAt: "2026-03-29T11:00:00.000Z",
-  };
-  apiState.cookieJar = "threefc_session=session-1";
-  apiState.seasons.set("autumn-cup", {
-    leagueId: "three-sided-football-club",
-    seasonId: "autumn-cup",
-    name: "Autumn Cup",
-    slug: "autumn-cup",
-    startsOn: null,
-    endsOn: null,
-    createdAt: "2026-03-28T11:00:02.000Z",
-    updatedAt: "2026-03-28T11:00:02.000Z",
-  });
-  apiState.games.set("game-goals-fail", {
+  const completeThirds = createDefaultThirdTimerSegments().map((third) => ({
+    ...third,
+    startedAt: `2026-03-28T11:0${third.third}:00.000Z`,
+    finishedAt: `2026-03-28T11:1${third.third}:00.000Z`,
+  }));
+  seedGoalScoringGame(apiState, {
     gameId: "game-goals-fail",
-    leagueId: "three-sided-football-club",
-    seasonId: "autumn-cup",
-    sessionId: "20260328",
-    status: "scheduled",
-    gameStartTs: "2026-03-28T10:00:00.000Z",
-    thirdLengthMinutes: DEFAULT_THIRD_LENGTH_MINUTES,
-    thirds: createDefaultThirdTimerSegments(),
-    createdAt: "2026-03-28T11:00:03.000Z",
-    updatedAt: "2026-03-28T11:00:03.000Z",
+    status: "finished",
+    thirds: completeThirds,
+    role: "admin",
   });
+  apiState.goalEvents.set("goal-unavailable-1", {
+    gameId: "game-goals-fail",
+    eventId: "goal-unavailable-1",
+    third: 1,
+    thirdMinute: 1,
+    gameMinute: 1,
+    elapsedSeconds: 30,
+    stoppageMinute: null,
+    displayTime: "1'",
+    scoringTeamId: "red",
+    concedingTeamId: "blue",
+    scorerPlayerId: "player-ari",
+    assistPlayerIds: ["player-bea"],
+    ownGoal: false,
+    createdAt: "2026-03-28T11:01:00.000Z",
+    updatedAt: "2026-03-28T11:01:00.000Z",
+  });
+  const seededGame = apiState.games.get("game-goals-fail");
+  assert(seededGame);
+  refreshMockFinishedResult(apiState, seededGame, "2026-03-28T11:02:00.000Z");
 
   const defaultFetch = createMockFetch(apiState);
   const failingGoalFetch: ReturnType<typeof createMockFetch> = async (input, init = {}) => {
@@ -2483,18 +2554,27 @@ test("game page remains usable when goal timeline load fails", async () => {
   const error = page.document.getElementById("setup-error");
   const rosterTeams = page.document.getElementById("roster-teams");
   const timeline = page.document.getElementById("goal-timeline");
+  const resultSummary = page.document.getElementById("game-result-summary");
+  const goalSummaryUnavailable = page.document.querySelector('[data-testid="final-goal-summary-unavailable"]');
   const quickCreateButton = page.document.querySelector('[data-action="quick-create-player"]');
 
   assert(status instanceof page.window.HTMLElement);
   assert(error instanceof page.window.HTMLElement);
   assert(rosterTeams instanceof page.window.HTMLElement);
   assert(timeline instanceof page.window.HTMLElement);
+  assert(resultSummary instanceof page.window.HTMLElement);
+  assert(goalSummaryUnavailable instanceof page.window.HTMLElement);
   assert(quickCreateButton instanceof page.window.HTMLButtonElement);
   assert.equal(status.textContent, "Could not load goal timeline.");
   assert.equal(error.hidden, false);
   assert.equal(error.textContent, "Goal feed unavailable.");
   assert.match(rosterTeams.textContent ?? "", /Red/);
-  assert.match(timeline.textContent ?? "", /No goals yet/);
+  assert.match(timeline.textContent ?? "", /Goal timeline unavailable/);
+  assert.equal(resultSummary.hidden, false);
+  assert.match(resultSummary.textContent ?? "", /Red win/);
+  assert.match(resultSummary.textContent ?? "", /Goal summaries unavailable/);
+  assert.doesNotMatch(resultSummary.textContent ?? "", /No goals recorded|No scorers recorded/);
+  assert.equal(page.document.querySelector('[data-testid="final-full-goal-log"]'), null);
   assert.equal(quickCreateButton.disabled, false);
 });
 

--- a/app/src/tests/ui-layout.test.ts
+++ b/app/src/tests/ui-layout.test.ts
@@ -244,7 +244,11 @@ test("game page renders editable game metadata view", () => {
   );
   assert.ok(
     html.indexOf('data-testid="panel-game-live"') < html.indexOf('data-testid="panel-game-timer"'),
-    "Run mode should prioritize live scoring before timer history.",
+    "Run mode should prioritize live scoring before timer controls.",
+  );
+  assert.ok(
+    html.indexOf('data-testid="panel-game-timer"') < html.indexOf('data-testid="run-latest-goals"'),
+    "Timer controls should appear before the growing latest-goals history.",
   );
   assert.match(html, /data-testid="panel-game-live"/);
   assert.match(html, /data-testid="live-scoreboard"/);

--- a/app/src/tests/ui-layout.test.ts
+++ b/app/src/tests/ui-layout.test.ts
@@ -206,6 +206,11 @@ test("game page renders editable game metadata view", () => {
   assert.match(html, /data-testid="game-mode-run-tab"/);
   assert.match(html, /data-testid="game-mode-final-tab"/);
   assert.match(html, /data-mode-label="final"/);
+  assert.doesNotMatch(html, /role="tablist"/);
+  assert.doesNotMatch(html, /data-testid="game-mode-final-tab"[^>]*role="tab"/);
+  assert.doesNotMatch(html, /data-testid="game-mode-final-tab"[^>]*aria-controls=/);
+  assert.doesNotMatch(html, /id="game-mode-tab-final"[^>]*role="tab"/);
+  assert.doesNotMatch(html, /id="game-mode-tab-final"[^>]*aria-controls=/);
   assert.match(html, /data-testid="game-mode-status"/);
   assert.match(html, /data-testid="game-mode-structure"/);
   assert.match(html, /data-testid="game-mode-players" hidden/);

--- a/app/src/tests/ui-layout.test.ts
+++ b/app/src/tests/ui-layout.test.ts
@@ -205,6 +205,7 @@ test("game page renders editable game metadata view", () => {
   assert.match(html, /data-testid="game-mode-players-tab"/);
   assert.match(html, /data-testid="game-mode-run-tab"/);
   assert.match(html, /data-testid="game-mode-final-tab"/);
+  assert.match(html, /data-mode-label="final"/);
   assert.match(html, /data-testid="game-mode-status"/);
   assert.match(html, /data-testid="game-mode-structure"/);
   assert.match(html, /data-testid="game-mode-players" hidden/);

--- a/app/src/tests/ui-layout.test.ts
+++ b/app/src/tests/ui-layout.test.ts
@@ -200,13 +200,37 @@ test("game page renders editable game metadata view", () => {
   assert.match(html, /data-testid="save-game"/);
   assert.match(html, /data-testid="delete-game"/);
   assert.match(html, /data-testid="create-another-game"/);
+  assert.match(html, /data-testid="game-mode-nav"/);
+  assert.match(html, /data-testid="game-mode-structure-tab"/);
+  assert.match(html, /data-testid="game-mode-players-tab"/);
+  assert.match(html, /data-testid="game-mode-run-tab"/);
+  assert.match(html, /data-testid="game-mode-final-tab"/);
+  assert.match(html, /data-testid="game-mode-status"/);
+  assert.match(html, /data-testid="game-mode-structure"/);
+  assert.match(html, /data-testid="game-mode-players" hidden/);
+  assert.match(html, /data-testid="game-mode-run" data-mode-layout="run" hidden/);
+  assert.match(html, /data-testid="game-mode-final" hidden/);
   assert.match(html, /data-testid="panel-game-timer"/);
   assert.match(html, /data-testid="third-timer"/);
   assert.match(html, /data-testid="start-third"/);
   assert.match(html, /data-testid="finish-third"/);
   assert.match(html, /data-testid="finish-game"/);
   assert.match(html, /data-testid="game-result-summary"/);
+  assert.match(html, /data-testid="panel-game-final"/);
+  assert.match(html, /data-testid="finalisation-board"/);
   assert.match(html, /data-testid="game-edit-third-length"/);
+  assert.ok(
+    html.indexOf('data-testid="game-mode-structure"') < html.indexOf('data-testid="game-mode-players"'),
+    "Structure mode should appear before player setup.",
+  );
+  assert.ok(
+    html.indexOf('data-testid="game-mode-players"') < html.indexOf('data-testid="game-mode-run"'),
+    "Player setup should appear before run mode.",
+  );
+  assert.ok(
+    html.indexOf('data-testid="game-mode-run"') < html.indexOf('data-testid="game-mode-final"'),
+    "Run mode should appear before finalisation.",
+  );
   assert.ok(
     html.indexOf('data-testid="panel-game-roster"') < html.indexOf('data-testid="panel-game-live"'),
     "Roster setup should appear before live scoring in the game workflow.",

--- a/app/src/tests/ui-layout.test.ts
+++ b/app/src/tests/ui-layout.test.ts
@@ -210,6 +210,12 @@ test("game page renders editable game metadata view", () => {
   assert.match(html, /data-testid="game-mode-players" hidden/);
   assert.match(html, /data-testid="game-mode-run" data-mode-layout="run" hidden/);
   assert.match(html, /data-testid="game-mode-final" hidden/);
+  assert.match(html, /data-testid="run-console"/);
+  assert.match(html, /data-testid="run-score-strip"/);
+  assert.match(html, /data-testid="run-primary-scoring"/);
+  assert.match(html, /data-testid="run-timer-bar"/);
+  assert.match(html, /data-testid="run-third-history"/);
+  assert.match(html, /data-testid="run-latest-goals"/);
   assert.match(html, /data-testid="panel-game-timer"/);
   assert.match(html, /data-testid="third-timer"/);
   assert.match(html, /data-testid="start-third"/);
@@ -234,6 +240,10 @@ test("game page renders editable game metadata view", () => {
   assert.ok(
     html.indexOf('data-testid="panel-game-roster"') < html.indexOf('data-testid="panel-game-live"'),
     "Roster setup should appear before live scoring in the game workflow.",
+  );
+  assert.ok(
+    html.indexOf('data-testid="panel-game-live"') < html.indexOf('data-testid="panel-game-timer"'),
+    "Run mode should prioritize live scoring before timer history.",
   );
   assert.match(html, /data-testid="panel-game-live"/);
   assert.match(html, /data-testid="live-scoreboard"/);

--- a/app/src/ui/layout.ts
+++ b/app/src/ui/layout.ts
@@ -783,36 +783,42 @@ export function renderGamePage(apiBaseUrl: string, input: GameContextPageInput):
     </div>`,
     "panel-game-details",
   );
-  const timerPanel = renderPanel(
-    "Third timer",
-    "Start and finish thirds in order.",
-    `<div data-ui="timer-board" data-testid="third-timer">
-      <div data-ui="timer-display">
-        <span id="timer-third-label">Third 1</span>
-        <strong id="timer-display-value">00:00</strong>
-        <span id="timer-phase-label">Not started</span>
+  const timerPanel = `<section data-ui="run-timer-panel" data-testid="panel-game-timer" aria-labelledby="run-timer-heading">
+    <header data-ui="section-heading">
+      <h2 id="run-timer-heading">Clock</h2>
+      <p>Start or stop the current third.</p>
+    </header>
+    <div data-ui="timer-board" data-testid="third-timer">
+      <div data-ui="run-timer-bar" data-testid="run-timer-bar">
+        <div data-ui="timer-display">
+          <span id="timer-third-label">Third 1</span>
+          <strong id="timer-display-value">00:00</strong>
+          <span id="timer-phase-label">Not started</span>
+        </div>
+        <div data-ui="button-row" data-density="compact">
+          ${renderButton("Start Third 1", "primary", {
+            type: "button",
+            "data-action": "start-active-third",
+            "data-testid": "start-third",
+          })}
+          ${renderButton("Finish Third", "secondary", {
+            type: "button",
+            "data-action": "finish-active-third",
+            "data-testid": "finish-third",
+          })}
+        </div>
       </div>
-      <dl data-ui="id-preview" data-testid="timer-context-details">
-        <div><dt>Length</dt><dd id="timer-third-length">20 minutes</dd></div>
-        <div><dt>Status</dt><dd id="timer-status">Not started</dd></div>
-        <div><dt>Active third</dt><dd id="timer-active-third">-</dd></div>
-      </dl>
-      <ol data-ui="third-status-list" id="third-status-list" data-testid="third-status-list"></ol>
-    </div>`,
-    `<div data-ui="button-row">
-      ${renderButton("Start Third 1", "primary", {
-        type: "button",
-        "data-action": "start-active-third",
-        "data-testid": "start-third",
-      })}
-      ${renderButton("Finish Third", "secondary", {
-        type: "button",
-        "data-action": "finish-active-third",
-        "data-testid": "finish-third",
-      })}
-    </div>`,
-    "panel-game-timer",
-  );
+      <details data-ui="run-third-history" data-testid="run-third-history">
+        <summary>Third history</summary>
+        <dl data-ui="id-preview" data-testid="timer-context-details">
+          <div><dt>Length</dt><dd id="timer-third-length">20 minutes</dd></div>
+          <div><dt>Status</dt><dd id="timer-status">Not started</dd></div>
+          <div><dt>Active third</dt><dd id="timer-active-third">-</dd></div>
+        </dl>
+        <ol data-ui="third-status-list" id="third-status-list" data-testid="third-status-list"></ol>
+      </details>
+    </div>
+  </section>`;
   const rosterPanel = renderPanel(
     "Roster setup",
     "Create players and assign them to game teams.",
@@ -858,51 +864,64 @@ export function renderGamePage(apiBaseUrl: string, input: GameContextPageInput):
     </div>`,
     "panel-game-roster",
   );
-  const livePanel = renderPanel(
-    "Live scoring",
-    "Score goals against the running third.",
-    `<div data-ui="live-scoreboard" id="live-scoreboard" data-testid="live-scoreboard"></div>
-    <div data-ui="field">
-      <label for="goal-scoring-team">Scoring team</label>
-      <select id="goal-scoring-team" data-ui="input" data-testid="goal-scoring-team"></select>
+  const livePanel = `<section data-ui="run-scoring-panel" data-testid="panel-game-live" aria-labelledby="run-scoring-heading">
+    <header data-ui="section-heading">
+      <h2 id="run-scoring-heading">Run game</h2>
+      <p>Record goals first; review corrections when needed.</p>
+    </header>
+    <div data-ui="run-score-strip" data-testid="run-score-strip">
+      <div data-ui="live-scoreboard" id="live-scoreboard" data-testid="live-scoreboard"></div>
     </div>
-    <div data-ui="field">
-      <label for="goal-conceding-team">Conceding team</label>
-      <select id="goal-conceding-team" data-ui="input" data-testid="goal-conceding-team"></select>
-    </div>
-    <label data-ui="check-row" for="goal-own-goal">
-      <input id="goal-own-goal" type="checkbox" data-testid="goal-own-goal" />
-      <span>Own goal</span>
-    </label>
-    <div data-ui="field">
-      <label for="goal-scorer">Scorer</label>
-      <select id="goal-scorer" data-ui="input" data-testid="goal-scorer"></select>
-    </div>
-    <div data-ui="field">
-      <span data-ui="field-label">Assists</span>
-      <div id="goal-assists" data-ui="assist-list" data-testid="goal-assists"></div>
-    </div>
-    <p data-ui="field-hint" id="goal-form-note">Start a third and assign players before scoring.</p>`,
-    `<div data-ui="button-row">
-      ${renderButton("Add goal", "primary", {
-        type: "button",
-        "data-action": "save-goal",
-        "data-testid": "add-goal",
-      })}
-      ${renderButton("Cancel edit", "secondary", {
-        type: "button",
-        "data-action": "cancel-goal-edit",
-        "data-testid": "cancel-goal-edit",
-      })}
-      ${renderButton("Undo last", "danger", {
-        type: "button",
-        "data-action": "undo-last-goal",
-        "data-testid": "undo-last-goal",
-      })}
-    </div>
-    <ol id="goal-timeline" data-ui="goal-timeline" data-testid="goal-timeline"></ol>`,
-    "panel-game-live",
-  );
+    <section data-ui="run-primary-scoring" data-testid="run-primary-scoring" aria-labelledby="run-goal-form-heading">
+      <header>
+        <h3 id="run-goal-form-heading">Record goal</h3>
+      </header>
+      <div data-ui="run-goal-form">
+        <div data-ui="field">
+          <label for="goal-scoring-team">Scoring team</label>
+          <select id="goal-scoring-team" data-ui="input" data-testid="goal-scoring-team"></select>
+        </div>
+        <div data-ui="field">
+          <label for="goal-conceding-team">Conceding team</label>
+          <select id="goal-conceding-team" data-ui="input" data-testid="goal-conceding-team"></select>
+        </div>
+        <div data-ui="field">
+          <label for="goal-scorer">Scorer</label>
+          <select id="goal-scorer" data-ui="input" data-testid="goal-scorer"></select>
+        </div>
+        <label data-ui="check-row" data-density="secondary" for="goal-own-goal">
+          <input id="goal-own-goal" type="checkbox" data-testid="goal-own-goal" />
+          <span>Own goal</span>
+        </label>
+        <details data-ui="run-secondary-scoring" open>
+          <summary>Assists</summary>
+          <div id="goal-assists" data-ui="assist-list" data-testid="goal-assists"></div>
+        </details>
+      </div>
+      <p data-ui="field-hint" id="goal-form-note">Start a third and assign players before scoring.</p>
+      <div data-ui="button-row" data-priority="scoring">
+        ${renderButton("Add goal", "primary", {
+          type: "button",
+          "data-action": "save-goal",
+          "data-testid": "add-goal",
+        })}
+        ${renderButton("Cancel edit", "secondary", {
+          type: "button",
+          "data-action": "cancel-goal-edit",
+          "data-testid": "cancel-goal-edit",
+        })}
+        ${renderButton("Undo last", "danger", {
+          type: "button",
+          "data-action": "undo-last-goal",
+          "data-testid": "undo-last-goal",
+        })}
+      </div>
+    </section>
+    <details data-ui="run-latest-goals" data-testid="run-latest-goals" open>
+      <summary>Latest goals</summary>
+      <ol id="goal-timeline" data-ui="goal-timeline" data-testid="goal-timeline"></ol>
+    </details>
+  </section>`;
   const finalPanel = renderPanel(
     "Finalisation",
     "Finish the match and review the summary.",
@@ -967,8 +986,10 @@ export function renderGamePage(apiBaseUrl: string, input: GameContextPageInput):
             ${rosterPanel}
           </section>
           <section data-ui="game-mode-panel" id="game-mode-run" role="tabpanel" aria-labelledby="game-mode-tab-run" data-game-mode="run" data-testid="game-mode-run" data-mode-layout="run" hidden>
-            ${timerPanel}
-            ${livePanel}
+            <div data-ui="run-console" data-testid="run-console">
+              ${livePanel}
+              ${timerPanel}
+            </div>
           </section>
           <section data-ui="game-mode-panel" id="game-mode-final" role="tabpanel" aria-labelledby="game-mode-tab-final" data-game-mode="final" data-testid="game-mode-final" hidden>
             ${finalPanel}

--- a/app/src/ui/layout.ts
+++ b/app/src/ui/layout.ts
@@ -864,14 +864,14 @@ export function renderGamePage(apiBaseUrl: string, input: GameContextPageInput):
     </div>`,
     "panel-game-roster",
   );
+  const scorePanel = `<div data-ui="run-score-strip" data-testid="run-score-strip">
+    <div data-ui="live-scoreboard" id="live-scoreboard" data-testid="live-scoreboard"></div>
+  </div>`;
   const livePanel = `<section data-ui="run-scoring-panel" data-testid="panel-game-live" aria-labelledby="run-scoring-heading">
     <header data-ui="section-heading">
       <h2 id="run-scoring-heading">Run game</h2>
       <p>Record goals first; review corrections when needed.</p>
     </header>
-    <div data-ui="run-score-strip" data-testid="run-score-strip">
-      <div data-ui="live-scoreboard" id="live-scoreboard" data-testid="live-scoreboard"></div>
-    </div>
     <section data-ui="run-primary-scoring" data-testid="run-primary-scoring" aria-labelledby="run-goal-form-heading">
       <header>
         <h3 id="run-goal-form-heading">Record goal</h3>
@@ -917,11 +917,11 @@ export function renderGamePage(apiBaseUrl: string, input: GameContextPageInput):
         })}
       </div>
     </section>
-    <details data-ui="run-latest-goals" data-testid="run-latest-goals" open>
+  </section>`;
+  const latestGoalsPanel = `<details data-ui="run-latest-goals" data-testid="run-latest-goals" open>
       <summary>Latest goals</summary>
       <ol id="goal-timeline" data-ui="goal-timeline" data-testid="goal-timeline"></ol>
-    </details>
-  </section>`;
+    </details>`;
   const finalPanel = renderPanel(
     "Finalisation",
     "Finish the match and review the summary.",
@@ -987,8 +987,10 @@ export function renderGamePage(apiBaseUrl: string, input: GameContextPageInput):
           </section>
           <section data-ui="game-mode-panel" id="game-mode-run" role="tabpanel" aria-labelledby="game-mode-tab-run" data-game-mode="run" data-testid="game-mode-run" data-mode-layout="run" hidden>
             <div data-ui="run-console" data-testid="run-console">
+              ${scorePanel}
               ${livePanel}
               ${timerPanel}
+              ${latestGoalsPanel}
             </div>
           </section>
           <section data-ui="game-mode-panel" id="game-mode-final" role="tabpanel" aria-labelledby="game-mode-tab-final" data-game-mode="final" data-testid="game-mode-final" hidden>

--- a/app/src/ui/layout.ts
+++ b/app/src/ui/layout.ts
@@ -716,7 +716,8 @@ function renderGameModeTab(input: {
 }): string {
   const tabId = `game-mode-tab-${input.mode}`;
   const panelId = `game-mode-${input.mode}`;
-  return `<button data-ui="game-mode-tab" type="button" role="tab" id="${tabId}" aria-controls="${panelId}" aria-selected="${
+  const controls = input.mode === "final" ? "" : ` aria-controls="${panelId}"`;
+  return `<button data-ui="game-mode-tab" type="button" id="${tabId}"${controls} aria-pressed="${
     input.active ? "true" : "false"
   }" data-action="select-game-mode" data-game-mode="${input.mode}" data-state="${input.active ? "active" : "idle"}" data-testid="game-mode-${input.mode}-tab">
     <span data-mode-label="${input.mode}">${escapeHtml(input.label)}</span>
@@ -970,7 +971,7 @@ export function renderGamePage(apiBaseUrl: string, input: GameContextPageInput):
         <p data-ui="status-note" id="setup-status">Loading game data…</p>
         <p data-ui="status-note" data-state="error" id="setup-error" hidden></p>
         <nav data-ui="game-mode-nav" data-testid="game-mode-nav" aria-label="Game workflow">
-          <div data-ui="game-mode-tabs" role="tablist" aria-label="Game workflow modes">
+          <div data-ui="game-mode-tabs" aria-label="Game workflow modes">
             ${renderGameModeTab({ mode: "structure", label: "Game", meta: "Setup", active: true })}
             ${renderGameModeTab({ mode: "players", label: "Players", meta: "Roster" })}
             ${renderGameModeTab({ mode: "run", label: "Run", meta: "Timer" })}
@@ -979,13 +980,13 @@ export function renderGamePage(apiBaseUrl: string, input: GameContextPageInput):
         </nav>
         <p data-ui="game-mode-status" id="game-mode-status" data-testid="game-mode-status">Game setup</p>
         <section data-ui="game-mode-panels" data-testid="game-grid">
-          <section data-ui="game-mode-panel" id="game-mode-structure" role="tabpanel" aria-labelledby="game-mode-tab-structure" data-game-mode="structure" data-testid="game-mode-structure">
+          <section data-ui="game-mode-panel" id="game-mode-structure" aria-labelledby="game-mode-tab-structure" data-game-mode="structure" data-testid="game-mode-structure">
             ${gameDetailsPanel}
           </section>
-          <section data-ui="game-mode-panel" id="game-mode-players" role="tabpanel" aria-labelledby="game-mode-tab-players" data-game-mode="players" data-testid="game-mode-players" hidden>
+          <section data-ui="game-mode-panel" id="game-mode-players" aria-labelledby="game-mode-tab-players" data-game-mode="players" data-testid="game-mode-players" hidden>
             ${rosterPanel}
           </section>
-          <section data-ui="game-mode-panel" id="game-mode-run" role="tabpanel" aria-labelledby="game-mode-tab-run" data-game-mode="run" data-testid="game-mode-run" data-mode-layout="run" hidden>
+          <section data-ui="game-mode-panel" id="game-mode-run" aria-labelledby="game-mode-tab-run" data-game-mode="run" data-testid="game-mode-run" data-mode-layout="run" hidden>
             <div data-ui="run-console" data-testid="run-console">
               ${scorePanel}
               ${livePanel}
@@ -993,7 +994,7 @@ export function renderGamePage(apiBaseUrl: string, input: GameContextPageInput):
               ${latestGoalsPanel}
             </div>
           </section>
-          <section data-ui="game-mode-panel" id="game-mode-final" role="tabpanel" aria-labelledby="game-mode-tab-final" data-game-mode="final" data-testid="game-mode-final" hidden>
+          <section data-ui="game-mode-panel" id="game-mode-final" aria-label="Finalisation" data-game-mode="final" data-testid="game-mode-final" hidden>
             ${finalPanel}
           </section>
         </section>

--- a/app/src/ui/layout.ts
+++ b/app/src/ui/layout.ts
@@ -719,7 +719,7 @@ function renderGameModeTab(input: {
   return `<button data-ui="game-mode-tab" type="button" role="tab" id="${tabId}" aria-controls="${panelId}" aria-selected="${
     input.active ? "true" : "false"
   }" data-action="select-game-mode" data-game-mode="${input.mode}" data-state="${input.active ? "active" : "idle"}" data-testid="game-mode-${input.mode}-tab">
-    <span>${escapeHtml(input.label)}</span>
+    <span data-mode-label="${input.mode}">${escapeHtml(input.label)}</span>
     <small data-mode-meta="${input.mode}">${escapeHtml(input.meta)}</small>
   </button>`;
 }

--- a/app/src/ui/layout.ts
+++ b/app/src/ui/layout.ts
@@ -708,9 +708,229 @@ export interface GameContextPageInput {
   gameStartTs?: string;
 }
 
+function renderGameModeTab(input: {
+  mode: "structure" | "players" | "run" | "final";
+  label: string;
+  meta: string;
+  active?: boolean;
+}): string {
+  const tabId = `game-mode-tab-${input.mode}`;
+  const panelId = `game-mode-${input.mode}`;
+  return `<button data-ui="game-mode-tab" type="button" role="tab" id="${tabId}" aria-controls="${panelId}" aria-selected="${
+    input.active ? "true" : "false"
+  }" data-action="select-game-mode" data-game-mode="${input.mode}" data-state="${input.active ? "active" : "idle"}" data-testid="game-mode-${input.mode}-tab">
+    <span>${escapeHtml(input.label)}</span>
+    <small data-mode-meta="${input.mode}">${escapeHtml(input.meta)}</small>
+  </button>`;
+}
+
 export function renderGamePage(apiBaseUrl: string, input: GameContextPageInput): string {
   const gameId = escapeHtml(input.gameId);
   const gameHeading = gameId.length > 0 ? gameId : "Game";
+  const gameDetailsPanel = renderPanel(
+    "Game details",
+    "Edit core game metadata.",
+    `<dl data-ui="id-preview" data-testid="game-context-details">
+      <div><dt>Game ID</dt><dd id="game-id-value">${gameHeading}</dd></div>
+      <div><dt>Join code</dt><dd id="game-join-code-value" data-testid="game-join-code-value">Loading…</dd></div>
+      <div><dt>Join link</dt><dd><a id="game-join-link" data-testid="game-join-link" href="/join">Loading…</a></dd></div>
+      <div data-ui="join-qr-row"><dt>Join QR</dt><dd id="game-join-qr" data-ui="join-qr" data-testid="game-join-qr">Loading…</dd></div>
+      <div><dt>League ID</dt><dd id="game-league-id">Loading…</dd></div>
+      <div><dt>Season ID</dt><dd id="game-season-id">Loading…</dd></div>
+    </dl>
+    ${renderValidatedField({
+      id: "game-edit-kickoff",
+      label: "Kickoff time",
+      type: "datetime-local",
+      required: true,
+    })}
+    <div data-ui="field">
+      <label for="game-edit-status">Status</label>
+      <select id="game-edit-status" data-ui="input" data-testid="game-edit-status">
+        <option value="scheduled">Scheduled</option>
+        <option value="live">Live</option>
+        <option value="finished" disabled>Finished</option>
+      </select>
+    </div>
+    <div data-ui="field">
+      <label for="game-edit-third-length">Third length</label>
+      <select id="game-edit-third-length" data-ui="input" data-testid="game-edit-third-length">
+        <option value="20">20 minutes</option>
+        <option value="25">25 minutes</option>
+        <option value="30">30 minutes</option>
+      </select>
+    </div>`,
+    `<div data-ui="button-row">
+      ${renderButton("Save changes", "primary", {
+        type: "button",
+        "data-action": "save-game",
+        "data-testid": "save-game",
+      })}
+      ${renderButton("Delete game", "danger", {
+        type: "button",
+        "data-action": "delete-game",
+        "data-testid": "delete-game",
+      })}
+      <a id="create-another-game-link" href="/setup" data-ui="button-link" data-variant="secondary" data-testid="create-another-game">Create another game</a>
+    </div>
+    <div data-ui="mode-actions">
+      ${renderButton("Players", "secondary", {
+        type: "button",
+        "data-action": "select-game-mode",
+        "data-game-mode": "players",
+        "data-testid": "game-mode-next-players",
+      })}
+    </div>`,
+    "panel-game-details",
+  );
+  const timerPanel = renderPanel(
+    "Third timer",
+    "Start and finish thirds in order.",
+    `<div data-ui="timer-board" data-testid="third-timer">
+      <div data-ui="timer-display">
+        <span id="timer-third-label">Third 1</span>
+        <strong id="timer-display-value">00:00</strong>
+        <span id="timer-phase-label">Not started</span>
+      </div>
+      <dl data-ui="id-preview" data-testid="timer-context-details">
+        <div><dt>Length</dt><dd id="timer-third-length">20 minutes</dd></div>
+        <div><dt>Status</dt><dd id="timer-status">Not started</dd></div>
+        <div><dt>Active third</dt><dd id="timer-active-third">-</dd></div>
+      </dl>
+      <ol data-ui="third-status-list" id="third-status-list" data-testid="third-status-list"></ol>
+    </div>`,
+    `<div data-ui="button-row">
+      ${renderButton("Start Third 1", "primary", {
+        type: "button",
+        "data-action": "start-active-third",
+        "data-testid": "start-third",
+      })}
+      ${renderButton("Finish Third", "secondary", {
+        type: "button",
+        "data-action": "finish-active-third",
+        "data-testid": "finish-third",
+      })}
+    </div>`,
+    "panel-game-timer",
+  );
+  const rosterPanel = renderPanel(
+    "Roster setup",
+    "Create players and assign them to game teams.",
+    `${renderValidatedField({
+      id: "player-nickname",
+      label: "Player nickname",
+      placeholder: "Ari",
+    })}
+    <div data-ui="button-row">
+      ${renderButton("Create player", "primary", {
+        type: "button",
+        "data-action": "quick-create-player",
+        "data-testid": "quick-create-player",
+      })}
+    </div>
+    <div data-ui="field">
+      <label for="player-search">Search players</label>
+      <input data-ui="input" id="player-search" name="player-search" type="search" placeholder="Nickname" autocomplete="off" />
+    </div>
+    <div data-ui="roster-workspace" data-testid="roster-workspace">
+      <section data-ui="player-pool" aria-labelledby="player-pool-title">
+        <h3 id="player-pool-title">Players</h3>
+        <div id="player-pool" data-ui="player-list" data-testid="player-pool"></div>
+      </section>
+      <section data-ui="roster-board" aria-labelledby="roster-board-title">
+        <h3 id="roster-board-title">Teams</h3>
+        <div id="roster-teams" data-ui="roster-grid" data-testid="roster-teams"></div>
+      </section>
+    </div>`,
+    `<div data-ui="mode-actions">
+      ${renderButton("Game", "secondary", {
+        type: "button",
+        "data-action": "select-game-mode",
+        "data-game-mode": "structure",
+        "data-testid": "game-mode-back-structure",
+      })}
+      ${renderButton("Run", "primary", {
+        type: "button",
+        "data-action": "select-game-mode",
+        "data-game-mode": "run",
+        "data-testid": "game-mode-next-run",
+      })}
+    </div>`,
+    "panel-game-roster",
+  );
+  const livePanel = renderPanel(
+    "Live scoring",
+    "Score goals against the running third.",
+    `<div data-ui="live-scoreboard" id="live-scoreboard" data-testid="live-scoreboard"></div>
+    <div data-ui="field">
+      <label for="goal-scoring-team">Scoring team</label>
+      <select id="goal-scoring-team" data-ui="input" data-testid="goal-scoring-team"></select>
+    </div>
+    <div data-ui="field">
+      <label for="goal-conceding-team">Conceding team</label>
+      <select id="goal-conceding-team" data-ui="input" data-testid="goal-conceding-team"></select>
+    </div>
+    <label data-ui="check-row" for="goal-own-goal">
+      <input id="goal-own-goal" type="checkbox" data-testid="goal-own-goal" />
+      <span>Own goal</span>
+    </label>
+    <div data-ui="field">
+      <label for="goal-scorer">Scorer</label>
+      <select id="goal-scorer" data-ui="input" data-testid="goal-scorer"></select>
+    </div>
+    <div data-ui="field">
+      <span data-ui="field-label">Assists</span>
+      <div id="goal-assists" data-ui="assist-list" data-testid="goal-assists"></div>
+    </div>
+    <p data-ui="field-hint" id="goal-form-note">Start a third and assign players before scoring.</p>`,
+    `<div data-ui="button-row">
+      ${renderButton("Add goal", "primary", {
+        type: "button",
+        "data-action": "save-goal",
+        "data-testid": "add-goal",
+      })}
+      ${renderButton("Cancel edit", "secondary", {
+        type: "button",
+        "data-action": "cancel-goal-edit",
+        "data-testid": "cancel-goal-edit",
+      })}
+      ${renderButton("Undo last", "danger", {
+        type: "button",
+        "data-action": "undo-last-goal",
+        "data-testid": "undo-last-goal",
+      })}
+    </div>
+    <ol id="goal-timeline" data-ui="goal-timeline" data-testid="goal-timeline"></ol>`,
+    "panel-game-live",
+  );
+  const finalPanel = renderPanel(
+    "Finalisation",
+    "Finish the match and review the summary.",
+    `<div data-ui="finalisation-board" data-testid="finalisation-board">
+      <dl data-ui="id-preview" data-testid="finalisation-context">
+        <div><dt>Game</dt><dd id="final-game-id-value">${gameHeading}</dd></div>
+        <div><dt>Status</dt><dd id="final-game-status">Loading…</dd></div>
+        <div><dt>Timeline</dt><dd id="final-game-readiness">Loading…</dd></div>
+      </dl>
+      <div data-ui="game-result-summary" id="game-result-summary" data-testid="game-result-summary" hidden></div>
+    </div>`,
+    `<div data-ui="button-row">
+      ${renderButton("Finish game", "primary", {
+        type: "button",
+        "data-action": "finish-game",
+        "data-testid": "finish-game",
+      })}
+    </div>
+    <div data-ui="mode-actions">
+      ${renderButton("Run", "secondary", {
+        type: "button",
+        "data-action": "select-game-mode",
+        "data-game-mode": "run",
+        "data-testid": "game-mode-back-run",
+      })}
+    </div>`,
+    "panel-game-final",
+  );
 
   return `<!doctype html>
 <html lang="en">
@@ -730,168 +950,29 @@ export function renderGamePage(apiBaseUrl: string, input: GameContextPageInput):
       <section data-ui="setup-flow" id="setup-flow-root" data-testid="setup-flow-root" data-page="game" data-api-base-url="${escapeHtml(apiBaseUrl)}" data-game-id="${gameId}">
         <p data-ui="status-note" id="setup-status">Loading game data…</p>
         <p data-ui="status-note" data-state="error" id="setup-error" hidden></p>
-        <section data-ui="panel-grid" data-testid="game-grid">
-          ${renderPanel(
-            "Game details",
-            "Edit core game metadata.",
-            `<dl data-ui="id-preview" data-testid="game-context-details">
-              <div><dt>Game ID</dt><dd id="game-id-value">${gameHeading}</dd></div>
-              <div><dt>Join code</dt><dd id="game-join-code-value" data-testid="game-join-code-value">Loading…</dd></div>
-              <div><dt>Join link</dt><dd><a id="game-join-link" data-testid="game-join-link" href="/join">Loading…</a></dd></div>
-              <div data-ui="join-qr-row"><dt>Join QR</dt><dd id="game-join-qr" data-ui="join-qr" data-testid="game-join-qr">Loading…</dd></div>
-              <div><dt>League ID</dt><dd id="game-league-id">Loading…</dd></div>
-              <div><dt>Season ID</dt><dd id="game-season-id">Loading…</dd></div>
-            </dl>
-            ${renderValidatedField({
-              id: "game-edit-kickoff",
-              label: "Kickoff time",
-              type: "datetime-local",
-              required: true,
-            })}
-            <div data-ui="field">
-              <label for="game-edit-status">Status</label>
-              <select id="game-edit-status" data-ui="input" data-testid="game-edit-status">
-                <option value="scheduled">Scheduled</option>
-                <option value="live">Live</option>
-                <option value="finished" disabled>Finished</option>
-              </select>
-            </div>
-            <div data-ui="field">
-              <label for="game-edit-third-length">Third length</label>
-              <select id="game-edit-third-length" data-ui="input" data-testid="game-edit-third-length">
-                <option value="20">20 minutes</option>
-                <option value="25">25 minutes</option>
-                <option value="30">30 minutes</option>
-              </select>
-            </div>`,
-            `<div data-ui="button-row">
-              ${renderButton("Save changes", "primary", {
-                type: "button",
-                "data-action": "save-game",
-                "data-testid": "save-game",
-              })}
-              ${renderButton("Delete game", "danger", {
-                type: "button",
-                "data-action": "delete-game",
-                "data-testid": "delete-game",
-              })}
-              <a id="create-another-game-link" href="/setup" data-ui="button-link" data-variant="secondary" data-testid="create-another-game">Create another game</a>
-            </div>`,
-            "panel-game-details",
-          )}
-          ${renderPanel(
-            "Third timer",
-            "Start and finish thirds in order.",
-            `<div data-ui="timer-board" data-testid="third-timer">
-              <div data-ui="timer-display">
-                <span id="timer-third-label">Third 1</span>
-                <strong id="timer-display-value">00:00</strong>
-                <span id="timer-phase-label">Not started</span>
-              </div>
-              <dl data-ui="id-preview" data-testid="timer-context-details">
-                <div><dt>Length</dt><dd id="timer-third-length">20 minutes</dd></div>
-                <div><dt>Status</dt><dd id="timer-status">Not started</dd></div>
-                <div><dt>Active third</dt><dd id="timer-active-third">-</dd></div>
-              </dl>
-              <ol data-ui="third-status-list" id="third-status-list" data-testid="third-status-list"></ol>
-            </div>`,
-            `<div data-ui="button-row">
-              ${renderButton("Start Third 1", "primary", {
-                type: "button",
-                "data-action": "start-active-third",
-                "data-testid": "start-third",
-              })}
-              ${renderButton("Finish Third", "secondary", {
-                type: "button",
-                "data-action": "finish-active-third",
-                "data-testid": "finish-third",
-              })}
-              ${renderButton("Finish game", "primary", {
-                type: "button",
-                "data-action": "finish-game",
-                "data-testid": "finish-game",
-              })}
-            </div>
-            <div data-ui="game-result-summary" id="game-result-summary" data-testid="game-result-summary" hidden></div>`,
-            "panel-game-timer",
-          )}
-          ${renderPanel(
-            "Roster setup",
-            "Create players and assign them to game teams.",
-            `${renderValidatedField({
-              id: "player-nickname",
-              label: "Player nickname",
-              placeholder: "Ari",
-            })}
-            <div data-ui="button-row">
-              ${renderButton("Create player", "primary", {
-                type: "button",
-                "data-action": "quick-create-player",
-                "data-testid": "quick-create-player",
-              })}
-            </div>
-            <div data-ui="field">
-              <label for="player-search">Search players</label>
-              <input data-ui="input" id="player-search" name="player-search" type="search" placeholder="Nickname" autocomplete="off" />
-            </div>
-            <div data-ui="roster-workspace" data-testid="roster-workspace">
-              <section data-ui="player-pool" aria-labelledby="player-pool-title">
-                <h3 id="player-pool-title">Players</h3>
-                <div id="player-pool" data-ui="player-list" data-testid="player-pool"></div>
-              </section>
-              <section data-ui="roster-board" aria-labelledby="roster-board-title">
-                <h3 id="roster-board-title">Teams</h3>
-                <div id="roster-teams" data-ui="roster-grid" data-testid="roster-teams"></div>
-              </section>
-            </div>`,
-            "",
-            "panel-game-roster",
-          )}
-          ${renderPanel(
-            "Live scoring",
-            "Score goals against the running third.",
-            `<div data-ui="live-scoreboard" id="live-scoreboard" data-testid="live-scoreboard"></div>
-            <div data-ui="field">
-              <label for="goal-scoring-team">Scoring team</label>
-              <select id="goal-scoring-team" data-ui="input" data-testid="goal-scoring-team"></select>
-            </div>
-            <div data-ui="field">
-              <label for="goal-conceding-team">Conceding team</label>
-              <select id="goal-conceding-team" data-ui="input" data-testid="goal-conceding-team"></select>
-            </div>
-            <label data-ui="check-row" for="goal-own-goal">
-              <input id="goal-own-goal" type="checkbox" data-testid="goal-own-goal" />
-              <span>Own goal</span>
-            </label>
-            <div data-ui="field">
-              <label for="goal-scorer">Scorer</label>
-              <select id="goal-scorer" data-ui="input" data-testid="goal-scorer"></select>
-            </div>
-            <div data-ui="field">
-              <span data-ui="field-label">Assists</span>
-              <div id="goal-assists" data-ui="assist-list" data-testid="goal-assists"></div>
-            </div>
-            <p data-ui="field-hint" id="goal-form-note">Start a third and assign players before scoring.</p>`,
-            `<div data-ui="button-row">
-              ${renderButton("Add goal", "primary", {
-                type: "button",
-                "data-action": "save-goal",
-                "data-testid": "add-goal",
-              })}
-              ${renderButton("Cancel edit", "secondary", {
-                type: "button",
-                "data-action": "cancel-goal-edit",
-                "data-testid": "cancel-goal-edit",
-              })}
-              ${renderButton("Undo last", "danger", {
-                type: "button",
-                "data-action": "undo-last-goal",
-                "data-testid": "undo-last-goal",
-              })}
-            </div>
-            <ol id="goal-timeline" data-ui="goal-timeline" data-testid="goal-timeline"></ol>`,
-            "panel-game-live",
-          )}
+        <nav data-ui="game-mode-nav" data-testid="game-mode-nav" aria-label="Game workflow">
+          <div data-ui="game-mode-tabs" role="tablist" aria-label="Game workflow modes">
+            ${renderGameModeTab({ mode: "structure", label: "Game", meta: "Setup", active: true })}
+            ${renderGameModeTab({ mode: "players", label: "Players", meta: "Roster" })}
+            ${renderGameModeTab({ mode: "run", label: "Run", meta: "Timer" })}
+            ${renderGameModeTab({ mode: "final", label: "Final", meta: "Summary" })}
+          </div>
+        </nav>
+        <p data-ui="game-mode-status" id="game-mode-status" data-testid="game-mode-status">Game setup</p>
+        <section data-ui="game-mode-panels" data-testid="game-grid">
+          <section data-ui="game-mode-panel" id="game-mode-structure" role="tabpanel" aria-labelledby="game-mode-tab-structure" data-game-mode="structure" data-testid="game-mode-structure">
+            ${gameDetailsPanel}
+          </section>
+          <section data-ui="game-mode-panel" id="game-mode-players" role="tabpanel" aria-labelledby="game-mode-tab-players" data-game-mode="players" data-testid="game-mode-players" hidden>
+            ${rosterPanel}
+          </section>
+          <section data-ui="game-mode-panel" id="game-mode-run" role="tabpanel" aria-labelledby="game-mode-tab-run" data-game-mode="run" data-testid="game-mode-run" data-mode-layout="run" hidden>
+            ${timerPanel}
+            ${livePanel}
+          </section>
+          <section data-ui="game-mode-panel" id="game-mode-final" role="tabpanel" aria-labelledby="game-mode-tab-final" data-game-mode="final" data-testid="game-mode-final" hidden>
+            ${finalPanel}
+          </section>
         </section>
       </section>
     </main>

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -1551,6 +1551,9 @@
 
       const timer = buildTimerState(currentGame);
       const hasStarted = timer.thirds.some((third) => third.startedAt !== null);
+      if (timer.status === "complete") {
+        return "final";
+      }
       if (hasStarted || rosteredPlayers().length > 0) {
         return hasStarted ? "run" : "players";
       }

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -2225,8 +2225,24 @@
       saveGoalButton.textContent = editingGoalId ? "Save goal" : "Add goal";
       cancelGoalEditButton.hidden = editingGoalId === null;
       cancelGoalEditButton.disabled = editingGoalId === null;
-      undoLastGoalButton.disabled = goalTimeline.length === 0 || (gameFinished && !finishedCorrectionsAllowed);
+      undoLastGoalButton.disabled =
+        !goalTimelineLoaded || goalTimeline.length === 0 || (gameFinished && !finishedCorrectionsAllowed);
       undoLastGoalButton.textContent = "Undo last";
+
+      if (!goalTimelineLoaded) {
+        goalScoringTeamInput.disabled = true;
+        goalConcedingTeamInput.disabled = true;
+        goalOwnGoalInput.disabled = true;
+        goalScorerInput.disabled = true;
+        saveGoalButton.disabled = true;
+        for (const input of goalAssistsElement.querySelectorAll("input")) {
+          if (input instanceof HTMLInputElement) {
+            input.disabled = true;
+          }
+        }
+        goalFormNote.textContent = "Goal timeline unavailable. Reload before scoring or correcting goals.";
+        return;
+      }
 
       if (gameFinished && !finishedCorrectionsAllowed) {
         goalScoringTeamInput.disabled = true;
@@ -2844,6 +2860,7 @@
           method: "GET",
         });
       } catch (error) {
+        goalTimelineLoaded = false;
         const message = error instanceof Error ? error.message : "Could not load goal timeline.";
         showError(message);
         setStatus("Could not load goal timeline.", "error");

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -1443,7 +1443,7 @@
       run: "Run game",
       final: "Finalisation",
     };
-    const gameModeTabs = [...root.querySelectorAll('[role="tab"][data-game-mode]')];
+    const gameModeTabs = [...root.querySelectorAll('[data-ui="game-mode-tab"][data-game-mode]')];
     const gameModeTriggers = [...root.querySelectorAll('[data-action="select-game-mode"][data-game-mode]')];
     const gameModePanels = [...root.querySelectorAll('[data-ui="game-mode-panel"][data-game-mode]')];
     const gameModeStatus = document.getElementById("game-mode-status");
@@ -1522,7 +1522,7 @@
           continue;
         }
         const active = tab.getAttribute("data-game-mode") === mode;
-        tab.setAttribute("aria-selected", active ? "true" : "false");
+        tab.setAttribute("aria-pressed", active ? "true" : "false");
         tab.setAttribute("data-state", active ? "active" : "idle");
       }
 
@@ -3150,7 +3150,7 @@
         return;
       }
       manualGameModeSelected = true;
-      setGameMode(mode, { focusPanel: trigger.getAttribute("role") !== "tab" });
+      setGameMode(mode, { focusPanel: trigger.getAttribute("data-ui") !== "game-mode-tab" });
     });
 
     if (rosterControlsAvailable()) {

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -1427,6 +1427,7 @@
     let goalTimeline = [];
     let editingGoalId = null;
     let currentLeagueRole = null;
+    let manualGameModeSelected = false;
     let pendingCreateGoalIdempotency = null;
     const pendingGoalMutationIdempotency = new Map();
     const gameModes = ["structure", "players", "run", "final"];
@@ -1559,6 +1560,24 @@
       }
 
       return "structure";
+    }
+
+    function gameModeAfterGameSave() {
+      if (!currentGame) {
+        return "structure";
+      }
+
+      if (isGameFinished()) {
+        return "final";
+      }
+
+      const timer = buildTimerState(currentGame);
+      if (timer.status === "complete") {
+        return "final";
+      }
+
+      const hasStarted = timer.thirds.some((third) => third.startedAt !== null);
+      return hasStarted ? "run" : "players";
     }
 
     function syncGameModeState() {
@@ -1913,8 +1932,9 @@
         </header>
         <div data-ui="result-team-list" data-testid="game-result-teams">
           ${teams
-            .map(
-              (team) => `<article data-ui="result-team" data-team-id="${escapeHtml(team.teamId)}" data-outcome="${escapeHtml(
+            .map((team) => {
+              const teamGoals = goalsForFinalTeam(team.teamId);
+              return `<article data-ui="result-team" data-team-id="${escapeHtml(team.teamId)}" data-outcome="${escapeHtml(
                 team.outcome,
               )}"${teamSwatchStyle(team)}>
                 <header>
@@ -1926,10 +1946,18 @@
                   <div><dt>Conceded</dt><dd>${escapeHtml(String(team.conceded))}</dd></div>
                   <div><dt>Scored</dt><dd>${escapeHtml(String(team.scored))}</dd></div>
                 </dl>
-              </article>`,
-            )
+                <details data-ui="final-team-log" data-testid="final-team-log-${escapeHtml(team.teamId)}">
+                  <summary>Scoring log</summary>
+                  <ol data-ui="final-goal-list">
+                    ${renderFinalGoalItems(teamGoals, "No goals recorded for this team.")}
+                  </ol>
+                </details>
+              </article>`;
+            })
             .join("")}
         </div>
+        ${renderFinalAggregateStats()}
+        ${renderFinalFullGoalLog()}
       </section>`;
       syncGameModeState();
     }
@@ -2159,6 +2187,161 @@
       return `${scorer} for ${teamName(goal.scoringTeamId)}`;
     }
 
+    function goalDisplayTime(goal) {
+      if (typeof goal.displayTime === "string" && goal.displayTime.length > 0) {
+        return goal.displayTime;
+      }
+
+      if (Number.isInteger(goal.gameMinute) && goal.gameMinute > 0) {
+        return `${goal.gameMinute}'`;
+      }
+
+      return "-";
+    }
+
+    function goalAssistLabel(goal) {
+      const assistPlayerIds = Array.isArray(goal.assistPlayerIds) ? goal.assistPlayerIds : [];
+      if (assistPlayerIds.length === 0) {
+        return "No assists";
+      }
+
+      return `Assisted by ${assistPlayerIds.map((playerId) => playerNickname(playerId)).join(", ")}`;
+    }
+
+    function finalTeamGoalLabel(goal) {
+      const scorer = playerNickname(goal.scorerPlayerId);
+      if (goal.ownGoal) {
+        return `${scorer} own goal`;
+      }
+
+      return scorer;
+    }
+
+    function finalTeamGoalDetail(goal) {
+      if (goal.ownGoal) {
+        return "Conceded-only own goal";
+      }
+
+      return goalAssistLabel(goal);
+    }
+
+    function goalsForFinalTeam(teamId) {
+      return goalTimeline.filter(
+        (goal) =>
+          (!goal.ownGoal && goal.scoringTeamId === teamId) ||
+          (goal.ownGoal && goal.concedingTeamId === teamId),
+      );
+    }
+
+    function renderFinalGoalItems(goals, emptyText) {
+      if (goals.length === 0) {
+        return `<li data-ui="empty-note">${escapeHtml(emptyText)}</li>`;
+      }
+
+      return goals
+        .map(
+          (goal) => `<li data-ui="final-goal-item" data-event-id="${escapeHtml(String(goal.eventId ?? ""))}">
+            <span data-ui="goal-time">${escapeHtml(goalDisplayTime(goal))}</span>
+            <div>
+              <strong>${escapeHtml(finalTeamGoalLabel(goal))}</strong>
+              <small>${escapeHtml(finalTeamGoalDetail(goal))}</small>
+            </div>
+          </li>`,
+        )
+        .join("");
+    }
+
+    function incrementPlayerStat(stats, playerId) {
+      if (typeof playerId !== "string" || playerId.length === 0) {
+        return;
+      }
+
+      const existing = stats.get(playerId) ?? 0;
+      stats.set(playerId, existing + 1);
+    }
+
+    function sortedPlayerStats(stats) {
+      return [...stats.entries()]
+        .map(([playerId, count]) => ({
+          playerId,
+          count,
+          name: playerNickname(playerId),
+        }))
+        .sort((left, right) => right.count - left.count || left.name.localeCompare(right.name));
+    }
+
+    function renderPlayerStatList(entries, emptyText) {
+      if (entries.length === 0) {
+        return `<p data-ui="empty-note">${escapeHtml(emptyText)}</p>`;
+      }
+
+      return `<ol data-ui="final-stat-list">
+        ${entries
+          .map(
+            (entry) => `<li>
+              <span>${escapeHtml(entry.name)}</span>
+              <strong>${escapeHtml(String(entry.count))}</strong>
+            </li>`,
+          )
+          .join("")}
+      </ol>`;
+    }
+
+    function finalAggregateStats() {
+      const scorers = new Map();
+      const assists = new Map();
+      const ownGoals = new Map();
+
+      for (const goal of goalTimeline) {
+        if (goal.ownGoal) {
+          incrementPlayerStat(ownGoals, goal.scorerPlayerId);
+        } else {
+          incrementPlayerStat(scorers, goal.scorerPlayerId);
+        }
+
+        for (const assistPlayerId of Array.isArray(goal.assistPlayerIds) ? goal.assistPlayerIds : []) {
+          incrementPlayerStat(assists, assistPlayerId);
+        }
+      }
+
+      return {
+        scorers: sortedPlayerStats(scorers),
+        assists: sortedPlayerStats(assists),
+        ownGoals: sortedPlayerStats(ownGoals),
+      };
+    }
+
+    function renderFinalAggregateStats() {
+      const stats = finalAggregateStats();
+      const ownGoalStats = stats.ownGoals.length > 0
+        ? `<section data-ui="final-stat-card" data-testid="final-own-goal-stats">
+          <h4>Own goals</h4>
+          ${renderPlayerStatList(stats.ownGoals, "No own goals.")}
+        </section>`
+        : "";
+
+      return `<section data-ui="final-aggregate-stats" data-testid="final-aggregate-stats" aria-label="Player statistics">
+        <section data-ui="final-stat-card" data-testid="final-scorer-stats">
+          <h4>Top scorers</h4>
+          ${renderPlayerStatList(stats.scorers, "No scorers recorded.")}
+        </section>
+        <section data-ui="final-stat-card" data-testid="final-assist-stats">
+          <h4>Assists</h4>
+          ${renderPlayerStatList(stats.assists, "No assists recorded.")}
+        </section>
+        ${ownGoalStats}
+      </section>`;
+    }
+
+    function renderFinalFullGoalLog() {
+      return `<details data-ui="final-full-log" data-testid="final-full-goal-log">
+        <summary>Full match log</summary>
+        <ol data-ui="final-goal-list">
+          ${renderFinalGoalItems(goalTimeline, "No goals recorded.")}
+        </ol>
+      </details>`;
+    }
+
     function renderGoalTimeline() {
       if (!(goalTimelineElement instanceof HTMLElement)) {
         return;
@@ -2211,6 +2394,7 @@
       renderLiveScoreboard();
       renderGoalControls(seed);
       renderGoalTimeline();
+      renderGameResult();
       syncGameModeState();
     }
 
@@ -2644,7 +2828,7 @@
         });
 
         await loadGame();
-        setGameMode("players", { focusPanel: true });
+        setGameMode(gameModeAfterGameSave(), { focusPanel: true });
         setStatus("Game updated.", "success");
       } catch (error) {
         const message = error instanceof Error ? error.message : "Could not update game.";
@@ -2810,6 +2994,7 @@
       }
 
       const mode = trigger.getAttribute("data-game-mode");
+      manualGameModeSelected = true;
       setGameMode(mode, { focusPanel: trigger.getAttribute("role") !== "tab" });
     });
 
@@ -3145,7 +3330,9 @@
     }
     await loadRosterSetup({ updateStatus: false });
     const goalsLoaded = await loadGameGoals();
-    setGameMode(preferredInitialGameMode());
+    if (!manualGameModeSelected) {
+      setGameMode(preferredInitialGameMode());
+    }
     syncGameModeState();
 
     try {

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -1430,6 +1430,7 @@
     let rosterSearchTimer = 0;
     let scoreboardTeams = [];
     let goalTimeline = [];
+    let goalTimelineLoaded = false;
     let editingGoalId = null;
     let currentLeagueRole = null;
     let manualGameModeSelected = false;
@@ -1720,18 +1721,19 @@
       const timer = currentGame ? buildTimerState(currentGame) : null;
       if (!timer) {
         setGameMode("structure", { focusPanel: true });
-        return;
+        return false;
       }
 
       if (isGameFinished() || timer.status === "complete") {
         setGameMode("final");
         focusElementAction(finishGameButton);
-        return;
+        return true;
       }
 
       setGameMode("run");
       const activeSegment = timer.thirds.find((third) => third.status === "running") ?? null;
       focusElementAction(activeSegment ? finishThirdButton : startThirdButton);
+      return true;
     }
 
     function syncStatusOptions(hasStarted) {
@@ -2024,6 +2026,7 @@
       const resultOutcome = result.outcome === "win" ? "win" : "draw";
       const computedAt = typeof result.computedAt === "string" ? formatLocalTimestamp(result.computedAt) : "";
 
+      const goalLogsLoaded = goalTimelineLoaded;
       gameResultSummaryElement.hidden = false;
       gameResultSummaryElement.innerHTML = `<section data-ui="result-board" data-outcome="${escapeHtml(resultOutcome)}">
         <header>
@@ -2047,18 +2050,19 @@
                   <div><dt>Conceded</dt><dd>${escapeHtml(String(team.conceded))}</dd></div>
                   <div><dt>Scored</dt><dd>${escapeHtml(String(team.scored))}</dd></div>
                 </dl>
-                <details data-ui="final-team-log" data-testid="final-team-log-${escapeHtml(team.teamId)}">
-                  <summary>Scoring log</summary>
-                  <ol data-ui="final-goal-list">
-                    ${renderFinalGoalItems(teamGoals, "No goals recorded for this team.")}
-                  </ol>
-                </details>
+                ${goalLogsLoaded
+                  ? `<details data-ui="final-team-log" data-testid="final-team-log-${escapeHtml(team.teamId)}">
+                    <summary>Scoring log</summary>
+                    <ol data-ui="final-goal-list">
+                      ${renderFinalGoalItems(teamGoals, "No goals recorded for this team.")}
+                    </ol>
+                  </details>`
+                  : `<p data-ui="empty-note" data-testid="final-team-log-unavailable-${escapeHtml(team.teamId)}">Goal log unavailable.</p>`}
               </article>`;
             })
             .join("")}
         </div>
-        ${renderFinalAggregateStats()}
-        ${renderFinalFullGoalLog()}
+        ${goalLogsLoaded ? `${renderFinalAggregateStats()}${renderFinalFullGoalLog()}` : renderFinalGoalSummariesUnavailable()}
       </section>`;
       syncGameModeState();
     }
@@ -2466,6 +2470,13 @@
       </section>`;
     }
 
+    function renderFinalGoalSummariesUnavailable() {
+      return `<section data-ui="final-goal-unavailable" data-testid="final-goal-summary-unavailable" aria-label="Goal summaries unavailable">
+        <h4>Goal summaries unavailable</h4>
+        <p data-ui="empty-note">Team result totals are shown, but scorer, assist, and full goal logs could not be loaded.</p>
+      </section>`;
+    }
+
     function renderFinalFullGoalLog() {
       return `<details data-ui="final-full-log" data-testid="final-full-goal-log">
         <summary>Full match log</summary>
@@ -2477,6 +2488,11 @@
 
     function renderGoalTimeline() {
       if (!(goalTimelineElement instanceof HTMLElement)) {
+        return;
+      }
+
+      if (!goalTimelineLoaded) {
+        goalTimelineElement.innerHTML = `<li data-ui="empty-note">Goal timeline unavailable.</li>`;
         return;
       }
 
@@ -2537,14 +2553,15 @@
       }
 
       if (Array.isArray(result?.timeline)) {
+        goalTimelineLoaded = true;
         goalTimeline = sortGoalTimeline(result.timeline);
-      } else if (result?.goal) {
+      } else if (goalTimelineLoaded && result?.goal) {
         const nextGoal = result.goal;
         goalTimeline = sortGoalTimeline([
           ...goalTimeline.filter((goal) => goal.eventId !== nextGoal.eventId),
           nextGoal,
         ]);
-      } else if (fallback.deletedEventId) {
+      } else if (goalTimelineLoaded && fallback.deletedEventId) {
         goalTimeline = goalTimeline.filter((goal) => goal.eventId !== fallback.deletedEventId);
       }
 
@@ -2834,6 +2851,7 @@
         return false;
       }
 
+      goalTimelineLoaded = true;
       if (Array.isArray(payload?.scoreboard?.teams)) {
         scoreboardTeams = normalizeScoreboardTeams(payload.scoreboard.teams);
       }
@@ -3127,11 +3145,11 @@
       }
 
       const mode = trigger.getAttribute("data-game-mode");
-      manualGameModeSelected = true;
       if (mode === "final") {
-        selectGameStateAction();
+        manualGameModeSelected = selectGameStateAction();
         return;
       }
+      manualGameModeSelected = true;
       setGameMode(mode, { focusPanel: trigger.getAttribute("role") !== "tab" });
     });
 
@@ -3461,6 +3479,7 @@
       });
     }
 
+    syncGameModeState();
     await loadGame();
     if (isGameFinished()) {
       await loadLeagueAccess();

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -2361,21 +2361,26 @@
       );
     }
 
-    function renderFinalGoalItems(goals, emptyText) {
+    function renderFinalGoalItems(goals, emptyText, options = {}) {
       if (goals.length === 0) {
         return `<li data-ui="empty-note">${escapeHtml(emptyText)}</li>`;
       }
 
       return goals
-        .map(
-          (goal) => `<li data-ui="final-goal-item" data-event-id="${escapeHtml(String(goal.eventId ?? ""))}">
+        .map((goal) => {
+          const detail = finalTeamGoalDetail(goal);
+          const rowDetail =
+            options.includeThird === true && Number.isInteger(goal.third)
+              ? `Third ${goal.third} · ${detail}`
+              : detail;
+          return `<li data-ui="final-goal-item" data-event-id="${escapeHtml(String(goal.eventId ?? ""))}">
             <span data-ui="goal-time">${escapeHtml(goalDisplayTime(goal))}</span>
             <div>
               <strong>${escapeHtml(finalTeamGoalLabel(goal))}</strong>
-              <small>${escapeHtml(finalTeamGoalDetail(goal))}</small>
+              <small>${escapeHtml(rowDetail)}</small>
             </div>
-          </li>`,
-        )
+          </li>`;
+        })
         .join("");
     }
 
@@ -2465,7 +2470,7 @@
       return `<details data-ui="final-full-log" data-testid="final-full-goal-log">
         <summary>Full match log</summary>
         <ol data-ui="final-goal-list">
-          ${renderFinalGoalItems(goalTimeline, "No goals recorded.")}
+          ${renderFinalGoalItems(goalTimeline, "No goals recorded.", { includeThird: true })}
         </ol>
       </details>`;
     }

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -1381,6 +1381,9 @@
     const finishThirdButton = root.querySelector('[data-action="finish-active-third"]');
     const finishGameButton = root.querySelector('[data-action="finish-game"]');
     const gameResultSummaryElement = document.getElementById("game-result-summary");
+    const finalGameIdValue = document.getElementById("final-game-id-value");
+    const finalGameStatus = document.getElementById("final-game-status");
+    const finalGameReadiness = document.getElementById("final-game-readiness");
     const playerNicknameInput = document.getElementById("player-nickname");
     const quickCreatePlayerButton = root.querySelector('[data-action="quick-create-player"]');
     const playerSearchInput = document.getElementById("player-search");
@@ -1426,6 +1429,17 @@
     let currentLeagueRole = null;
     let pendingCreateGoalIdempotency = null;
     const pendingGoalMutationIdempotency = new Map();
+    const gameModes = ["structure", "players", "run", "final"];
+    const gameModeLabels = {
+      structure: "Game setup",
+      players: "Players",
+      run: "Run game",
+      final: "Finalisation",
+    };
+    const gameModeTabs = [...root.querySelectorAll('[role="tab"][data-game-mode]')];
+    const gameModeTriggers = [...root.querySelectorAll('[data-action="select-game-mode"][data-game-mode]')];
+    const gameModePanels = [...root.querySelectorAll('[data-ui="game-mode-panel"][data-game-mode]')];
+    const gameModeStatus = document.getElementById("game-mode-status");
 
     kickoffInput.addEventListener("input", () => {
       setFieldMessage("game-edit-kickoff");
@@ -1453,6 +1467,125 @@
 
     function isFinishedGoalCorrection() {
       return isGameFinished() && isEditingGoal() && canCorrectFinishedGoals();
+    }
+
+    function humanGameStatus(value) {
+      const labels = {
+        scheduled: "Scheduled",
+        live: "Live",
+        finished: "Finished",
+      };
+      return labels[value] ?? "Loading";
+    }
+
+    function isGameMode(value) {
+      return gameModes.includes(value);
+    }
+
+    function setModeMeta(mode, text) {
+      const meta = root.querySelector(`[data-mode-meta="${mode}"]`);
+      if (meta instanceof HTMLElement) {
+        meta.textContent = text;
+      }
+    }
+
+    function setGameMode(mode, options = {}) {
+      if (!isGameMode(mode)) {
+        return;
+      }
+
+      for (const panel of gameModePanels) {
+        if (!(panel instanceof HTMLElement)) {
+          continue;
+        }
+        const active = panel.getAttribute("data-game-mode") === mode;
+        panel.hidden = !active;
+        panel.setAttribute("tabindex", "-1");
+      }
+
+      for (const tab of gameModeTabs) {
+        if (!(tab instanceof HTMLElement)) {
+          continue;
+        }
+        const active = tab.getAttribute("data-game-mode") === mode;
+        tab.setAttribute("aria-selected", active ? "true" : "false");
+        tab.setAttribute("data-state", active ? "active" : "idle");
+      }
+
+      for (const trigger of gameModeTriggers) {
+        if (trigger instanceof HTMLElement) {
+          trigger.setAttribute("data-current", trigger.getAttribute("data-game-mode") === mode ? "true" : "false");
+        }
+      }
+
+      if (gameModeStatus instanceof HTMLElement) {
+        gameModeStatus.textContent = gameModeLabels[mode] ?? "Game setup";
+      }
+
+      if (options.focusPanel === true) {
+        const panel = gameModePanels.find((candidate) => candidate.getAttribute("data-game-mode") === mode);
+        if (panel instanceof HTMLElement) {
+          panel.focus({ preventScroll: false });
+        }
+      }
+    }
+
+    function gameModeFromHash() {
+      const hashMode = window.location.hash.replace(/^#/, "").replace(/^mode-/, "");
+      return isGameMode(hashMode) ? hashMode : null;
+    }
+
+    function preferredInitialGameMode() {
+      const requested = gameModeFromHash();
+      if (requested) {
+        return requested;
+      }
+
+      if (!currentGame) {
+        return "structure";
+      }
+
+      if (isGameFinished()) {
+        return "final";
+      }
+
+      const timer = buildTimerState(currentGame);
+      const hasStarted = timer.thirds.some((third) => third.startedAt !== null);
+      if (hasStarted || rosteredPlayers().length > 0) {
+        return hasStarted ? "run" : "players";
+      }
+
+      return "structure";
+    }
+
+    function syncGameModeState() {
+      const timer = currentGame ? buildTimerState(currentGame) : null;
+      const rosteredCount = rosteredPlayers().length;
+      const hasStarted = timer ? timer.thirds.some((third) => third.startedAt !== null) : false;
+      const complete = timer?.status === "complete";
+      const finished = isGameFinished();
+      const finalReadiness = finished
+        ? "Summary posted"
+        : complete
+          ? "Ready to finish"
+          : hasStarted
+            ? humanTimerStatus(timer.status)
+            : "Not started";
+
+      setModeMeta("structure", humanGameStatus(currentGame?.status));
+      setModeMeta("players", `${rosteredCount} assigned`);
+      setModeMeta("run", timer ? humanTimerStatus(timer.status) : "Timer");
+      setModeMeta("final", finished || complete ? "Ready" : "Pending");
+
+      if (finalGameIdValue instanceof HTMLElement && currentGame?.gameId) {
+        finalGameIdValue.textContent = currentGame.gameId;
+      }
+      if (finalGameStatus instanceof HTMLElement) {
+        finalGameStatus.textContent = humanGameStatus(currentGame?.status);
+      }
+      if (finalGameReadiness instanceof HTMLElement) {
+        finalGameReadiness.textContent = finalReadiness;
+      }
     }
 
     function nextStartableThird(timer) {
@@ -1583,6 +1716,7 @@
         timerTickInterval = window.setInterval(renderTimer, 1000);
       }
       renderGameResult();
+      syncGameModeState();
     }
 
     function rosterControlsAvailable() {
@@ -1758,6 +1892,7 @@
       if (!isGameFinished() || !result || teams.length === 0) {
         gameResultSummaryElement.hidden = true;
         gameResultSummaryElement.innerHTML = "";
+        syncGameModeState();
         return;
       }
 
@@ -1793,6 +1928,7 @@
             .join("")}
         </div>
       </section>`;
+      syncGameModeState();
     }
 
     function renderSelectOptions(selectElement, options, selectedValue, emptyLabel = "Select", missingSelectedLabel = null) {
@@ -2072,6 +2208,7 @@
       renderLiveScoreboard();
       renderGoalControls(seed);
       renderGoalTimeline();
+      syncGameModeState();
     }
 
     function applyGoalMutationResult(result, fallback = {}) {
@@ -2328,6 +2465,7 @@
       }
       renderPlayerPool();
       renderRosterTeams();
+      syncGameModeState();
     }
 
     async function loadRosterSetup(options = {}) {
@@ -2405,6 +2543,9 @@
       if (gameIdValue) {
         gameIdValue.textContent = game.gameId;
       }
+      if (finalGameIdValue) {
+        finalGameIdValue.textContent = game.gameId;
+      }
       if (gameJoinCodeValue) {
         gameJoinCodeValue.textContent = typeof game.joinCode === "string" && game.joinCode.length > 0
           ? game.joinCode
@@ -2436,6 +2577,7 @@
       statusInput.value = game.status;
       thirdLengthInput.value = String(parseThirdLengthMinutes(game.thirdLengthMinutes ?? game.timer?.thirdLengthMinutes));
       renderTimer();
+      syncGameModeState();
 
       if (gameLeagueLink instanceof HTMLAnchorElement) {
         gameLeagueLink.href = `/leagues/${encodeURIComponent(game.leagueId)}`;
@@ -2499,6 +2641,7 @@
         });
 
         await loadGame();
+        setGameMode("players", { focusPanel: true });
         setStatus("Game updated.", "success");
       } catch (error) {
         const message = error instanceof Error ? error.message : "Could not update game.";
@@ -2556,6 +2699,7 @@
           `/v1/games/${encodeURIComponent(gameId)}/thirds/${encodeURIComponent(third)}/start`,
           { method: "POST" },
         );
+        setGameMode("run");
         renderTimer();
         renderLiveScoring();
         statusInput.value = currentGame.status;
@@ -2590,6 +2734,9 @@
           `/v1/games/${encodeURIComponent(gameId)}/thirds/${encodeURIComponent(third)}/finish`,
           { method: "POST" },
         );
+        if (buildTimerState(currentGame).status === "complete") {
+          setGameMode("final");
+        }
         renderTimer();
         renderLiveScoring();
         statusInput.value = currentGame.status;
@@ -2632,6 +2779,7 @@
         if (isGameFinished()) {
           await loadLeagueAccess();
         }
+        setGameMode("final");
         statusInput.value = currentGame.status;
         renderTimer();
         renderRosterSetup();
@@ -2646,6 +2794,20 @@
         renderRosterSetup();
         renderLiveScoring();
       }
+    });
+
+    root.addEventListener("click", (event) => {
+      const target = event.target;
+      const trigger =
+        target instanceof Element
+          ? target.closest('[data-action="select-game-mode"][data-game-mode]')
+          : null;
+      if (!(trigger instanceof HTMLElement)) {
+        return;
+      }
+
+      const mode = trigger.getAttribute("data-game-mode");
+      setGameMode(mode, { focusPanel: trigger.getAttribute("role") !== "tab" });
     });
 
     if (rosterControlsAvailable()) {
@@ -2980,6 +3142,8 @@
     }
     await loadRosterSetup({ updateStatus: false });
     const goalsLoaded = await loadGameGoals();
+    setGameMode(preferredInitialGameMode());
+    syncGameModeState();
 
     try {
       const season = await requestJsonOrThrow(`/v1/seasons/${encodeURIComponent(currentSeasonId)}`, {

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -567,6 +567,11 @@
     return offsetAdjusted.toISOString().slice(0, 16);
   }
 
+  function formatLocalTimestamp(isoTimestamp) {
+    const localValue = toLocalDateTimeInput(isoTimestamp);
+    return localValue ? localValue.replace("T", " ") : String(isoTimestamp ?? "");
+  }
+
   function todayDate() {
     const now = new Date();
     const localNow = new Date(now.getTime() - now.getTimezoneOffset() * 60000);
@@ -1196,7 +1201,7 @@
       gamesBody.innerHTML = games
         .map((game) => `<tr>
           <td><a href="/games/${encodeURIComponent(game.gameId)}">${escapeHtml(game.gameId)}</a></td>
-          <td>${escapeHtml(game.gameStartTs)}</td>
+          <td>${escapeHtml(formatLocalTimestamp(game.gameStartTs))}</td>
           <td>${escapeHtml(game.status)}</td>
           <td>
             <div data-ui="row-action-buttons">
@@ -1490,6 +1495,13 @@
       }
     }
 
+    function setModeLabel(mode, text) {
+      const label = root.querySelector(`[data-mode-label="${mode}"]`);
+      if (label instanceof HTMLElement) {
+        label.textContent = text;
+      }
+    }
+
     function setGameMode(mode, options = {}) {
       if (!isGameMode(mode)) {
         return;
@@ -1580,6 +1592,60 @@
       return hasStarted ? "run" : "players";
     }
 
+    function gameStateTabState(timer) {
+      if (!currentGame || !timer) {
+        return {
+          label: "Pregame",
+          meta: "Loading",
+          state: "loading",
+        };
+      }
+
+      if (isGameFinished()) {
+        return {
+          label: "Final",
+          meta: "Summary",
+          state: "finished",
+        };
+      }
+
+      if (timer.status === "complete") {
+        return {
+          label: "Final",
+          meta: "Finish game",
+          state: "ready",
+        };
+      }
+
+      const activeSegment = timer.thirds.find((third) => third.status === "running") ?? null;
+      if (activeSegment?.startedAt) {
+        const timerDisplay = formatTimerDisplay(
+          elapsedSeconds(activeSegment.startedAt, activeSegment.finishedAt),
+          timer.thirdLengthMinutes,
+        ).displayTime;
+        return {
+          label: timerDisplay,
+          meta: `Third ${activeSegment.third}`,
+          state: "running",
+        };
+      }
+
+      if (timer.status === "between_thirds") {
+        const nextThird = nextStartableThird(timer);
+        return {
+          label: "Break",
+          meta: nextThird ? `Start T${nextThird}` : "Ready",
+          state: "break",
+        };
+      }
+
+      return {
+        label: "Pregame",
+        meta: "Start clock",
+        state: "pregame",
+      };
+    }
+
     function syncGameModeState() {
       const timer = currentGame ? buildTimerState(currentGame) : null;
       const rosteredCount = rosteredPlayers().length;
@@ -1597,7 +1663,13 @@
       setModeMeta("structure", humanGameStatus(currentGame?.status));
       setModeMeta("players", `${rosteredCount} assigned`);
       setModeMeta("run", timer ? humanTimerStatus(timer.status) : "Timer");
-      setModeMeta("final", finished || complete ? "Ready" : "Pending");
+      const gameState = gameStateTabState(timer);
+      setModeLabel("final", gameState.label);
+      setModeMeta("final", gameState.meta);
+      const gameStateTab = root.querySelector('[data-testid="game-mode-final-tab"]');
+      if (gameStateTab instanceof HTMLElement) {
+        gameStateTab.setAttribute("data-game-state", gameState.state);
+      }
 
       if (finalGameIdValue instanceof HTMLElement && currentGame?.gameId) {
         finalGameIdValue.textContent = currentGame.gameId;
@@ -1631,6 +1703,35 @@
 
       const finished = [...timer.thirds].reverse().find((third) => third.status === "finished");
       return finished ?? timer.thirds[0] ?? null;
+    }
+
+    function focusElementAction(element) {
+      if (!(element instanceof HTMLElement)) {
+        return;
+      }
+
+      if (typeof element.scrollIntoView === "function") {
+        element.scrollIntoView({ block: "center" });
+      }
+      element.focus({ preventScroll: true });
+    }
+
+    function selectGameStateAction() {
+      const timer = currentGame ? buildTimerState(currentGame) : null;
+      if (!timer) {
+        setGameMode("structure", { focusPanel: true });
+        return;
+      }
+
+      if (isGameFinished() || timer.status === "complete") {
+        setGameMode("final");
+        focusElementAction(finishGameButton);
+        return;
+      }
+
+      setGameMode("run");
+      const activeSegment = timer.thirds.find((third) => third.status === "running") ?? null;
+      focusElementAction(activeSegment ? finishThirdButton : startThirdButton);
     }
 
     function syncStatusOptions(hasStarted) {
@@ -1697,9 +1798,9 @@
           .map((third) => {
             const status = humanTimerStatus(third.status);
             const detail = third.finishedAt
-              ? `Finished ${third.finishedAt}`
+              ? `Finished ${formatLocalTimestamp(third.finishedAt)}`
               : third.startedAt
-                ? `Started ${third.startedAt}`
+                ? `Started ${formatLocalTimestamp(third.startedAt)}`
                 : "Waiting";
             return `<li data-ui="third-status-item" data-state="${escapeHtml(third.status)}">
               <strong>Third ${third.third}</strong>
@@ -1921,7 +2022,7 @@
       const winner = teams.find((team) => team.teamId === result.winnerTeamId) ?? null;
       const outcomeText = winner ? `${winner.name} win` : "Draw";
       const resultOutcome = result.outcome === "win" ? "win" : "draw";
-      const computedAt = typeof result.computedAt === "string" ? result.computedAt : "";
+      const computedAt = typeof result.computedAt === "string" ? formatLocalTimestamp(result.computedAt) : "";
 
       gameResultSummaryElement.hidden = false;
       gameResultSummaryElement.innerHTML = `<section data-ui="result-board" data-outcome="${escapeHtml(resultOutcome)}">
@@ -2188,12 +2289,39 @@
     }
 
     function goalDisplayTime(goal) {
-      if (typeof goal.displayTime === "string" && goal.displayTime.length > 0) {
-        return goal.displayTime;
+      if (Number.isInteger(goal.gameMinute) && goal.gameMinute > 0) {
+        if (Number.isInteger(goal.stoppageMinute) && goal.stoppageMinute > 0) {
+          return `${goal.gameMinute}+${goal.stoppageMinute}"`;
+        }
+
+        return `${goal.gameMinute}"`;
       }
 
-      if (Number.isInteger(goal.gameMinute) && goal.gameMinute > 0) {
-        return `${goal.gameMinute}'`;
+      const thirdLength = parseThirdLengthMinutes(currentGame?.thirdLengthMinutes ?? currentGame?.timer?.thirdLengthMinutes);
+      if (Number.isInteger(goal.third) && Number.isInteger(goal.thirdMinute) && goal.third > 0 && goal.thirdMinute > 0) {
+        const regulationMinute = (goal.third - 1) * thirdLength + Math.min(goal.thirdMinute, thirdLength);
+        if (Number.isInteger(goal.stoppageMinute) && goal.stoppageMinute > 0) {
+          return `${goal.third * thirdLength}+${goal.stoppageMinute}"`;
+        }
+
+        return `${regulationMinute}"`;
+      }
+
+      if (typeof goal.displayTime === "string" && goal.displayTime.length > 0) {
+        const stoppageMatch = goal.displayTime.match(/^(\d+)\+0?(\d+)$/);
+        if (stoppageMatch) {
+          return `${stoppageMatch[1]}+${Number.parseInt(stoppageMatch[2], 10)}"`;
+        }
+
+        const clockMatch = goal.displayTime.match(/^(\d+):\d{2}$/);
+        if (clockMatch) {
+          return `${Math.max(1, Number.parseInt(clockMatch[1], 10))}"`;
+        }
+
+        const minuteMatch = goal.displayTime.match(/^(\d+)'?$/);
+        if (minuteMatch) {
+          return `${Number.parseInt(minuteMatch[1], 10)}"`;
+        }
       }
 
       return "-";
@@ -2367,7 +2495,7 @@
             latest ? ' data-state="latest"' : ""
           }>
             <div data-ui="goal-event-main">
-              <strong>${escapeHtml(goal.displayTime)} · Third ${escapeHtml(String(goal.third))}</strong>
+              <strong>${escapeHtml(goalDisplayTime(goal))} · Third ${escapeHtml(String(goal.third))}</strong>
               <span>${escapeHtml(timelineGoalLabel(goal))}</span>
               <small>Assists: ${escapeHtml(assists)}</small>
               ${goal.ownGoal ? `<small>Own goal: conceding tally only</small>` : ""}
@@ -2724,7 +2852,7 @@
       }
 
       if (subtitle) {
-        subtitle.innerHTML = `Kickoff (UTC): <code>${escapeHtml(game.gameStartTs)}</code>`;
+        subtitle.innerHTML = `Kickoff: <code>${escapeHtml(formatLocalTimestamp(game.gameStartTs))}</code>`;
       }
 
       if (gameIdValue) {
@@ -2995,6 +3123,10 @@
 
       const mode = trigger.getAttribute("data-game-mode");
       manualGameModeSelected = true;
+      if (mode === "final") {
+        selectGameStateAction();
+        return;
+      }
       setGameMode(mode, { focusPanel: trigger.getAttribute("role") !== "tab" });
     });
 

--- a/app/src/ui/styles.css
+++ b/app/src/ui/styles.css
@@ -474,6 +474,48 @@ body {
   gap: 0.75rem;
 }
 
+[data-ui="run-console"] {
+  display: grid;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+[data-ui="run-scoring-panel"],
+[data-ui="run-timer-panel"] {
+  display: grid;
+  gap: 0.75rem;
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--surface-elevated);
+  padding: 0.75rem;
+  box-shadow: 0 10px 24px rgba(33, 57, 53, 0.08);
+}
+
+[data-ui="section-heading"] {
+  display: grid;
+  gap: 0.15rem;
+
+  h2 {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 1.15rem;
+  }
+
+  p {
+    margin: 0;
+    color: var(--ink-soft);
+    font-size: 0.82rem;
+  }
+}
+
+[data-ui="run-score-strip"] {
+  border: 1px solid #c9ded7;
+  border-radius: 8px;
+  background: #f7fcfa;
+  padding: 0.45rem;
+}
+
 [data-ui="live-scoreboard"] {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -531,6 +573,86 @@ body {
     border-radius: 999px;
     background: var(--team-color);
     box-shadow: inset 0 0 0 1px rgba(29, 42, 47, 0.18);
+  }
+}
+
+[data-ui="run-primary-scoring"] {
+  display: grid;
+  gap: 0.65rem;
+  min-width: 0;
+  border: 1px solid #b8d4ca;
+  border-radius: 10px;
+  background: #ffffff;
+  padding: 0.7rem;
+
+  > header {
+    display: grid;
+    gap: 0.1rem;
+
+    h3 {
+      margin: 0;
+      font-size: 1rem;
+      color: #234b45;
+    }
+  }
+}
+
+[data-ui="run-goal-form"] {
+  display: grid;
+  gap: 0.6rem;
+}
+
+[data-ui="run-secondary-scoring"],
+[data-ui="run-latest-goals"],
+[data-ui="run-third-history"],
+[data-ui="final-team-log"],
+[data-ui="final-full-log"] {
+  display: grid;
+  gap: 0.5rem;
+  min-width: 0;
+
+  summary {
+    cursor: pointer;
+    color: #294f49;
+    font-weight: 850;
+    font-size: 0.86rem;
+  }
+}
+
+[data-ui="run-secondary-scoring"] {
+  border: 1px solid #d4e4df;
+  border-radius: 8px;
+  padding: 0.55rem;
+  background: #fbfdfc;
+}
+
+[data-ui="run-latest-goals"],
+[data-ui="run-third-history"] {
+  border: 1px solid #d3e5df;
+  border-radius: 8px;
+  background: #fbfdfc;
+  padding: 0.6rem;
+}
+
+[data-ui="run-timer-bar"] {
+  display: grid;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+[data-ui="button-row"][data-priority="scoring"] {
+  [data-ui="button"][data-variant="primary"] {
+    flex: 1 1 100%;
+    min-height: 3rem;
+    font-size: 1rem;
+  }
+}
+
+[data-ui="button-row"][data-density="compact"] {
+  gap: 0.4rem;
+
+  [data-ui="button"] {
+    padding: 0.48rem 0.78rem;
   }
 }
 
@@ -641,6 +763,107 @@ body {
   }
 }
 
+[data-ui="final-team-log"] {
+  border-top: 1px solid #d9e8e3;
+  padding-top: 0.45rem;
+}
+
+[data-ui="final-goal-list"] {
+  display: grid;
+  gap: 0.45rem;
+  margin: 0.5rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+[data-ui="final-goal-item"] {
+  display: grid;
+  grid-template-columns: 3rem minmax(0, 1fr);
+  gap: 0.45rem;
+  align-items: start;
+  padding: 0.42rem;
+  border: 1px solid #d7e7e2;
+  border-radius: 8px;
+  background: #ffffff;
+
+  [data-ui="goal-time"] {
+    border-radius: 999px;
+    background: #edf6f2;
+    color: #24564e;
+    padding: 0.1rem 0.34rem;
+    text-align: center;
+    font-weight: 850;
+    font-size: 0.76rem;
+  }
+
+  div {
+    display: grid;
+    gap: 0.12rem;
+    min-width: 0;
+  }
+
+  strong,
+  small {
+    overflow-wrap: anywhere;
+  }
+
+  small {
+    color: var(--ink-soft);
+    font-size: 0.76rem;
+  }
+}
+
+[data-ui="final-aggregate-stats"] {
+  display: grid;
+  gap: 0.55rem;
+}
+
+[data-ui="final-stat-card"] {
+  display: grid;
+  gap: 0.45rem;
+  border: 1px solid #c9ded7;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 0.6rem;
+
+  h4 {
+    margin: 0;
+    color: #294f49;
+    font-size: 0.9rem;
+  }
+}
+
+[data-ui="final-stat-list"] {
+  display: grid;
+  gap: 0.35rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+
+  li {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 0.45rem;
+    align-items: baseline;
+  }
+
+  span {
+    overflow-wrap: anywhere;
+  }
+
+  strong {
+    min-width: 1.7rem;
+    text-align: right;
+  }
+}
+
+[data-ui="final-full-log"] {
+  border: 1px solid #d3e5df;
+  border-radius: 8px;
+  background: #fbfdfc;
+  padding: 0.6rem;
+}
+
 [data-ui="rank-chip"] {
   border-radius: 999px;
   padding: 0.08rem 0.34rem;
@@ -654,8 +877,8 @@ body {
   display: grid;
   gap: 0.2rem;
   border: 1px solid #c6ddd5;
-  border-radius: 10px;
-  padding: 0.75rem;
+  border-radius: 8px;
+  padding: 0.6rem;
   background: #f7fcfa;
 
   span {
@@ -666,7 +889,7 @@ body {
 
   strong {
     font-family: var(--font-display);
-    font-size: 2.4rem;
+    font-size: 2rem;
     line-height: 1;
   }
 }
@@ -1301,9 +1524,31 @@ code {
     grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 
-  [data-ui="game-mode-panel"][data-mode-layout="run"] {
-    grid-template-columns: minmax(17rem, 0.8fr) minmax(0, 1.2fr);
+  [data-ui="run-console"] {
+    grid-template-columns: minmax(0, 1.2fr) minmax(17rem, 0.8fr);
     align-items: start;
+  }
+
+  [data-ui="run-scoring-panel"] {
+    grid-column: 1;
+    grid-row: 1 / span 2;
+  }
+
+  [data-ui="run-timer-panel"] {
+    grid-column: 2;
+  }
+
+  [data-ui="run-timer-bar"] {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  [data-ui="run-goal-form"] {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  [data-ui="run-goal-form"] [data-ui="field"]:nth-of-type(3),
+  [data-ui="run-secondary-scoring"] {
+    grid-column: 1 / -1;
   }
 
   [data-ui="context-grid"] {
@@ -1316,6 +1561,10 @@ code {
 
   [data-ui="result-team-list"] {
     grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  [data-ui="final-aggregate-stats"] {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   [data-ui="roster-workspace"] {

--- a/app/src/ui/styles.css
+++ b/app/src/ui/styles.css
@@ -510,10 +510,14 @@ body {
 }
 
 [data-ui="run-score-strip"] {
+  position: sticky;
+  top: 4.45rem;
+  z-index: 18;
   border: 1px solid #c9ded7;
   border-radius: 8px;
   background: #f7fcfa;
   padding: 0.45rem;
+  box-shadow: 0 8px 20px rgba(31, 63, 57, 0.1);
 }
 
 [data-ui="live-scoreboard"] {
@@ -599,7 +603,14 @@ body {
 
 [data-ui="run-goal-form"] {
   display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.6rem;
+}
+
+[data-ui="run-goal-form"] [data-ui="field"]:nth-of-type(3),
+[data-ui="run-goal-form"] > [data-ui="check-row"],
+[data-ui="run-secondary-scoring"] {
+  grid-column: 1 / -1;
 }
 
 [data-ui="run-secondary-scoring"],
@@ -1387,6 +1398,7 @@ body {
     color: var(--ink-strong);
     font-weight: 850;
     line-height: 1.05;
+    overflow-wrap: anywhere;
   }
 
   small {
@@ -1403,6 +1415,37 @@ body {
     span,
     small {
       color: var(--accent-strong);
+    }
+  }
+
+  &[data-game-state="running"] {
+    border-color: #d7983c;
+    background: #fff4dd;
+
+    span,
+    small {
+      color: #744412;
+    }
+  }
+
+  &[data-game-state="break"],
+  &[data-game-state="ready"] {
+    border-color: #79afa1;
+    background: #eaf7f2;
+
+    span,
+    small {
+      color: #174f47;
+    }
+  }
+
+  &[data-game-state="finished"] {
+    border-color: #9fb7c5;
+    background: #eef5f8;
+
+    span,
+    small {
+      color: #27495a;
     }
   }
 
@@ -1547,6 +1590,7 @@ code {
   }
 
   [data-ui="run-goal-form"] [data-ui="field"]:nth-of-type(3),
+  [data-ui="run-goal-form"] > [data-ui="check-row"],
   [data-ui="run-secondary-scoring"] {
     grid-column: 1 / -1;
   }

--- a/app/src/ui/styles.css
+++ b/app/src/ui/styles.css
@@ -1572,13 +1572,20 @@ code {
     align-items: start;
   }
 
+  [data-ui="run-score-strip"] {
+    grid-column: 1 / -1;
+  }
+
   [data-ui="run-scoring-panel"] {
     grid-column: 1;
-    grid-row: 1 / span 2;
   }
 
   [data-ui="run-timer-panel"] {
     grid-column: 2;
+  }
+
+  [data-ui="run-latest-goals"] {
+    grid-column: 1;
   }
 
   [data-ui="run-timer-bar"] {

--- a/app/src/ui/styles.css
+++ b/app/src/ui/styles.css
@@ -1097,6 +1097,7 @@ body {
 
 [data-ui="status-note"] {
   margin-top: 0.9rem;
+  min-width: 0;
   font-size: 0.84rem;
   color: #5a6f6b;
 
@@ -1122,6 +1123,102 @@ body {
   gap: 0.6rem;
 }
 
+[data-ui="game-mode-nav"] {
+  position: sticky;
+  top: 0.35rem;
+  z-index: 20;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  background: rgba(251, 250, 247, 0.96);
+  box-shadow: 0 10px 24px rgba(9, 44, 39, 0.12);
+  padding: 0.3rem;
+}
+
+[data-ui="game-mode-tabs"] {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.28rem;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+  scrollbar-width: thin;
+}
+
+[data-ui="game-mode-tab"] {
+  min-height: 3.15rem;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--ink-soft);
+  display: grid;
+  align-content: center;
+  gap: 0.1rem;
+  padding: 0.45rem 0.55rem;
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
+
+  span {
+    color: var(--ink-strong);
+    font-weight: 850;
+    line-height: 1.05;
+  }
+
+  small {
+    color: var(--ink-soft);
+    font-size: 0.72rem;
+    font-weight: 700;
+    overflow-wrap: anywhere;
+  }
+
+  &[data-state="active"] {
+    border-color: var(--accent);
+    background: var(--accent-soft);
+
+    span,
+    small {
+      color: var(--accent-strong);
+    }
+  }
+
+  &:focus-visible {
+    outline: 2px solid #5eb6aa73;
+    outline-offset: 2px;
+  }
+}
+
+[data-ui="game-mode-status"] {
+  margin: 0;
+  color: #31534f;
+  font-size: 0.82rem;
+  font-weight: 800;
+}
+
+[data-ui="game-mode-panels"],
+[data-ui="game-mode-panel"] {
+  display: grid;
+  gap: 0.85rem;
+  min-width: 0;
+}
+
+[data-ui="game-mode-panel"][hidden] {
+  display: none;
+}
+
+[data-ui="mode-actions"] {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+[data-ui="finalisation-board"] {
+  display: grid;
+  gap: 0.75rem;
+}
+
 [data-ui="setup-mode"][hidden] {
   display: none;
 }
@@ -1138,8 +1235,9 @@ body {
 
   div {
     display: grid;
-    grid-template-columns: minmax(7rem, 9rem) 1fr;
+    grid-template-columns: minmax(7rem, 9rem) minmax(0, 1fr);
     gap: 0.4rem;
+    min-width: 0;
   }
 
   dt {
@@ -1152,6 +1250,8 @@ body {
     color: #29433f;
     font-family: "SF Mono", "Menlo", "Monaco", monospace;
     font-size: 0.82rem;
+    min-width: 0;
+    overflow-wrap: anywhere;
   }
 }
 
@@ -1195,6 +1295,15 @@ code {
   [data-ui="panel-grid"] {
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 0.95rem;
+  }
+
+  [data-ui="game-mode-tabs"] {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  [data-ui="game-mode-panel"][data-mode-layout="run"] {
+    grid-template-columns: minmax(17rem, 0.8fr) minmax(0, 1.2fr);
+    align-items: start;
   }
 
   [data-ui="context-grid"] {

--- a/tests/e2e/m2-smoke.spec.ts
+++ b/tests/e2e/m2-smoke.spec.ts
@@ -619,6 +619,11 @@ async function createAndAssignPlayer(
   return playerId;
 }
 
+async function selectGameMode(page: Page, mode: "structure" | "players" | "run" | "final"): Promise<void> {
+  await page.getByTestId(`game-mode-${mode}-tab`).click();
+  await expect(page.getByTestId(`game-mode-${mode}`)).toBeVisible();
+}
+
 async function startThird(page: Page, third: 1 | 2 | 3): Promise<void> {
   await expect(page.getByTestId("start-third")).toHaveText(`Start Third ${third}`);
   await page.getByTestId("start-third").click();
@@ -965,6 +970,8 @@ test.describe("M2 local-stack smoke", () => {
       ]);
       await expect(page.getByTestId("game-shell")).toBeVisible();
       await expect(page.locator("#game-id-value")).toHaveText(gameId);
+      await expect(page.getByTestId("game-mode-structure")).toBeVisible();
+      await expect(page.getByTestId("game-mode-players")).toBeHidden();
       const joinCodeValue = page.getByTestId("game-join-code-value");
       await expect(joinCodeValue).toHaveText(/^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{8}$/);
       const joinCode = (await joinCodeValue.innerText()).trim();
@@ -1009,6 +1016,7 @@ test.describe("M2 local-stack smoke", () => {
         playerIds.push(joinResult.body.player.playerId);
       }
 
+      await selectGameMode(page, "players");
       await page.locator("#player-search").fill("Cy");
       await expect(page.locator('[data-ui="roster-player"]').filter({ hasText: "Cy" })).toBeVisible();
       await page.locator("#player-search").fill("");
@@ -1020,6 +1028,9 @@ test.describe("M2 local-stack smoke", () => {
         playerIds.push(playerId);
       });
 
+      await selectGameMode(page, "run");
+      await expect(page.getByTestId("add-goal")).toBeVisible();
+      await expect(page.getByTestId("undo-last-goal")).toBeVisible();
       await startThird(page, 1);
       await page.locator("#goal-scoring-team").selectOption("red");
       await page.locator("#goal-conceding-team").selectOption("blue");
@@ -1038,6 +1049,7 @@ test.describe("M2 local-stack smoke", () => {
       await startThird(page, 3);
       await finishThird(page, 3);
 
+      await expect(page.getByTestId("game-mode-final")).toBeVisible();
       await expect(page.getByTestId("finish-game")).toBeEnabled();
       await page.getByTestId("finish-game").click();
 
@@ -1052,10 +1064,12 @@ test.describe("M2 local-stack smoke", () => {
       await expect(page.getByTestId("finish-game")).toBeDisabled();
       await expect(page.getByTestId("finish-game")).toHaveText("Game finished");
       await expect(page.getByTestId("delete-game")).toBeDisabled();
+      await selectGameMode(page, "players");
       await expect(page.getByTestId("quick-create-player")).toBeEnabled();
+      await expectAllEnabled(page.locator('[data-action="assign-player"]'));
+      await selectGameMode(page, "run");
       await expect(page.getByTestId("add-goal")).toBeEnabled();
       await expect(page.locator("#goal-form-note")).toContainText("final whistle");
-      await expectAllEnabled(page.locator('[data-action="assign-player"]'));
       await expect(page.locator('[data-action="edit-goal"]').first()).toBeEnabled();
       await expect(page.locator('[data-action="delete-goal"]').first()).toBeEnabled();
       await expect(page.getByTestId("undo-last-goal")).toBeEnabled();

--- a/tests/e2e/m2-smoke.spec.ts
+++ b/tests/e2e/m2-smoke.spec.ts
@@ -1060,6 +1060,10 @@ test.describe("M2 local-stack smoke", () => {
       await expect(resultTeams.locator('[data-ui="result-team"][data-team-id="red"]')).toContainText(/Scored\s*1/);
       await expect(resultTeams.locator('[data-ui="result-team"][data-team-id="blue"]')).toContainText(/Conceded\s*1/);
       await expect(resultTeams.locator('[data-ui="result-team"][data-team-id="blue"]')).toContainText(/Scored\s*0/);
+      await expect(page.getByTestId("final-team-log-red")).toContainText(ariNickname);
+      await expect(page.getByTestId("final-scorer-stats").locator("li").filter({ hasText: ariNickname })).toContainText("1");
+      await expect(page.getByTestId("final-assist-stats").locator("li").filter({ hasText: beaNickname })).toContainText("1");
+      await expect(page.getByTestId("final-full-goal-log")).toContainText(ariNickname);
       await expect(page.locator("#game-edit-status")).toHaveValue("finished");
       await expect(page.getByTestId("finish-game")).toBeDisabled();
       await expect(page.getByTestId("finish-game")).toHaveText("Game finished");


### PR DESCRIPTION
<!-- review-packet-version:1 -->

## Behavioural claim

Reworks the game page into four mobile-first workflow modes - Game, Players, Run, and Final - and refines Run into a scoring-first console so scorekeepers can record goals, reference the live score, start/finish thirds, and make occasional corrections without losing draft state or being pulled out of the active workflow. The Final mode includes team scoring logs, full match log, aggregate scorers, assists, and own-goal statistics. This update also addresses QA timing/layout feedback: goal summaries now use full-match football notation, visible timestamps are shown in the user's local timezone, the Run score strip stays visible while scrolling, scoring/conceding team selectors share the first form row on phone, and the fourth sticky workflow control becomes a live game-state/clock action until the game is final.

## Specification and acceptance evidence

| Acceptance criterion | Evidence | Result |
| --- | --- | --- |
| Game pages render stable workflow controls and keep only the active mode panel visible. | `npm test -w @3fc/app` on branch `codex/m2-09-mobile-game-flow` at `e1ebd40` | PASS |
| Run mode prioritizes live scoring over timer controls while keeping timer controls ahead of the growing latest-goals history. | `game page renders editable game metadata view`; `npm test -w @3fc/app` on branch `codex/m2-09-mobile-game-flow` at `e1ebd40` | PASS |
| Switching between Players and Run modes preserves an in-progress scoring draft, including scorer and assist selections. | `game page mode panels switch without resetting a goal draft`; `npm test -w @3fc/app` on branch `codex/m2-09-mobile-game-flow` at `e1ebd40` | PASS |
| Manual fourth-control selections made before initial game data finishes loading do not suppress the later mode selection for a running game. | `game page retries early game-state tab selection after initial game loading`; `npm test -w @3fc/app` at `e1ebd40` | PASS |
| Starting thirds keeps the scorekeeper in Run mode, completing third 3 advances to Final, and finishing the game renders the final summary in Final mode. | `game page mode panels advance from setup to run and finalisation`; `npm test -w @3fc/app` on branch `codex/m2-09-mobile-game-flow` at `e1ebd40` | PASS |
| Reloading a live game after all thirds are complete resumes in Final mode with Finish game visible. | `game page resumes completed live timers in finalisation mode`; `npm test -w @3fc/app` on branch `codex/m2-09-mobile-game-flow` at `e1ebd40` | PASS |
| Saving editable live-game metadata after a third has started returns the scorekeeper to Run mode rather than Players. | `game page preserves run mode after live game metadata save`; `npm test -w @3fc/app` on branch `codex/m2-09-mobile-game-flow` at `e1ebd40` | PASS |
| Final mode renders per-team scoring logs plus aggregate scorer, assist, own-goal, and full match logs. | `game page renders final team logs and aggregate player stats`; mobile Playwright smoke final-screen assertions; `npm test -w @3fc/app`; `npm run smoke:m2:playwright -- -g "scorekeeper can set up and finish a live game" --project=chromium-mobile` at `e1ebd40` | PASS |
| Final result totals remain visible but goal-derived summaries are marked unavailable if the goal timeline cannot be loaded. | `game page remains usable when goal timeline load fails`; `npm test -w @3fc/app` at `e1ebd40` | PASS |
| Failed timeline refreshes after prior successful loads invalidate goal-derived UI instead of leaving stale edit or undo controls actionable. | `game page invalidates current goals when correction replay refresh fails`; `npm test -w @3fc/app` at `e1ebd40` | PASS |
| The full match log includes third context so goals at the same visible minute in different thirds remain distinguishable. | `game page renders final team logs and aggregate player stats` verifies `Third 2` appears in the full match log; `npm test -w @3fc/app` at `e1ebd40` | PASS |
| Goal times in live and final summaries use full-match football notation, including second-third aggregate minutes and stoppage time such as `25+3"`. | `game page renders final team logs and aggregate player stats` covers `1"`, `43"`, and `25+3"` for a 25-minute-thirds game; `npm test -w @3fc/app` at `e1ebd40` | PASS |
| Visible game timestamps render in the user's local timezone rather than raw UTC strings. | `season page renders game kickoff times in the user local timezone`; `setup happy path runs from sign-in to created game context`; `game page mode panels advance from setup to run and finalisation`; `game page renders final team logs and aggregate player stats`; `npm test -w @3fc/app` at `e1ebd40` | PASS |
| The sticky fourth mode button reflects the current game state and acts as a shortcut to the timer/finalisation action. | `game page mode panels advance from setup to run and finalisation` verifies Pregame -> running clock/third -> Break -> ready Final -> finished Summary labels and click focus behaviour; `npm test -w @3fc/app` at `e1ebd40` | PASS |
| The live game-state shortcut uses ordinary button semantics rather than a misdeclared ARIA tab with a static panel target. | `game page mode panels advance from setup to run and finalisation`; `game page renders editable game metadata view`; `npm test -w @3fc/app` at `e1ebd40` | PASS |
| The Run panel keeps the score strip sticky and compresses scoring/conceding team selectors onto the first form row on mobile. | `app/src/ui/styles.css` applies sticky positioning to `run-score-strip` and a two-column `run-goal-form`; `game page renders editable game metadata view`; mobile Playwright smoke at `e1ebd40` exercises the scorekeeper flow on `chromium-mobile` | PASS |
| Existing API and review-gate regressions stay green. | `npm run build -w @3fc/contracts`; `npm test -w @3fc/contracts`; `npm test -w @3fc/api`; `npm run typecheck --workspaces`; `npm run test:review-gate`; `git diff --check` on branch `codex/m2-09-mobile-game-flow` at `e1ebd40` | PASS |

## Scope boundaries

Included: game-page mode navigation, scoring-first Run layout, sticky score visibility, compact score/concede team selectors, live fourth-button state/clock shortcut, local timestamp presentation, football-style goal time presentation, mode-aware finalisation summary placement, final per-team/aggregate goal summaries, mode auto-advance, manual-mode bootstrap preservation, mobile overflow constraints, JSDOM coverage, and mobile Playwright smoke coverage.

Excluded: API contract changes, scoring-rule changes, roster ownership changes, authentication/authorization changes, infrastructure changes, durable state migrations, and 3FC rules-policy refinements beyond preserving the existing scoring controls and result semantics.

## Change classification

- Declared risk: `high`
- [ ] `documentation-only` - Documentation only
- [ ] `tests-only` - Tests only
- [x] `application-behaviour` - Application or API behaviour
- [ ] `backlog-maintenance` - Canonical backlog maintenance
- [ ] `dependency-tooling` - Dependency or tooling
- [ ] `public-contract` - Public API or repository contract
- [ ] `data-migration` - Database schema or data migration
- [ ] `permission-trust-boundary` - Permission or trust boundary
- [ ] `durable-state-ownership` - Durable state or ownership
- [ ] `destructive-behaviour` - Destructive or difficult-to-reverse behaviour
- [ ] `new-production-dependency` - New production dependency
- [ ] `authentication-authorisation` - Authentication or authorisation
- [ ] `privacy-regulated-data` - Privacy or regulated data
- [ ] `infrastructure-production-configuration` - Infrastructure or deployment control
- [ ] `review-policy` - Review policy, packet, or workflow

## Architecture and invariants

- [ ] `architecture:none`
- [x] `architecture:documented`
- [ ] `architecture:judgement-required`

### Affected invariants

| Invariant | How this PR affects it | Why it remains valid | Evidence |
| --- | --- | --- | --- |
| INV-005 | Moves live scoring controls into a scoring-first Run mode panel, renders football-style goal times in live/final logs, and moves final result/stat displays into a Final mode panel. | The underlying goal payloads, tally semantics, own-goal handling, correction paths, and API writes are unchanged; the UI only changes how controls, clocks, and summaries are presented. | `npm test -w @3fc/app`; `npm test -w @3fc/api`; mobile Playwright smoke |
| INV-008 | Adds mode switching around scorer and assist controls, renders assist aggregates after finalisation, and adds live-state navigation around those controls. | Mode changes hide and show the existing controls without recreating or clearing selected scorer/assist state, and existing API validation remains responsible for assist limits and scorer exclusion. | `game page mode panels switch without resetting a goal draft`; `game page renders final team logs and aggregate player stats`; `npm test -w @3fc/api`; mobile Playwright smoke |

### Architecture or decision record

No ADR is required. This remains a frontend workflow/layout change that keeps the existing app/API boundary, durable state model, scoring contracts, and deployment ownership intact. The mode structure follows the UX review recommendation to group the scorekeeper workflow into Structure, Players, Run, and Final panels while preserving existing DOM controls and state owners.

## Failure and rollback

### Failure behaviour

If mode switching or live-state shortcut handling fails, the user-visible failure is navigation between panels not reflecting the selected workflow control, the shortcut focusing the wrong timer/finalisation control, or scorekeeper controls not being visible at the expected stage. If formatting fails, the API data remains intact but the app may show raw UTC timestamps or non-football goal minute labels. Existing API failures for score/timer mutations still surface through the current UI error handling.

### Rollback approach

Revert the merge commit for this PR and redeploy the previous app build; no database, API, permission, or infrastructure rollback is required.

### Rollback evidence

The change is limited to app UI rendering, app UI state management, CSS, and tests. `npm run build -w @3fc/contracts`, `npm test -w @3fc/contracts`, `npm test -w @3fc/app`, `npm test -w @3fc/api`, `npm run typecheck --workspaces`, `npm run test:review-gate`, `git diff --check`, and the targeted mobile Playwright smoke passed on branch `codex/m2-09-mobile-game-flow` at `e1ebd40`.

## Automated and agent review disposition

### Unresolved blocking findings

None.

### Rejected findings and evidence

None. Resolved review thread `PRRT_kwDORVMqbs6VjwUF` by selecting Final mode before the generic started-timer rule when all thirds are complete, with `game page resumes completed live timers in finalisation mode` proving the Finish game action is visible after reload.

Addressed review thread `PRRT_kwDORVMqbs6Vjzww` by deriving the post-save mode from the reloaded timer state, with `game page preserves run mode after live game metadata save` proving a running match returns to Run after metadata save.

The updated mobile smoke exposed and verified a related bootstrap race: manual mode selections are now preserved if the scorekeeper chooses a mode while initial goal/roster loading is still settling. QA follow-up feedback on time notation, sticky scoring visibility, compact team selectors, live fourth-control state, and local timestamp rendering was addressed in `80f5a7c`.

Addressed review thread `PRRT_kwDORVMqbs6VlwIJ` by including third context in the full match log rows, with `game page renders final team logs and aggregate player stats` proving the full log displays `Third 2`.

Addressed review thread `PRRT_kwDORVMqbs6VlwIK` by moving the score strip to a sticky Run-console child and splitting the growing Latest goals history after the timer controls, with `game page renders editable game metadata view` proving timer controls appear before latest goals in DOM order and the mobile Playwright smoke proving the scorekeeper flow remains usable.

Addressed review thread `PRRT_kwDORVMqbs6VmDDs` by tracking whether the goal timeline has loaded separately from whether it is empty, keeping authoritative final result totals visible while marking team logs, scorer/assist aggregates, and the full match log unavailable when `GET /v1/games/{id}/goals` fails. `game page remains usable when goal timeline load fails` covers a finished game with nonzero result totals and verifies the UI does not render false “No goals recorded” or “No scorers recorded” summaries.

Addressed review thread `PRRT_kwDORVMqbs6VmDDt` by only marking the fourth game-state control as a manual selection when the action can be resolved against loaded game state. `game page retries early game-state tab selection after initial game loading` covers the slow initial game request race and verifies the page still lands in Run for an already-running game.

Addressed review thread `PRRT_kwDORVMqbs6VmHdL` by rendering the live game-state shortcut as an ordinary pressed-state button instead of a `role="tab"` with a static `aria-controls` target. `game page mode panels advance from setup to run and finalisation` now verifies the shortcut has no tab role or static panel target while still focusing the correct Run/Final controls.

Addressed review thread `PRRT_kwDORVMqbs6VmLkD` by marking the goal timeline as unavailable whenever a refresh fails, not only on initial load. `game page invalidates current goals when correction replay refresh fails` verifies stale goal rows disappear and save/undo goal controls are disabled after a failed post-correction refresh.

## Human judgement

- [ ] `human-judgement:none`
- [x] `human-judgement:required`

### Decision requiring judgement

Final QA acceptance that the sticky score strip, compact selectors, and live fourth-button clock/action feel right on the target mobile viewport.

### Options considered

Accept the implemented mobile layout and live-state shortcut as ready for merge, or request narrower visual/interaction adjustments after QA review.

### Reason selected

Automated tests prove the state transitions, local-time rendering, goal notation, and API-backed scorekeeper flow. The final judgement is visual and ergonomic, especially for sticky positioning and selector density on real phone screens.

### Reversal cost

Low. This is app-only CSS/JS and test coverage; reverting the PR restores the previous workflow without data, API, permission, or infrastructure rollback.

## Review focus

Please inspect the scoring-first Run panel structure in `app/src/ui/layout.ts`, the mode-selection/state preservation and time formatting in `app/src/ui/setup-flow.js`, the final statistics rendering in `app/src/ui/setup-flow.js`, the mobile layout constraints in `app/src/ui/styles.css`, and the updated Playwright path that verifies the scorekeeper can assign players, score goals, finish the game, see final scoring/assist summaries, and make finished-game corrections.
