### PR TITLE
[codex] Add claimed player scorer delegation

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -190,6 +190,36 @@ jobs:
 
           jq -e '.error == "unauthorized"' /tmp/prod-core.json >/dev/null
 
+          CLAIM_ENDPOINT="https://${API_ID}.execute-api.ap-southeast-2.amazonaws.com/v1/players/smoke-player/claim"
+          CLAIM_HTTP_CODE="$(curl -sS -o /tmp/prod-claim.json -w '%{http_code}' \
+            -X POST "$CLAIM_ENDPOINT" \
+            -H 'content-type: application/json' \
+            -H 'origin: https://app.3fc.football' \
+            -d '{}')"
+
+          if [ "$CLAIM_HTTP_CODE" != "401" ]; then
+            echo "Smoke test failed for ${CLAIM_ENDPOINT} (HTTP ${CLAIM_HTTP_CODE})"
+            cat /tmp/prod-claim.json
+            exit 1
+          fi
+
+          jq -e '.error == "unauthorized"' /tmp/prod-claim.json >/dev/null
+
+          ACCESS_ENDPOINT="https://${API_ID}.execute-api.ap-southeast-2.amazonaws.com/v1/leagues/smoke-league/access"
+          ACCESS_HTTP_CODE="$(curl -sS -o /tmp/prod-access.json -w '%{http_code}' \
+            -X POST "$ACCESS_ENDPOINT" \
+            -H 'content-type: application/json' \
+            -H 'origin: https://app.3fc.football' \
+            -d '{"userId":"scorekeeper@3fc.football","role":"scorekeeper"}')"
+
+          if [ "$ACCESS_HTTP_CODE" != "401" ]; then
+            echo "Smoke test failed for ${ACCESS_ENDPOINT} (HTTP ${ACCESS_HTTP_CODE})"
+            cat /tmp/prod-access.json
+            exit 1
+          fi
+
+          jq -e '.error == "unauthorized"' /tmp/prod-access.json >/dev/null
+
           MAGIC_ENDPOINT="https://${API_ID}.execute-api.ap-southeast-2.amazonaws.com/v1/auth/magic/start"
           MAGIC_HTTP_CODE="$(curl -sS -o /tmp/prod-magic.json -w '%{http_code}' \
             -X POST "$MAGIC_ENDPOINT" \
@@ -206,6 +236,10 @@ jobs:
           {
             echo "SMOKE_CORE_ENDPOINT=${CORE_ENDPOINT}"
             echo "SMOKE_CORE_HTTP_CODE=${CORE_HTTP_CODE}"
+            echo "SMOKE_CLAIM_ENDPOINT=${CLAIM_ENDPOINT}"
+            echo "SMOKE_CLAIM_HTTP_CODE=${CLAIM_HTTP_CODE}"
+            echo "SMOKE_ACCESS_ENDPOINT=${ACCESS_ENDPOINT}"
+            echo "SMOKE_ACCESS_HTTP_CODE=${ACCESS_HTTP_CODE}"
             echo "SMOKE_MAGIC_ENDPOINT=${MAGIC_ENDPOINT}"
             echo "SMOKE_MAGIC_HTTP_CODE=${MAGIC_HTTP_CODE}"
           } >> "$GITHUB_ENV"
@@ -227,6 +261,10 @@ jobs:
             echo "- Smoke status: HTTP ${SMOKE_HTTP_CODE}"
             echo "- Core smoke endpoint: ${SMOKE_CORE_ENDPOINT}"
             echo "- Core smoke status: HTTP ${SMOKE_CORE_HTTP_CODE}"
+            echo "- Claim route smoke endpoint: ${SMOKE_CLAIM_ENDPOINT}"
+            echo "- Claim route smoke status: HTTP ${SMOKE_CLAIM_HTTP_CODE}"
+            echo "- Access route smoke endpoint: ${SMOKE_ACCESS_ENDPOINT}"
+            echo "- Access route smoke status: HTTP ${SMOKE_ACCESS_HTTP_CODE}"
             echo "- Magic-link smoke endpoint: ${SMOKE_MAGIC_ENDPOINT}"
             echo "- Magic-link smoke status: HTTP ${SMOKE_MAGIC_HTTP_CODE}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -113,6 +113,8 @@ jobs:
           ROOT_HTTP_CODE="$(curl -sS -o /tmp/prod-site-root.html -w '%{http_code}' "${SITE_URL}/")"
           SIGNIN_HTTP_CODE="$(curl -sS -o /tmp/prod-site-signin.html -w '%{http_code}' "${SITE_URL}/sign-in")"
           SETUP_HTTP_CODE="$(curl -sS -o /tmp/prod-site-setup.html -w '%{http_code}' "${SITE_URL}/setup")"
+          JOIN_HTTP_CODE="$(curl -sS -o /tmp/prod-site-join.html -w '%{http_code}' "${SITE_URL}/join")"
+          JOIN_LINK_HTTP_CODE="$(curl -sS -o /tmp/prod-site-join-link.html -w '%{http_code}' "${SITE_URL}/join?code=ABCDEFGH")"
 
           if [ "$ROOT_HTTP_CODE" != "200" ]; then
             echo "Smoke test failed for ${SITE_URL}/ (HTTP ${ROOT_HTTP_CODE})"
@@ -132,15 +134,31 @@ jobs:
             exit 1
           fi
 
+          if [ "$JOIN_HTTP_CODE" != "200" ]; then
+            echo "Smoke test failed for ${SITE_URL}/join (HTTP ${JOIN_HTTP_CODE})"
+            cat /tmp/prod-site-join.html
+            exit 1
+          fi
+
+          if [ "$JOIN_LINK_HTTP_CODE" != "200" ]; then
+            echo "Smoke test failed for ${SITE_URL}/join?code=ABCDEFGH (HTTP ${JOIN_LINK_HTTP_CODE})"
+            cat /tmp/prod-site-join-link.html
+            exit 1
+          fi
+
           grep -q "Dashboard" /tmp/prod-site-root.html
           grep -q "Sign in before setup" /tmp/prod-site-signin.html
           grep -q "Dashboard" /tmp/prod-site-setup.html
+          grep -q "Join game" /tmp/prod-site-join.html
+          grep -q "Join game" /tmp/prod-site-join-link.html
 
           {
             echo "SITE_URL=${SITE_URL}"
             echo "SITE_ROOT_HTTP_CODE=${ROOT_HTTP_CODE}"
             echo "SITE_SIGNIN_HTTP_CODE=${SIGNIN_HTTP_CODE}"
             echo "SITE_SETUP_HTTP_CODE=${SETUP_HTTP_CODE}"
+            echo "SITE_JOIN_HTTP_CODE=${JOIN_HTTP_CODE}"
+            echo "SITE_JOIN_LINK_HTTP_CODE=${JOIN_LINK_HTTP_CODE}"
           } >> "$GITHUB_ENV"
 
       - name: Smoke test deployed production core endpoints
@@ -203,6 +221,8 @@ jobs:
             echo "- Site root status: HTTP ${SITE_ROOT_HTTP_CODE}"
             echo "- Site sign-in status: HTTP ${SITE_SIGNIN_HTTP_CODE}"
             echo "- Site setup status: HTTP ${SITE_SETUP_HTTP_CODE}"
+            echo "- Site join status: HTTP ${SITE_JOIN_HTTP_CODE}"
+            echo "- Site join link status: HTTP ${SITE_JOIN_LINK_HTTP_CODE}"
             echo "- Smoke endpoint: ${SMOKE_ENDPOINT}"
             echo "- Smoke status: HTTP ${SMOKE_HTTP_CODE}"
             echo "- Core smoke endpoint: ${SMOKE_CORE_ENDPOINT}"

--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -191,6 +191,36 @@ jobs:
 
           jq -e '.error == "unauthorized"' /tmp/qa-core.json >/dev/null
 
+          CLAIM_ENDPOINT="https://${API_ID}.execute-api.ap-southeast-2.amazonaws.com/v1/players/smoke-player/claim"
+          CLAIM_HTTP_CODE="$(curl -sS -o /tmp/qa-claim.json -w '%{http_code}' \
+            -X POST "$CLAIM_ENDPOINT" \
+            -H 'content-type: application/json' \
+            -H 'origin: https://qa.3fc.football' \
+            -d '{}')"
+
+          if [ "$CLAIM_HTTP_CODE" != "401" ]; then
+            echo "Smoke test failed for ${CLAIM_ENDPOINT} (HTTP ${CLAIM_HTTP_CODE})"
+            cat /tmp/qa-claim.json
+            exit 1
+          fi
+
+          jq -e '.error == "unauthorized"' /tmp/qa-claim.json >/dev/null
+
+          ACCESS_ENDPOINT="https://${API_ID}.execute-api.ap-southeast-2.amazonaws.com/v1/leagues/smoke-league/access"
+          ACCESS_HTTP_CODE="$(curl -sS -o /tmp/qa-access.json -w '%{http_code}' \
+            -X POST "$ACCESS_ENDPOINT" \
+            -H 'content-type: application/json' \
+            -H 'origin: https://qa.3fc.football' \
+            -d '{"userId":"scorekeeper@3fc.football","role":"scorekeeper"}')"
+
+          if [ "$ACCESS_HTTP_CODE" != "401" ]; then
+            echo "Smoke test failed for ${ACCESS_ENDPOINT} (HTTP ${ACCESS_HTTP_CODE})"
+            cat /tmp/qa-access.json
+            exit 1
+          fi
+
+          jq -e '.error == "unauthorized"' /tmp/qa-access.json >/dev/null
+
           MAGIC_ENDPOINT="https://${API_ID}.execute-api.ap-southeast-2.amazonaws.com/v1/auth/magic/start"
           MAGIC_HTTP_CODE="$(curl -sS -o /tmp/qa-magic.json -w '%{http_code}' \
             -X POST "$MAGIC_ENDPOINT" \
@@ -207,6 +237,10 @@ jobs:
           {
             echo "SMOKE_CORE_ENDPOINT=${CORE_ENDPOINT}"
             echo "SMOKE_CORE_HTTP_CODE=${CORE_HTTP_CODE}"
+            echo "SMOKE_CLAIM_ENDPOINT=${CLAIM_ENDPOINT}"
+            echo "SMOKE_CLAIM_HTTP_CODE=${CLAIM_HTTP_CODE}"
+            echo "SMOKE_ACCESS_ENDPOINT=${ACCESS_ENDPOINT}"
+            echo "SMOKE_ACCESS_HTTP_CODE=${ACCESS_HTTP_CODE}"
             echo "SMOKE_MAGIC_ENDPOINT=${MAGIC_ENDPOINT}"
             echo "SMOKE_MAGIC_HTTP_CODE=${MAGIC_HTTP_CODE}"
           } >> "$GITHUB_ENV"
@@ -228,6 +262,10 @@ jobs:
             echo "- Smoke status: HTTP ${SMOKE_HTTP_CODE}"
             echo "- Core smoke endpoint: ${SMOKE_CORE_ENDPOINT}"
             echo "- Core smoke status: HTTP ${SMOKE_CORE_HTTP_CODE}"
+            echo "- Claim route smoke endpoint: ${SMOKE_CLAIM_ENDPOINT}"
+            echo "- Claim route smoke status: HTTP ${SMOKE_CLAIM_HTTP_CODE}"
+            echo "- Access route smoke endpoint: ${SMOKE_ACCESS_ENDPOINT}"
+            echo "- Access route smoke status: HTTP ${SMOKE_ACCESS_HTTP_CODE}"
             echo "- Magic-link smoke endpoint: ${SMOKE_MAGIC_ENDPOINT}"
             echo "- Magic-link smoke status: HTTP ${SMOKE_MAGIC_HTTP_CODE}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -114,6 +114,8 @@ jobs:
           ROOT_HTTP_CODE="$(curl -sS -o /tmp/qa-site-root.html -w '%{http_code}' "${SITE_URL}/")"
           SIGNIN_HTTP_CODE="$(curl -sS -o /tmp/qa-site-signin.html -w '%{http_code}' "${SITE_URL}/sign-in")"
           SETUP_HTTP_CODE="$(curl -sS -o /tmp/qa-site-setup.html -w '%{http_code}' "${SITE_URL}/setup")"
+          JOIN_HTTP_CODE="$(curl -sS -o /tmp/qa-site-join.html -w '%{http_code}' "${SITE_URL}/join")"
+          JOIN_DEEP_HTTP_CODE="$(curl -sS -o /tmp/qa-site-join-deep.html -w '%{http_code}' "${SITE_URL}/join/ABCDEFGH")"
 
           if [ "$ROOT_HTTP_CODE" != "200" ]; then
             echo "Smoke test failed for ${SITE_URL}/ (HTTP ${ROOT_HTTP_CODE})"
@@ -133,15 +135,31 @@ jobs:
             exit 1
           fi
 
+          if [ "$JOIN_HTTP_CODE" != "200" ]; then
+            echo "Smoke test failed for ${SITE_URL}/join (HTTP ${JOIN_HTTP_CODE})"
+            cat /tmp/qa-site-join.html
+            exit 1
+          fi
+
+          if [ "$JOIN_DEEP_HTTP_CODE" != "200" ]; then
+            echo "Smoke test failed for ${SITE_URL}/join/ABCDEFGH (HTTP ${JOIN_DEEP_HTTP_CODE})"
+            cat /tmp/qa-site-join-deep.html
+            exit 1
+          fi
+
           grep -q "Dashboard" /tmp/qa-site-root.html
           grep -q "Sign in before setup" /tmp/qa-site-signin.html
           grep -q "Dashboard" /tmp/qa-site-setup.html
+          grep -q "Join game" /tmp/qa-site-join.html
+          grep -q "Join game" /tmp/qa-site-join-deep.html
 
           {
             echo "SITE_URL=${SITE_URL}"
             echo "SITE_ROOT_HTTP_CODE=${ROOT_HTTP_CODE}"
             echo "SITE_SIGNIN_HTTP_CODE=${SIGNIN_HTTP_CODE}"
             echo "SITE_SETUP_HTTP_CODE=${SETUP_HTTP_CODE}"
+            echo "SITE_JOIN_HTTP_CODE=${JOIN_HTTP_CODE}"
+            echo "SITE_JOIN_DEEP_HTTP_CODE=${JOIN_DEEP_HTTP_CODE}"
           } >> "$GITHUB_ENV"
 
       - name: Smoke test deployed QA core endpoints
@@ -204,6 +222,8 @@ jobs:
             echo "- Site root status: HTTP ${SITE_ROOT_HTTP_CODE}"
             echo "- Site sign-in status: HTTP ${SITE_SIGNIN_HTTP_CODE}"
             echo "- Site setup status: HTTP ${SITE_SETUP_HTTP_CODE}"
+            echo "- Site join status: HTTP ${SITE_JOIN_HTTP_CODE}"
+            echo "- Site join deep-link status: HTTP ${SITE_JOIN_DEEP_HTTP_CODE}"
             echo "- Smoke endpoint: ${SMOKE_ENDPOINT}"
             echo "- Smoke status: HTTP ${SMOKE_HTTP_CODE}"
             echo "- Core smoke endpoint: ${SMOKE_CORE_ENDPOINT}"

--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -115,7 +115,7 @@ jobs:
           SIGNIN_HTTP_CODE="$(curl -sS -o /tmp/qa-site-signin.html -w '%{http_code}' "${SITE_URL}/sign-in")"
           SETUP_HTTP_CODE="$(curl -sS -o /tmp/qa-site-setup.html -w '%{http_code}' "${SITE_URL}/setup")"
           JOIN_HTTP_CODE="$(curl -sS -o /tmp/qa-site-join.html -w '%{http_code}' "${SITE_URL}/join")"
-          JOIN_DEEP_HTTP_CODE="$(curl -sS -o /tmp/qa-site-join-deep.html -w '%{http_code}' "${SITE_URL}/join/ABCDEFGH")"
+          JOIN_LINK_HTTP_CODE="$(curl -sS -o /tmp/qa-site-join-link.html -w '%{http_code}' "${SITE_URL}/join?code=ABCDEFGH")"
 
           if [ "$ROOT_HTTP_CODE" != "200" ]; then
             echo "Smoke test failed for ${SITE_URL}/ (HTTP ${ROOT_HTTP_CODE})"
@@ -141,9 +141,9 @@ jobs:
             exit 1
           fi
 
-          if [ "$JOIN_DEEP_HTTP_CODE" != "200" ]; then
-            echo "Smoke test failed for ${SITE_URL}/join/ABCDEFGH (HTTP ${JOIN_DEEP_HTTP_CODE})"
-            cat /tmp/qa-site-join-deep.html
+          if [ "$JOIN_LINK_HTTP_CODE" != "200" ]; then
+            echo "Smoke test failed for ${SITE_URL}/join?code=ABCDEFGH (HTTP ${JOIN_LINK_HTTP_CODE})"
+            cat /tmp/qa-site-join-link.html
             exit 1
           fi
 
@@ -151,7 +151,7 @@ jobs:
           grep -q "Sign in before setup" /tmp/qa-site-signin.html
           grep -q "Dashboard" /tmp/qa-site-setup.html
           grep -q "Join game" /tmp/qa-site-join.html
-          grep -q "Join game" /tmp/qa-site-join-deep.html
+          grep -q "Join game" /tmp/qa-site-join-link.html
 
           {
             echo "SITE_URL=${SITE_URL}"
@@ -159,7 +159,7 @@ jobs:
             echo "SITE_SIGNIN_HTTP_CODE=${SIGNIN_HTTP_CODE}"
             echo "SITE_SETUP_HTTP_CODE=${SETUP_HTTP_CODE}"
             echo "SITE_JOIN_HTTP_CODE=${JOIN_HTTP_CODE}"
-            echo "SITE_JOIN_DEEP_HTTP_CODE=${JOIN_DEEP_HTTP_CODE}"
+            echo "SITE_JOIN_LINK_HTTP_CODE=${JOIN_LINK_HTTP_CODE}"
           } >> "$GITHUB_ENV"
 
       - name: Smoke test deployed QA core endpoints
@@ -223,7 +223,7 @@ jobs:
             echo "- Site sign-in status: HTTP ${SITE_SIGNIN_HTTP_CODE}"
             echo "- Site setup status: HTTP ${SITE_SETUP_HTTP_CODE}"
             echo "- Site join status: HTTP ${SITE_JOIN_HTTP_CODE}"
-            echo "- Site join deep-link status: HTTP ${SITE_JOIN_DEEP_HTTP_CODE}"
+            echo "- Site join link status: HTTP ${SITE_JOIN_LINK_HTTP_CODE}"
             echo "- Smoke endpoint: ${SMOKE_ENDPOINT}"
             echo "- Smoke status: HTTP ${SMOKE_HTTP_CODE}"
             echo "- Core smoke endpoint: ${SMOKE_CORE_ENDPOINT}"

--- a/api/src/auth/acl.ts
+++ b/api/src/auth/acl.ts
@@ -254,22 +254,37 @@ function missingScope(scopeType: "game" | "season" | "session", scopeId: string)
 }
 
 async function verifyLeagueAdmin(
-  userId: string,
+  userIds: string | readonly string[],
   leagueId: string,
   aclLookup: AclLookup,
 ): Promise<boolean> {
-  const access = await aclLookup.getLeagueAccess(leagueId, userId);
-  return access?.role === "admin";
+  for (const userId of normalizeUserIds(userIds)) {
+    const access = await aclLookup.getLeagueAccess(leagueId, userId);
+    if (access?.role === "admin") {
+      return true;
+    }
+  }
+  return false;
 }
 
 async function verifyLeagueRole(
-  userId: string,
+  userIds: string | readonly string[],
   leagueId: string,
   aclLookup: AclLookup,
   allowedRoles: ReadonlySet<LeagueAclRecord["role"]>,
 ): Promise<boolean> {
-  const access = await aclLookup.getLeagueAccess(leagueId, userId);
-  return access ? allowedRoles.has(access.role) : false;
+  for (const userId of normalizeUserIds(userIds)) {
+    const access = await aclLookup.getLeagueAccess(leagueId, userId);
+    if (access && allowedRoles.has(access.role)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function normalizeUserIds(userIds: string | readonly string[]): string[] {
+  const values = Array.isArray(userIds) ? userIds : [userIds];
+  return values.filter((value, index) => value.trim().length > 0 && values.indexOf(value) === index);
 }
 
 async function resolveGameScope(
@@ -301,7 +316,7 @@ async function resolveGameScope(
 export async function authorizeProtectedMutation(
   method: string,
   route: string,
-  userId: string,
+  userId: string | readonly string[],
   aclLookup: AclLookup,
 ): Promise<AclAuthorizationResult> {
   const resolvedRoute = resolveProtectedMutationRoute(method, route);

--- a/api/src/auth/acl.ts
+++ b/api/src/auth/acl.ts
@@ -16,6 +16,8 @@ const ROUTES = {
   updateGoal: /^\/v1\/games\/([^/]+)\/goals\/([^/]+)$/,
   deleteGoal: /^\/v1\/games\/([^/]+)\/goals\/([^/]+)$/,
   undoLastGoal: /^\/v1\/games\/([^/]+)\/goals\/undo-last$/,
+  claimPlayer: /^\/v1\/players\/([^/]+)\/claim$/,
+  grantLeagueAccess: /^\/v1\/leagues\/([^/]+)\/access$/,
 } as const;
 
 export type ProtectedMutationOperation =
@@ -33,7 +35,9 @@ export type ProtectedMutationOperation =
   | "createGoal"
   | "updateGoal"
   | "deleteGoal"
-  | "undoLastGoal";
+  | "undoLastGoal"
+  | "claimPlayer"
+  | "grantLeagueAccess";
 
 export interface ProtectedMutationRoute {
   operation: ProtectedMutationOperation;
@@ -189,6 +193,21 @@ export function resolveProtectedMutationRoute(
     };
   }
 
+  const claimPlayerMatch = upperMethod === "POST" ? route.match(ROUTES.claimPlayer) : null;
+  if (claimPlayerMatch) {
+    return {
+      operation: "claimPlayer",
+    };
+  }
+
+  const grantLeagueAccessMatch = upperMethod === "POST" ? route.match(ROUTES.grantLeagueAccess) : null;
+  if (grantLeagueAccessMatch) {
+    return {
+      operation: "grantLeagueAccess",
+      leagueId: decodeRouteParam(grantLeagueAccessMatch[1]),
+    };
+  }
+
   return null;
 }
 
@@ -306,7 +325,34 @@ export async function authorizeProtectedMutation(
     };
   }
 
+  if (resolvedRoute.operation === "claimPlayer") {
+    return {
+      allowed: true,
+      statusCode: 200,
+      operation: resolvedRoute.operation,
+      scope: null,
+      error: null,
+    };
+  }
+
   if (resolvedRoute.operation === "createSeason") {
+    const leagueId = resolvedRoute.leagueId as string;
+    const isAdmin = await verifyLeagueAdmin(userId, leagueId, aclLookup);
+
+    if (!isAdmin) {
+      return forbiddenAdminRequired(leagueId);
+    }
+
+    return {
+      allowed: true,
+      statusCode: 200,
+      operation: resolvedRoute.operation,
+      scope: { leagueId },
+      error: null,
+    };
+  }
+
+  if (resolvedRoute.operation === "grantLeagueAccess") {
     const leagueId = resolvedRoute.leagueId as string;
     const isAdmin = await verifyLeagueAdmin(userId, leagueId, aclLookup);
 

--- a/api/src/auth/magic-link.ts
+++ b/api/src/auth/magic-link.ts
@@ -55,6 +55,7 @@ export interface MagicLinkStartResult {
 export interface MagicLinkCompleteResult {
   sessionId: string;
   email: string;
+  subject: string;
   createdAt: string;
   expiresAt: string;
   maxAgeSeconds: number;
@@ -63,6 +64,7 @@ export interface MagicLinkCompleteResult {
 export interface AuthSessionRecord {
   sessionId: string;
   email: string;
+  subject?: string;
   createdAt: string;
   expiresAt: string;
 }
@@ -108,6 +110,12 @@ export function isMagicLinkEmailLike(value: string): boolean {
 
 function hashTokenSecret(secret: string): string {
   return createHash("sha256").update(secret, "utf8").digest("hex");
+}
+
+export function magicLinkSubjectForEmail(email: string): string {
+  const normalizedEmail = normalizeMagicLinkEmail(email);
+  const digest = createHash("sha256").update(normalizedEmail, "utf8").digest("base64url");
+  return `magic-link:${digest}`;
 }
 
 function tokenPk(tokenId: string): string {
@@ -298,6 +306,7 @@ export class MagicLinkService {
     }
 
     const email = readString(updatedToken.Attributes?.email, "email");
+    const subject = magicLinkSubjectForEmail(email);
     const sessionId = this.randomProvider.sessionId();
     const expiresAtEpoch = nowEpoch + this.options.sessionTtlSeconds;
     const expiresAtIso = new Date(expiresAtEpoch * 1000).toISOString();
@@ -311,6 +320,7 @@ export class MagicLinkService {
           sk: { S: METADATA_SK },
           entityType: { S: ENTITY_TYPE.session },
           email: { S: email },
+          subject: { S: subject },
           createdAt: { S: nowIso },
           updatedAt: { S: nowIso },
           expiresAtEpoch: { N: String(expiresAtEpoch) },
@@ -322,6 +332,7 @@ export class MagicLinkService {
     return {
       sessionId,
       email,
+      subject,
       createdAt: nowIso,
       expiresAt: expiresAtIso,
       maxAgeSeconds: this.options.sessionTtlSeconds,
@@ -360,9 +371,13 @@ export class MagicLinkService {
       return null;
     }
 
+    const email = readString(item.email, "email");
+    const subject = item.subject?.S ?? magicLinkSubjectForEmail(email);
+
     return {
       sessionId,
-      email: readString(item.email, "email"),
+      email,
+      subject,
       createdAt: readString(item.createdAt, "createdAt"),
       expiresAt: new Date(expiresAtEpoch * 1000).toISOString(),
     };

--- a/api/src/auth/session.ts
+++ b/api/src/auth/session.ts
@@ -135,6 +135,14 @@ export function isAuthenticatedApiRoute(method: string, route: string): boolean 
     return true;
   }
 
+  if (method === "POST" && /^\/v1\/players\/[^/]+\/claim$/.test(route)) {
+    return true;
+  }
+
+  if (method === "POST" && /^\/v1\/leagues\/[^/]+\/access$/.test(route)) {
+    return true;
+  }
+
   if (method === "GET" && route === "/v1/auth/session") {
     return true;
   }

--- a/api/src/contracts/core-write.ts
+++ b/api/src/contracts/core-write.ts
@@ -4,6 +4,7 @@ import { MAX_ASSISTS, TEAM_IDS, THIRD_LENGTH_MINUTES } from "@3fc/contracts";
 const nonEmptyTrimmedString = z.string().trim().min(1, "must be a non-empty string");
 const optionalNullableString = z.string().nullable().optional();
 const teamIdSchema = z.enum(TEAM_IDS);
+const delegatedLeagueRoleSchema = z.enum(["admin", "scorekeeper"]);
 const joinCodePathPattern = /^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{8}$/;
 export const PUBLIC_JOIN_NICKNAME_MAX_LENGTH = 80;
 const thirdLengthMinutesSchema = z.union([
@@ -72,6 +73,15 @@ export const joinGameRequestSchema = z
       PUBLIC_JOIN_NICKNAME_MAX_LENGTH,
       `must be ${PUBLIC_JOIN_NICKNAME_MAX_LENGTH} characters or fewer`,
     ),
+  })
+  .strict();
+
+export const claimPlayerRequestSchema = z.object({}).strict();
+
+export const grantLeagueAccessRequestSchema = z
+  .object({
+    userId: nonEmptyTrimmedString,
+    role: delegatedLeagueRoleSchema,
   })
   .strict();
 

--- a/api/src/data/keys.ts
+++ b/api/src/data/keys.ts
@@ -4,6 +4,7 @@ export const ENTITY_PK_PREFIX = {
   game: "GAME#",
   session: "SESSION#",
   player: "PLAYER#",
+  user: "USER#",
   joinCode: "JOIN_CODE#",
   idempotency: "IDEMPOTENCY#",
 } as const;
@@ -38,6 +39,14 @@ export function gamePk(gameId: string): string {
 
 export function playerPk(playerId: string): string {
   return `${ENTITY_PK_PREFIX.player}${playerId}`;
+}
+
+export function userPk(userId: string): string {
+  return `${ENTITY_PK_PREFIX.user}${userId}`;
+}
+
+export function playerClaimSk(playerId: string): string {
+  return `PLAYER#${playerId}`;
 }
 
 export function joinCodePk(joinCode: string): string {

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -53,6 +53,7 @@ import {
 } from "./keys.js";
 import type {
   AssignRosterInput,
+  ClaimPlayerInput,
   CreateAndLinkGamePlayerInput,
   CreateGameTeamInput,
   CreateGameInput,
@@ -218,6 +219,17 @@ export class GameJoinRegistrationError extends Error {
   }
 }
 
+export class PlayerClaimError extends Error {
+  constructor(
+    readonly code: "player_already_claimed" | "claim_state_changed",
+    readonly statusCode: 409,
+    message: string,
+  ) {
+    super(message);
+    this.name = "PlayerClaimError";
+  }
+}
+
 type GoalRuleErrorKind = "creation" | "correction";
 
 function goalRuleError(
@@ -234,6 +246,12 @@ function goalRuleError(
 function requireNonEmpty(name: string, value: string): void {
   if (value.trim().length === 0) {
     throw new Error(`${name} must be a non-empty string.`);
+  }
+}
+
+function requireLeagueRole(role: string): asserts role is LeagueAclRecord["role"] {
+  if (role !== "admin" && role !== "scorekeeper" && role !== "viewer") {
+    throw new Error("role must be admin, scorekeeper, or viewer.");
   }
 }
 
@@ -2292,6 +2310,91 @@ export class ThreeFcRepository {
     return withTimestamps(item.data as Omit<PlayerRecord, "createdAt" | "updatedAt">, item.createdAt, item.updatedAt);
   }
 
+  async claimPlayer(input: ClaimPlayerInput): Promise<PlayerRecord | null> {
+    requireNonEmpty("playerId", input.playerId);
+    requireNonEmpty("userId", input.userId);
+
+    const playerItem = await this.getEntity(playerPk(input.playerId), profileSk(), {
+      consistentRead: true,
+    });
+    if (!playerItem || playerItem.entityType !== ENTITY_TYPE.player) {
+      return null;
+    }
+
+    const player = withTimestamps(
+      playerItem.data as Omit<PlayerRecord, "createdAt" | "updatedAt">,
+      playerItem.createdAt,
+      playerItem.updatedAt,
+    );
+    if (player.claimedByUserId === input.userId) {
+      return player;
+    }
+    if (player.claimedByUserId !== null) {
+      throw new PlayerClaimError(
+        "player_already_claimed",
+        409,
+        `Player ${input.playerId} has already been claimed.`,
+      );
+    }
+
+    const now = this.clock.now();
+    const payload = {
+      playerId: player.playerId,
+      nickname: player.nickname,
+      claimedByUserId: input.userId,
+    };
+
+    try {
+      await this.client.send(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            {
+              Put: {
+                TableName: this.tableName,
+                Item: buildItemWithTimestamps(
+                  playerPk(input.playerId),
+                  profileSk(),
+                  ENTITY_TYPE.player,
+                  payload,
+                  player.createdAt,
+                  now,
+                ),
+                ConditionExpression: "#updatedAt = :expectedPlayerUpdatedAt AND #data = :expectedPlayerData",
+                ExpressionAttributeNames: {
+                  "#updatedAt": "updatedAt",
+                  "#data": "data",
+                },
+                ExpressionAttributeValues: {
+                  ":expectedPlayerUpdatedAt": { S: playerItem.updatedAt },
+                  ":expectedPlayerData": { S: playerItem.rawData },
+                },
+              },
+            },
+          ],
+        }),
+      );
+    } catch (error) {
+      if (isConditionalWriteFailure(error)) {
+        const latest = await this.getPlayer(input.playerId);
+        if (latest?.claimedByUserId === input.userId) {
+          return latest;
+        }
+
+        throw new PlayerClaimError(
+          latest?.claimedByUserId ? "player_already_claimed" : "claim_state_changed",
+          409,
+          latest?.claimedByUserId
+            ? `Player ${input.playerId} has already been claimed.`
+            : `Player ${input.playerId} changed before it could be claimed. Reload and try again.`,
+        );
+      }
+
+      throw error;
+    }
+
+    return withTimestamps(payload, player.createdAt, now);
+  }
+
   async listPlayers(input: ListPlayersInput = {}): Promise<PlayerRecord[]> {
     const rawSearch = input.search?.trim().toLowerCase() ?? "";
     const limit = Math.max(1, Math.min(input.limit ?? 20, 50));
@@ -2462,6 +2565,7 @@ export class ThreeFcRepository {
   async grantLeagueAccess(input: GrantLeagueAccessInput): Promise<LeagueAclRecord> {
     requireNonEmpty("leagueId", input.leagueId);
     requireNonEmpty("userId", input.userId);
+    requireLeagueRole(input.role);
     requireNonEmpty("grantedByUserId", input.grantedByUserId);
 
     const now = this.clock.now();

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -258,6 +258,23 @@ function requireLeagueRole(role: string): asserts role is LeagueAclRecord["role"
   }
 }
 
+function leagueRoleRank(role: LeagueAclRecord["role"]): number {
+  if (role === "admin") {
+    return 3;
+  }
+  if (role === "scorekeeper") {
+    return 2;
+  }
+  return 1;
+}
+
+function higherLeagueRole(
+  left: LeagueAclRecord["role"],
+  right: LeagueAclRecord["role"],
+): LeagueAclRecord["role"] {
+  return leagueRoleRank(left) >= leagueRoleRank(right) ? left : right;
+}
+
 function requireThirdNumber(third: number): asserts third is ThirdNumber {
   if (!THIRD_NUMBERS.includes(third as ThirdNumber)) {
     throw new Error("third must be 1, 2, or 3.");
@@ -2607,16 +2624,71 @@ export class ThreeFcRepository {
     requireLeagueRole(input.role);
     requireNonEmpty("grantedByUserId", input.grantedByUserId);
 
-    const now = this.clock.now();
-    const payload = {
-      leagueId: input.leagueId,
-      userId: input.userId,
-      role: input.role,
-      grantedByUserId: input.grantedByUserId,
-    };
+    const pk = leaguePk(input.leagueId);
+    const sk = aclSk(input.userId);
 
-    await this.putEntity(leaguePk(input.leagueId), aclSk(input.userId), ENTITY_TYPE.acl, payload, now);
-    return withTimestamps(payload, now, now);
+    for (;;) {
+      const existingItem = await this.getEntity(pk, sk, { consistentRead: true });
+      const existing =
+        existingItem?.entityType === ENTITY_TYPE.acl
+          ? withTimestamps(
+              existingItem.data as Omit<LeagueAclRecord, "createdAt" | "updatedAt">,
+              existingItem.createdAt,
+              existingItem.updatedAt,
+            )
+          : null;
+
+      const role = existing ? higherLeagueRole(existing.role, input.role) : input.role;
+      if (existing && role === existing.role) {
+        return existing;
+      }
+
+      const now = this.clock.now();
+      const payload = {
+        leagueId: input.leagueId,
+        userId: input.userId,
+        role,
+        grantedByUserId: input.grantedByUserId,
+      };
+
+      try {
+        await this.client.send(
+          new PutItemCommand({
+            TableName: this.tableName,
+            Item: buildItemWithTimestamps(
+              pk,
+              sk,
+              ENTITY_TYPE.acl,
+              payload,
+              existing?.createdAt ?? now,
+              now,
+            ),
+            ...(existingItem
+              ? {
+                  ConditionExpression: "#updatedAt = :expectedUpdatedAt AND #data = :expectedData",
+                  ExpressionAttributeNames: {
+                    "#updatedAt": "updatedAt",
+                    "#data": "data",
+                  },
+                  ExpressionAttributeValues: {
+                    ":expectedUpdatedAt": { S: existingItem.updatedAt },
+                    ":expectedData": { S: existingItem.rawData },
+                  },
+                }
+              : {
+                  ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
+                }),
+          }),
+        );
+        return withTimestamps(payload, existing?.createdAt ?? now, now);
+      } catch (error) {
+        if (isConditionalWriteFailure(error)) {
+          continue;
+        }
+
+        throw error;
+      }
+    }
   }
 
   async listLeagueAccess(leagueId: string): Promise<LeagueAclRecord[]> {

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -42,6 +42,7 @@ import {
   joinCodePk,
   leaguePk,
   metadataSk,
+  playerClaimSk,
   playerPk,
   profileSk,
   rosterSk,
@@ -50,6 +51,7 @@ import {
   sessionPk,
   sessionSk,
   teamSk,
+  userPk,
 } from "./keys.js";
 import type {
   AssignRosterInput,
@@ -110,6 +112,7 @@ const ENTITY_TYPE = {
   gameJoinCode: "gameJoinCode",
   sessionGame: "sessionGame",
   player: "player",
+  playerClaim: "playerClaim",
   acl: "acl",
   roster: "roster",
   goal: "goal",
@@ -2368,6 +2371,22 @@ export class ThreeFcRepository {
                   ":expectedPlayerUpdatedAt": { S: playerItem.updatedAt },
                   ":expectedPlayerData": { S: playerItem.rawData },
                 },
+              },
+            },
+            {
+              Put: {
+                TableName: this.tableName,
+                Item: buildItem(
+                  userPk(input.userId),
+                  playerClaimSk(input.playerId),
+                  ENTITY_TYPE.playerClaim,
+                  {
+                    userId: input.userId,
+                    playerId: input.playerId,
+                  },
+                  now,
+                ),
+                ConditionExpression: "attribute_not_exists(pk)",
               },
             },
           ],

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -2503,11 +2503,28 @@ export class ThreeFcRepository {
       changedMessage: `Game ${input.gameId} changed before the player could be saved. Reload and try again.`,
     });
     const now = this.clock.now();
-    const playerPayload = {
-      playerId: input.playerId,
-      nickname: input.nickname,
-      claimedByUserId: input.claimedByUserId ?? null,
-    };
+    const existingPlayerItem = await this.getEntity(playerPk(input.playerId), profileSk(), {
+      consistentRead: true,
+    });
+    const existingPlayer =
+      existingPlayerItem?.entityType === ENTITY_TYPE.player
+        ? withTimestamps(
+            existingPlayerItem.data as Omit<PlayerRecord, "createdAt" | "updatedAt">,
+            existingPlayerItem.createdAt,
+            existingPlayerItem.updatedAt,
+          )
+        : null;
+    const playerPayload = existingPlayer
+      ? {
+          playerId: existingPlayer.playerId,
+          nickname: existingPlayer.nickname,
+          claimedByUserId: existingPlayer.claimedByUserId,
+        }
+      : {
+          playerId: input.playerId,
+          nickname: input.nickname,
+          claimedByUserId: input.claimedByUserId ?? null,
+        };
     const existingGamePlayer = await this.getEntity(
       gamePk(input.gameId),
       gamePlayerSk(input.playerId),
@@ -2519,37 +2536,36 @@ export class ThreeFcRepository {
     };
 
     try {
+      const transactionItems: TransactWriteItem[] = [
+        this.buildGameConditionCheck(input.gameId, gameItem),
+        {
+          Put: {
+            TableName: this.tableName,
+            Item: buildItemWithTimestamps(
+              gamePk(input.gameId),
+              gamePlayerSk(input.playerId),
+              ENTITY_TYPE.gamePlayer,
+              linkPayload,
+              existingGamePlayer?.createdAt ?? now,
+              now,
+            ),
+          },
+        },
+      ];
+
+      if (!existingPlayer) {
+        transactionItems.splice(1, 0, {
+          Put: {
+            TableName: this.tableName,
+            Item: buildItem(playerPk(input.playerId), profileSk(), ENTITY_TYPE.player, playerPayload, now),
+            ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
+          },
+        });
+      }
+
       await this.client.send(
         new TransactWriteItemsCommand({
-          TransactItems: [
-            this.buildGameConditionCheck(input.gameId, gameItem),
-            {
-              Put: {
-                TableName: this.tableName,
-                Item: buildItemWithTimestamps(
-                  playerPk(input.playerId),
-                  profileSk(),
-                  ENTITY_TYPE.player,
-                  playerPayload,
-                  now,
-                  now,
-                ),
-              },
-            },
-            {
-              Put: {
-                TableName: this.tableName,
-                Item: buildItemWithTimestamps(
-                  gamePk(input.gameId),
-                  gamePlayerSk(input.playerId),
-                  ENTITY_TYPE.gamePlayer,
-                  linkPayload,
-                  existingGamePlayer?.createdAt ?? now,
-                  now,
-                ),
-              },
-            },
-          ],
+          TransactItems: transactionItems,
         }),
       );
     } catch (error) {
@@ -2563,7 +2579,11 @@ export class ThreeFcRepository {
       throw error;
     }
 
-    return withTimestamps(playerPayload, now, now);
+    return withTimestamps(
+      playerPayload,
+      existingPlayer?.createdAt ?? now,
+      existingPlayer?.updatedAt ?? now,
+    );
   }
 
   async listGamePlayers(gameId: string): Promise<GamePlayerRecord[]> {

--- a/api/src/data/types.ts
+++ b/api/src/data/types.ts
@@ -297,6 +297,11 @@ export interface JoinGameByCodeResult {
   link: GamePlayerRecord;
 }
 
+export interface ClaimPlayerInput {
+  playerId: string;
+  userId: string;
+}
+
 export interface GrantLeagueAccessInput {
   leagueId: string;
   userId: string;

--- a/api/src/lambda-core.ts
+++ b/api/src/lambda-core.ts
@@ -107,6 +107,7 @@ interface RequestDetails {
 type AuthSessionRecord = {
   sessionId: string;
   email: string;
+  subject?: string;
   createdAt: string;
   expiresAt: string;
 };
@@ -124,10 +125,24 @@ interface MagicLinkServiceContract extends SessionLookup {
   complete(token: string): Promise<{
     sessionId: string;
     email: string;
+    subject?: string;
     createdAt: string;
     expiresAt: string;
     maxAgeSeconds: number;
   }>;
+}
+
+function sessionSubject(session: AuthSessionRecord): string {
+  return session.subject ?? session.email;
+}
+
+function normalizeUserIds(userIds: string | readonly string[]): string[] {
+  const values = Array.isArray(userIds) ? userIds : [userIds];
+  return values.filter((value, index) => value.trim().length > 0 && values.indexOf(value) === index);
+}
+
+function sessionUserIds(session: AuthSessionRecord): string[] {
+  return normalizeUserIds([sessionSubject(session), session.email]);
 }
 
 interface RepositoryGameRecord {
@@ -537,6 +552,22 @@ interface RepositoryContract {
   }): Promise<boolean>;
 }
 
+type LeagueListRecord = Awaited<ReturnType<RepositoryContract["listLeaguesForUser"]>>[number];
+
+async function listLeaguesForSession(
+  repository: Pick<RepositoryContract, "listLeaguesForUser">,
+  session: AuthSessionRecord,
+): Promise<LeagueListRecord[]> {
+  const leaguesById = new Map<string, LeagueListRecord>();
+  for (const userId of sessionUserIds(session)) {
+    const leagues = await repository.listLeaguesForUser(userId);
+    for (const league of leagues) {
+      leaguesById.set(league.leagueId, league);
+    }
+  }
+  return [...leaguesById.values()];
+}
+
 interface CoreHandlerDependencies {
   repository: RepositoryContract;
   magicLinkService: MagicLinkServiceContract;
@@ -759,33 +790,45 @@ function conflict(
 async function ensureLeagueAccess(
   repository: RepositoryContract,
   leagueId: string,
-  userId: string,
+  userIds: string | readonly string[],
 ): Promise<{ allowed: boolean; role: "admin" | "scorekeeper" | "viewer" | null }> {
-  const access = await repository.getLeagueAccess(leagueId, userId);
-  if (!access) {
-    return { allowed: false, role: null };
+  for (const userId of normalizeUserIds(userIds)) {
+    const access = await repository.getLeagueAccess(leagueId, userId);
+    if (access) {
+      return { allowed: true, role: access.role };
+    }
   }
 
-  return { allowed: true, role: access.role };
+  return { allowed: false, role: null };
 }
 
 async function ensureLeagueAdmin(
   repository: RepositoryContract,
   leagueId: string,
-  userId: string,
+  userIds: string | readonly string[],
 ): Promise<boolean> {
-  const access = await repository.getLeagueAccess(leagueId, userId);
-  return access?.role === "admin";
+  for (const userId of normalizeUserIds(userIds)) {
+    const access = await repository.getLeagueAccess(leagueId, userId);
+    if (access?.role === "admin") {
+      return true;
+    }
+  }
+  return false;
 }
 
 async function ensureLeagueRole(
   repository: RepositoryContract,
   leagueId: string,
-  userId: string,
+  userIds: string | readonly string[],
   allowedRoles: ReadonlySet<"admin" | "scorekeeper" | "viewer">,
 ): Promise<boolean> {
-  const access = await repository.getLeagueAccess(leagueId, userId);
-  return access ? allowedRoles.has(access.role) : false;
+  for (const userId of normalizeUserIds(userIds)) {
+    const access = await repository.getLeagueAccess(leagueId, userId);
+    if (access && allowedRoles.has(access.role)) {
+      return true;
+    }
+  }
+  return false;
 }
 
 function parseTeamId(value: string): TeamId | null {
@@ -2093,7 +2136,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
         const aclResult = await authorizeProtectedMutation(
           method,
           route,
-          session.email,
+          sessionUserIds(session),
           dependencies.repository,
         );
         if (!aclResult.allowed) {
@@ -2154,7 +2197,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
         }
 
         if (method === "GET" && route === "/v1/leagues") {
-          const leagues = await dependencies.repository.listLeaguesForUser(session.email);
+          const leagues = await listLeaguesForSession(dependencies.repository, session);
           status = 200;
           return createJsonResponse(
             status,
@@ -2168,7 +2211,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
         const getLeagueMatch = route.match(/^\/v1\/leagues\/([^/]+)$/);
         if (method === "GET" && getLeagueMatch) {
           const leagueId = decodeRouteParam(getLeagueMatch[1]);
-          const access = await ensureLeagueAccess(dependencies.repository, leagueId, session.email);
+          const access = await ensureLeagueAccess(dependencies.repository, leagueId, sessionUserIds(session));
           if (!access.allowed) {
             status = 403;
             return forbidden(
@@ -2294,7 +2337,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
         const listSeasonsMatch = route.match(/^\/v1\/leagues\/([^/]+)\/seasons$/);
         if (method === "GET" && listSeasonsMatch) {
           const leagueId = decodeRouteParam(listSeasonsMatch[1]);
-          const access = await ensureLeagueAccess(dependencies.repository, leagueId, session.email);
+          const access = await ensureLeagueAccess(dependencies.repository, leagueId, sessionUserIds(session));
           if (!access.allowed) {
             status = 403;
             return forbidden(
@@ -2319,7 +2362,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
         const deleteLeagueMatch = route.match(/^\/v1\/leagues\/([^/]+)$/);
         if (method === "DELETE" && deleteLeagueMatch) {
           const leagueId = decodeRouteParam(deleteLeagueMatch[1]);
-          const isAdmin = await ensureLeagueAdmin(dependencies.repository, leagueId, session.email);
+          const isAdmin = await ensureLeagueAdmin(dependencies.repository, leagueId, sessionUserIds(session));
           if (!isAdmin) {
             status = 403;
             return forbidden(
@@ -3705,7 +3748,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
           try {
             player = await dependencies.repository.claimPlayer({
               playerId,
-              userId: session.email,
+              userId: sessionSubject(session),
             });
           } catch (error) {
             if (error instanceof PlayerClaimError) {
@@ -3751,7 +3794,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
             return notFound(origin, dependencies.corsAllowedOrigins, `Game ${gameId} was not found.`);
           }
 
-          const access = await ensureLeagueAccess(dependencies.repository, game.leagueId, session.email);
+          const access = await ensureLeagueAccess(dependencies.repository, game.leagueId, sessionUserIds(session));
           if (!access.allowed || (access.role !== "admin" && access.role !== "scorekeeper")) {
             status = 403;
             return forbidden(
@@ -3975,7 +4018,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
             return finishedBlock;
           }
 
-          const isAdmin = await ensureLeagueAdmin(dependencies.repository, game.leagueId, session.email);
+          const isAdmin = await ensureLeagueAdmin(dependencies.repository, game.leagueId, sessionUserIds(session));
           let rawBody: Record<string, unknown>;
           try {
             rawBody = parseJsonBody(event);

--- a/api/src/lambda-core.ts
+++ b/api/src/lambda-core.ts
@@ -40,6 +40,7 @@ import {
   resolveSessionCookieSecureFlag,
 } from "./auth/session.js";
 import {
+  claimPlayerRequestSchema,
   createGameRequestSchema,
   createGoalRequestSchema,
   createLeagueRequestSchema,
@@ -47,6 +48,7 @@ import {
   createSessionRequestSchema,
   assignRosterPlayerRequestSchema,
   formatSchemaValidationError,
+  grantLeagueAccessRequestSchema,
   idempotencyKeyHeaderSchema,
   isJoinCodePathParamValid,
   joinGameRequestSchema,
@@ -64,6 +66,7 @@ import {
   GameTimerTransitionError,
   GoalCorrectionError,
   GoalCreationError,
+  PlayerClaimError,
   ThreeFcRepository,
 } from "./data/repository.js";
 import type { CreateGoalResult, DeleteGoalResult, GameStatus, UpdateGoalResult } from "./data/types.js";
@@ -352,6 +355,19 @@ interface RepositoryContract {
       }
     | null
   >;
+  claimPlayer(input: {
+    playerId: string;
+    userId: string;
+  }): Promise<
+    | {
+        playerId: string;
+        nickname: string;
+        claimedByUserId: string | null;
+        createdAt: string;
+        updatedAt: string;
+      }
+    | null
+  >;
   listPlayers(input?: {
     search?: string | null;
     limit?: number;
@@ -457,6 +473,19 @@ interface RepositoryContract {
       }
     | null
   >;
+  grantLeagueAccess(input: {
+    leagueId: string;
+    userId: string;
+    role: "admin" | "scorekeeper" | "viewer";
+    grantedByUserId: string;
+  }): Promise<{
+    leagueId: string;
+    userId: string;
+    role: "admin" | "scorekeeper" | "viewer";
+    grantedByUserId: string;
+    createdAt: string;
+    updatedAt: string;
+  }>;
   getSeason(
     seasonId: string,
   ): Promise<
@@ -1064,6 +1093,33 @@ function toPublicPlayer(player: {
     nickname: player.nickname,
     createdAt: player.createdAt,
     updatedAt: player.updatedAt,
+  };
+}
+
+async function toGamePlayerForLeagueRole(input: {
+  repository: RepositoryContract;
+  player: {
+    playerId: string;
+    nickname: string;
+    claimedByUserId: string | null;
+    createdAt: string;
+    updatedAt: string;
+  };
+  leagueId: string;
+  callerRole: "admin" | "scorekeeper" | "viewer" | null;
+}) {
+  const publicPlayer = toPublicPlayer(input.player);
+  if (input.callerRole !== "admin" || !input.player.claimedByUserId) {
+    return publicPlayer;
+  }
+
+  const access = await input.repository.getLeagueAccess(input.leagueId, input.player.claimedByUserId);
+  return {
+    ...publicPlayer,
+    access: {
+      userId: input.player.claimedByUserId,
+      role: access?.role ?? null,
+    },
   };
 }
 
@@ -2138,6 +2194,47 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
                 role: access.role,
               },
             },
+            buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
+          );
+        }
+
+        const grantLeagueAccessMatch = route.match(/^\/v1\/leagues\/([^/]+)\/access$/);
+        if (method === "POST" && grantLeagueAccessMatch) {
+          const leagueId = decodeRouteParam(grantLeagueAccessMatch[1]);
+          const league = await dependencies.repository.getLeague(leagueId);
+          if (!league) {
+            status = 404;
+            return notFound(origin, dependencies.corsAllowedOrigins, `League ${leagueId} was not found.`);
+          }
+
+          let rawBody: Record<string, unknown>;
+          try {
+            rawBody = parseJsonBody(event);
+          } catch {
+            status = 400;
+            return badRequest(origin, dependencies.corsAllowedOrigins, "Request body must be valid JSON.");
+          }
+
+          const parsedBody = grantLeagueAccessRequestSchema.safeParse(rawBody);
+          if (!parsedBody.success) {
+            status = 400;
+            return badRequest(
+              origin,
+              dependencies.corsAllowedOrigins,
+              formatSchemaValidationError(parsedBody.error),
+            );
+          }
+
+          const accessGrant = await dependencies.repository.grantLeagueAccess({
+            leagueId,
+            userId: parsedBody.data.userId,
+            role: parsedBody.data.role,
+            grantedByUserId: session.email,
+          });
+          status = 200;
+          return createJsonResponse(
+            status,
+            accessGrant,
             buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
           );
         }
@@ -3583,6 +3680,68 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
           );
         }
 
+        const claimPlayerMatch = route.match(/^\/v1\/players\/([^/]+)\/claim$/);
+        if (method === "POST" && claimPlayerMatch) {
+          let rawBody: Record<string, unknown>;
+          try {
+            rawBody = parseJsonBody(event);
+          } catch {
+            status = 400;
+            return badRequest(origin, dependencies.corsAllowedOrigins, "Request body must be valid JSON.");
+          }
+
+          const parsedBody = claimPlayerRequestSchema.safeParse(rawBody);
+          if (!parsedBody.success) {
+            status = 400;
+            return badRequest(
+              origin,
+              dependencies.corsAllowedOrigins,
+              formatSchemaValidationError(parsedBody.error),
+            );
+          }
+
+          const playerId = decodeRouteParam(claimPlayerMatch[1]);
+          let player;
+          try {
+            player = await dependencies.repository.claimPlayer({
+              playerId,
+              userId: session.email,
+            });
+          } catch (error) {
+            if (error instanceof PlayerClaimError) {
+              status = 409;
+              return createJsonResponse(
+                status,
+                {
+                  error: "conflict",
+                  code: error.code,
+                  message: error.message,
+                },
+                buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
+              );
+            }
+
+            throw error;
+          }
+
+          if (!player) {
+            status = 404;
+            return notFound(origin, dependencies.corsAllowedOrigins, `Player ${playerId} was not found.`);
+          }
+
+          status = 200;
+          return createJsonResponse(
+            status,
+            {
+              player: toPublicPlayer(player),
+              claim: {
+                claimedByCurrentUser: true,
+              },
+            },
+            buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
+          );
+        }
+
         const listGamePlayersMatch = route.match(/^\/v1\/games\/([^/]+)\/players$/);
         if (method === "GET" && listGamePlayersMatch) {
           const gameId = decodeRouteParam(listGamePlayersMatch[1]);
@@ -3592,13 +3751,8 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
             return notFound(origin, dependencies.corsAllowedOrigins, `Game ${gameId} was not found.`);
           }
 
-          const canManageRoster = await ensureLeagueRole(
-            dependencies.repository,
-            game.leagueId,
-            session.email,
-            new Set(["admin", "scorekeeper"]),
-          );
-          if (!canManageRoster) {
+          const access = await ensureLeagueAccess(dependencies.repository, game.leagueId, session.email);
+          if (!access.allowed || (access.role !== "admin" && access.role !== "scorekeeper")) {
             status = 403;
             return forbidden(
               origin,
@@ -3610,7 +3764,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
 
           const search = getQueryParam(event, "search")?.trim().toLowerCase() ?? "";
           const playerLinks = await dependencies.repository.listGamePlayers(gameId);
-          const players = (
+          const playerEntries = (
             await Promise.all(
               playerLinks.map(async (link) => ({
                 link,
@@ -3630,8 +3784,17 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
 
               return left.player.nickname.localeCompare(right.player.nickname);
             })
-            .slice(0, 20)
-            .map((entry) => toPublicPlayer(entry.player));
+            .slice(0, 20);
+          const players = await Promise.all(
+            playerEntries.map((entry) =>
+              toGamePlayerForLeagueRole({
+                repository: dependencies.repository,
+                player: entry.player,
+                leagueId: game.leagueId,
+                callerRole: access.role,
+              }),
+            ),
+          );
           status = 200;
           return createJsonResponse(
             status,

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -50,6 +50,7 @@ import {
   resolveSessionCookieSecureFlag,
 } from "./auth/session.js";
 import {
+  claimPlayerRequestSchema,
   createGameRequestSchema,
   createGoalRequestSchema,
   createLeagueRequestSchema,
@@ -57,6 +58,7 @@ import {
   createSessionRequestSchema,
   assignRosterPlayerRequestSchema,
   formatSchemaValidationError,
+  grantLeagueAccessRequestSchema,
   idempotencyKeyHeaderSchema,
   isJoinCodePathParamValid,
   joinGameRequestSchema,
@@ -74,6 +76,7 @@ import {
   GameTimerTransitionError,
   GoalCorrectionError,
   GoalCreationError,
+  PlayerClaimError,
   ThreeFcRepository,
 } from "./data/repository.js";
 import type { GameRecord } from "./data/types.js";
@@ -674,6 +677,32 @@ function toPublicPlayer(player: {
     nickname: player.nickname,
     createdAt: player.createdAt,
     updatedAt: player.updatedAt,
+  };
+}
+
+async function toGamePlayerForLeagueRole(input: {
+  player: {
+    playerId: string;
+    nickname: string;
+    claimedByUserId: string | null;
+    createdAt: string;
+    updatedAt: string;
+  };
+  leagueId: string;
+  callerRole: "admin" | "scorekeeper" | "viewer" | null;
+}) {
+  const publicPlayer = toPublicPlayer(input.player);
+  if (input.callerRole !== "admin" || !input.player.claimedByUserId) {
+    return publicPlayer;
+  }
+
+  const access = await repository.getLeagueAccess(input.leagueId, input.player.claimedByUserId);
+  return {
+    ...publicPlayer,
+    access: {
+      userId: input.player.claimedByUserId,
+      role: access?.role ?? null,
+    },
   };
 }
 
@@ -2546,6 +2575,49 @@ async function start(): Promise<void> {
         return;
       }
 
+      const grantLeagueAccessMatch = route.match(/^\/v1\/leagues\/([^/]+)\/access$/);
+      if (method === "POST" && grantLeagueAccessMatch) {
+        if (!authGate.session) {
+          status = 500;
+          sendJsonWithCors(request, response, status, {
+            error: "internal_error",
+            message: "Session should be available for authenticated route.",
+          });
+          return;
+        }
+
+        const leagueId = decodeURIComponent(grantLeagueAccessMatch[1]);
+        const league = await repository.getLeague(leagueId);
+        if (!league) {
+          status = notFound(request, response, `League ${leagueId} was not found.`);
+          return;
+        }
+
+        let rawBody: Record<string, unknown>;
+        try {
+          rawBody = await parseJsonBody(request);
+        } catch {
+          status = badRequest(request, response, "Request body must be valid JSON.");
+          return;
+        }
+
+        const parsedBody = grantLeagueAccessRequestSchema.safeParse(rawBody);
+        if (!parsedBody.success) {
+          status = badRequest(request, response, formatSchemaValidationError(parsedBody.error));
+          return;
+        }
+
+        const accessGrant = await repository.grantLeagueAccess({
+          leagueId,
+          userId: parsedBody.data.userId,
+          role: parsedBody.data.role,
+          grantedByUserId: authGate.session.email,
+        });
+        status = 200;
+        sendJsonWithCors(request, response, status, accessGrant);
+        return;
+      }
+
       const createSeasonMatch = route.match(/^\/v1\/leagues\/([^/]+)\/seasons$/);
       if (method === "POST" && createSeasonMatch) {
         if (!authGate.session) {
@@ -3526,6 +3598,67 @@ async function start(): Promise<void> {
         return;
       }
 
+      const claimPlayerMatch = route.match(/^\/v1\/players\/([^/]+)\/claim$/);
+      if (method === "POST" && claimPlayerMatch) {
+        if (!authGate.session) {
+          status = 500;
+          sendJsonWithCors(request, response, status, {
+            error: "internal_error",
+            message: "Session should be available for authenticated route.",
+          });
+          return;
+        }
+
+        let rawBody: Record<string, unknown>;
+        try {
+          rawBody = await parseJsonBody(request);
+        } catch {
+          status = badRequest(request, response, "Request body must be valid JSON.");
+          return;
+        }
+
+        const parsedBody = claimPlayerRequestSchema.safeParse(rawBody);
+        if (!parsedBody.success) {
+          status = badRequest(request, response, formatSchemaValidationError(parsedBody.error));
+          return;
+        }
+
+        const playerId = decodeURIComponent(claimPlayerMatch[1]);
+        let player;
+        try {
+          player = await repository.claimPlayer({
+            playerId,
+            userId: authGate.session.email,
+          });
+        } catch (error) {
+          if (error instanceof PlayerClaimError) {
+            status = 409;
+            sendJsonWithCors(request, response, status, {
+              error: "conflict",
+              code: error.code,
+              message: error.message,
+            });
+            return;
+          }
+
+          throw error;
+        }
+
+        if (!player) {
+          status = notFound(request, response, `Player ${playerId} was not found.`);
+          return;
+        }
+
+        status = 200;
+        sendJsonWithCors(request, response, status, {
+          player: toPublicPlayer(player),
+          claim: {
+            claimedByCurrentUser: true,
+          },
+        });
+        return;
+      }
+
       const listGamePlayersMatch = route.match(/^\/v1\/games\/([^/]+)\/players$/);
       if (method === "GET" && listGamePlayersMatch) {
         if (!authGate.session) {
@@ -3544,12 +3677,8 @@ async function start(): Promise<void> {
           return;
         }
 
-        const canManageRoster = await ensureLeagueRole(
-          game.leagueId,
-          authGate.session.email,
-          new Set(["admin", "scorekeeper"]),
-        );
-        if (!canManageRoster) {
+        const access = await ensureLeagueAccess(game.leagueId, authGate.session.email);
+        if (!access.allowed || (access.role !== "admin" && access.role !== "scorekeeper")) {
           status = forbidden(
             request,
             response,
@@ -3561,7 +3690,7 @@ async function start(): Promise<void> {
 
         const search = requestUrl.searchParams.get("search")?.trim().toLowerCase() ?? "";
         const playerLinks = await repository.listGamePlayers(gameId);
-        const players = (
+        const playerEntries = (
           await Promise.all(
             playerLinks.map(async (link) => ({
               link,
@@ -3581,8 +3710,16 @@ async function start(): Promise<void> {
 
             return left.player.nickname.localeCompare(right.player.nickname);
           })
-          .slice(0, 20)
-          .map((entry) => toPublicPlayer(entry.player));
+          .slice(0, 20);
+        const players = await Promise.all(
+          playerEntries.map((entry) =>
+            toGamePlayerForLeagueRole({
+              player: entry.player,
+              leagueId: game.leagueId,
+              callerRole: access.role,
+            }),
+          ),
+        );
         status = 200;
         sendJsonWithCors(request, response, status, {
           players,

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -347,41 +347,87 @@ function conflict(request: IncomingMessage, response: ServerResponse, message: s
   return 409;
 }
 
+type UserIdCandidate = string | null | undefined;
+
 async function ensureLeagueAccess(
   leagueId: string,
-  userId: string,
+  userIds: UserIdCandidate | readonly UserIdCandidate[],
   repositoryClient: Pick<ThreeFcRepository, "getLeagueAccess"> = repository,
 ): Promise<{ allowed: boolean; role: "admin" | "scorekeeper" | "viewer" | null }> {
-  const access = await repositoryClient.getLeagueAccess(leagueId, userId);
-  if (!access) {
-    return {
-      allowed: false,
-      role: null,
-    };
+  for (const userId of normalizeUserIds(userIds)) {
+    const access = await repositoryClient.getLeagueAccess(leagueId, userId);
+    if (access) {
+      return {
+        allowed: true,
+        role: access.role,
+      };
+    }
   }
 
   return {
-    allowed: true,
-    role: access.role,
+    allowed: false,
+    role: null,
   };
 }
 
 async function ensureLeagueAdmin(
   leagueId: string,
-  userId: string,
+  userIds: UserIdCandidate | readonly UserIdCandidate[],
   repositoryClient: Pick<ThreeFcRepository, "getLeagueAccess"> = repository,
 ): Promise<boolean> {
-  const access = await repositoryClient.getLeagueAccess(leagueId, userId);
-  return access?.role === "admin";
+  for (const userId of normalizeUserIds(userIds)) {
+    const access = await repositoryClient.getLeagueAccess(leagueId, userId);
+    if (access?.role === "admin") {
+      return true;
+    }
+  }
+  return false;
 }
 
 async function ensureLeagueRole(
   leagueId: string,
-  userId: string,
+  userIds: UserIdCandidate | readonly UserIdCandidate[],
   allowedRoles: ReadonlySet<"admin" | "scorekeeper" | "viewer">,
 ): Promise<boolean> {
-  const access = await repository.getLeagueAccess(leagueId, userId);
-  return access ? allowedRoles.has(access.role) : false;
+  for (const userId of normalizeUserIds(userIds)) {
+    const access = await repository.getLeagueAccess(leagueId, userId);
+    if (access && allowedRoles.has(access.role)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function normalizeUserIds(userIds: UserIdCandidate | readonly UserIdCandidate[]): string[] {
+  const values = Array.isArray(userIds) ? userIds : [userIds];
+  return values.filter(
+    (value, index): value is string =>
+      typeof value === "string" && value.trim().length > 0 && values.indexOf(value) === index,
+  );
+}
+
+function sessionUserIds(session: Pick<AuthSessionRecord, "email" | "subject">): string[] {
+  return normalizeUserIds([session.subject, session.email]);
+}
+
+function sessionSubject(session: Pick<AuthSessionRecord, "email" | "subject">): string {
+  return session.subject ?? session.email;
+}
+
+type LeagueListRecord = Awaited<ReturnType<ThreeFcRepository["listLeaguesForUser"]>>[number];
+
+async function listLeaguesForSession(
+  session: Pick<AuthSessionRecord, "email" | "subject">,
+  repositoryClient: Pick<ThreeFcRepository, "listLeaguesForUser"> = repository,
+): Promise<LeagueListRecord[]> {
+  const leaguesById = new Map<string, LeagueListRecord>();
+  for (const userId of sessionUserIds(session)) {
+    const leagues = await repositoryClient.listLeaguesForUser(userId);
+    for (const league of leagues) {
+      leaguesById.set(league.leagueId, league);
+    }
+  }
+  return [...leaguesById.values()];
 }
 
 function parseTeamId(value: string): TeamId | null {
@@ -1701,7 +1747,7 @@ async function enforceAclIfRequired(
     };
   }
 
-  const aclResult = await authorizeProtectedMutation(method, route, session.email, repository);
+  const aclResult = await authorizeProtectedMutation(method, route, sessionUserIds(session), repository);
   if (!aclResult.allowed) {
     sendJsonWithCors(request, response, aclResult.statusCode, aclResult.error);
     return {
@@ -2514,7 +2560,7 @@ async function start(): Promise<void> {
         method === "GET" &&
         route === "/v1/leagues"
       ) {
-        const leagues = await repository.listLeaguesForUser(authGate.session.email);
+        const leagues = await listLeaguesForSession(authGate.session);
         status = 200;
         sendJsonWithCors(request, response, status, {
           leagues,
@@ -2548,7 +2594,7 @@ async function start(): Promise<void> {
         }
 
         const leagueId = decodeURIComponent(getLeagueMatch[1]);
-        const access = await ensureLeagueAccess(leagueId, authGate.session.email);
+        const access = await ensureLeagueAccess(leagueId, sessionUserIds(authGate.session));
         if (!access.allowed) {
           status = forbidden(
             request,
@@ -2652,7 +2698,7 @@ async function start(): Promise<void> {
         }
 
         const leagueId = decodeURIComponent(listSeasonsMatch[1]);
-        const access = await ensureLeagueAccess(leagueId, authGate.session.email);
+        const access = await ensureLeagueAccess(leagueId, sessionUserIds(authGate.session));
         if (!access.allowed) {
           status = forbidden(
             request,
@@ -2683,7 +2729,7 @@ async function start(): Promise<void> {
         }
 
         const leagueId = decodeURIComponent(deleteLeagueMatch[1]);
-        const isAdmin = await ensureLeagueAdmin(leagueId, authGate.session.email);
+        const isAdmin = await ensureLeagueAdmin(leagueId, sessionUserIds(authGate.session));
         if (!isAdmin) {
           status = forbidden(
             request,
@@ -2754,7 +2800,7 @@ async function start(): Promise<void> {
           return;
         }
 
-        const access = await ensureLeagueAccess(season.leagueId, authGate.session.email);
+        const access = await ensureLeagueAccess(season.leagueId, sessionUserIds(authGate.session));
         if (!access.allowed) {
           status = forbidden(
             request,
@@ -2788,7 +2834,7 @@ async function start(): Promise<void> {
           return;
         }
 
-        const access = await ensureLeagueAccess(season.leagueId, authGate.session.email);
+        const access = await ensureLeagueAccess(season.leagueId, sessionUserIds(authGate.session));
         if (!access.allowed) {
           status = forbidden(
             request,
@@ -2835,7 +2881,7 @@ async function start(): Promise<void> {
           return;
         }
 
-        const access = await ensureLeagueAccess(season.leagueId, authGate.session.email);
+        const access = await ensureLeagueAccess(season.leagueId, sessionUserIds(authGate.session));
         if (!access.allowed) {
           status = forbidden(
             request,
@@ -2907,7 +2953,7 @@ async function start(): Promise<void> {
           return;
         }
 
-        const isAdmin = await ensureLeagueAdmin(season.leagueId, authGate.session.email);
+        const isAdmin = await ensureLeagueAdmin(season.leagueId, sessionUserIds(authGate.session));
         if (!isAdmin) {
           status = forbidden(
             request,
@@ -3520,7 +3566,7 @@ async function start(): Promise<void> {
           return;
         }
 
-        const access = await ensureLeagueAccess(game.leagueId, authGate.session.email);
+        const access = await ensureLeagueAccess(game.leagueId, sessionUserIds(authGate.session));
         if (!access.allowed) {
           status = forbidden(
             request,
@@ -3561,7 +3607,7 @@ async function start(): Promise<void> {
           return;
         }
 
-        const access = await ensureLeagueAccess(game.leagueId, authGate.session.email);
+        const access = await ensureLeagueAccess(game.leagueId, sessionUserIds(authGate.session));
         if (!access.allowed) {
           status = forbidden(
             request,
@@ -3628,7 +3674,7 @@ async function start(): Promise<void> {
         try {
           player = await repository.claimPlayer({
             playerId,
-            userId: authGate.session.email,
+            userId: sessionSubject(authGate.session),
           });
         } catch (error) {
           if (error instanceof PlayerClaimError) {
@@ -3677,7 +3723,7 @@ async function start(): Promise<void> {
           return;
         }
 
-        const access = await ensureLeagueAccess(game.leagueId, authGate.session.email);
+        const access = await ensureLeagueAccess(game.leagueId, sessionUserIds(authGate.session));
         if (!access.allowed || (access.role !== "admin" && access.role !== "scorekeeper")) {
           status = forbidden(
             request,
@@ -3858,7 +3904,7 @@ async function start(): Promise<void> {
           return;
         }
 
-        const access = await ensureLeagueAccess(game.leagueId, authGate.session.email);
+        const access = await ensureLeagueAccess(game.leagueId, sessionUserIds(authGate.session));
         if (!access.allowed) {
           status = forbidden(
             request,
@@ -3905,7 +3951,7 @@ async function start(): Promise<void> {
           return;
         }
 
-        const isAdmin = await ensureLeagueAdmin(game.leagueId, authGate.session.email);
+        const isAdmin = await ensureLeagueAdmin(game.leagueId, sessionUserIds(authGate.session));
         let rawBody: Record<string, unknown>;
         try {
           rawBody = await parseJsonBody(request);
@@ -3993,7 +4039,7 @@ async function start(): Promise<void> {
           return;
         }
 
-        const isAdmin = await ensureLeagueAdmin(existingGame.leagueId, authGate.session.email);
+        const isAdmin = await ensureLeagueAdmin(existingGame.leagueId, sessionUserIds(authGate.session));
         if (!isAdmin) {
           status = forbidden(
             request,

--- a/api/src/tests/acl.test.ts
+++ b/api/src/tests/acl.test.ts
@@ -102,6 +102,13 @@ test("resolveProtectedMutationRoute maps supported mutation endpoints", () => {
     operation: "undoLastGoal",
     gameId: "game-1",
   });
+  assert.deepEqual(resolveProtectedMutationRoute("POST", "/v1/players/player-1/claim"), {
+    operation: "claimPlayer",
+  });
+  assert.deepEqual(resolveProtectedMutationRoute("POST", "/v1/leagues/league-1/access"), {
+    operation: "grantLeagueAccess",
+    leagueId: "league-1",
+  });
   assert.equal(resolveProtectedMutationRoute("GET", "/v1/leagues"), null);
 });
 
@@ -116,6 +123,66 @@ test("createLeague mutation is allowed for authenticated users", async () => {
   assert.equal(result.allowed, true);
   assert.equal(result.operation, "createLeague");
   assert.equal(result.error, null);
+});
+
+test("claimPlayer mutation is allowed for authenticated users without league access", async () => {
+  const result = await authorizeProtectedMutation(
+    "POST",
+    "/v1/players/player-1/claim",
+    "participant@example.com",
+    new InMemoryAclLookup({}),
+  );
+
+  assert.equal(result.allowed, true);
+  assert.equal(result.operation, "claimPlayer");
+  assert.equal(result.scope, null);
+  assert.equal(result.error, null);
+});
+
+test("grantLeagueAccess mutation requires league admin", async () => {
+  const adminResult = await authorizeProtectedMutation(
+    "POST",
+    "/v1/leagues/league-1/access",
+    "admin-user",
+    new InMemoryAclLookup({
+      leagueAccess: {
+        "league-1:admin-user": {
+          leagueId: "league-1",
+          userId: "admin-user",
+          role: "admin",
+          grantedByUserId: "owner",
+          createdAt: "2026-02-23T00:00:00.000Z",
+          updatedAt: "2026-02-23T00:00:00.000Z",
+        },
+      },
+    }),
+  );
+
+  assert.equal(adminResult.allowed, true);
+  assert.equal(adminResult.operation, "grantLeagueAccess");
+  assert.deepEqual(adminResult.scope, { leagueId: "league-1" });
+
+  const scorekeeperResult = await authorizeProtectedMutation(
+    "POST",
+    "/v1/leagues/league-1/access",
+    "scorekeeper-user",
+    new InMemoryAclLookup({
+      leagueAccess: {
+        "league-1:scorekeeper-user": {
+          leagueId: "league-1",
+          userId: "scorekeeper-user",
+          role: "scorekeeper",
+          grantedByUserId: "owner",
+          createdAt: "2026-02-23T00:00:00.000Z",
+          updatedAt: "2026-02-23T00:00:00.000Z",
+        },
+      },
+    }),
+  );
+
+  assert.equal(scorekeeperResult.allowed, false);
+  assert.equal(scorekeeperResult.statusCode, 403);
+  assert.equal(scorekeeperResult.error?.code, "admin_required");
 });
 
 test("league-scoped mutation rejects non-admin users", async () => {

--- a/api/src/tests/deployment-config.test.ts
+++ b/api/src/tests/deployment-config.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const serverlessCoreConfig = readFileSync(resolve(process.cwd(), "../serverless.api-core.yml"), "utf8");
+
+function assertServerlessRoute(method: string, path: string): void {
+  assert.match(
+    serverlessCoreConfig,
+    new RegExp(`method:\\s*${method}\\s+path:\\s*${path.replace(/[{}]/g, "\\$&")}`),
+  );
+}
+
+test("api core deployment config registers claim and access routes", () => {
+  assertServerlessRoute("POST", "/v1/players/{playerId}/claim");
+  assertServerlessRoute("OPTIONS", "/v1/players/{playerId}/claim");
+  assertServerlessRoute("POST", "/v1/leagues/{leagueId}/access");
+  assertServerlessRoute("OPTIONS", "/v1/leagues/{leagueId}/access");
+});

--- a/api/src/tests/lambda-core.test.ts
+++ b/api/src/tests/lambda-core.test.ts
@@ -33,6 +33,7 @@ import {
 interface MockSessionRecord {
   sessionId: string;
   email: string;
+  subject?: string;
   createdAt: string;
   expiresAt: string;
 }
@@ -45,6 +46,12 @@ interface MockLeagueAccessRecord {
   createdAt: string;
   updatedAt: string;
 }
+
+const leagueRoleRank: Record<MockLeagueAccessRecord["role"], number> = {
+  viewer: 1,
+  scorekeeper: 2,
+  admin: 3,
+};
 
 interface MockSeasonRecord {
   leagueId: string;
@@ -1640,6 +1647,12 @@ function createHarness(config: HarnessConfig = {}) {
         return leagueAccess.get(`${leagueId}:${userId}`) ?? null;
       },
       async grantLeagueAccess(input) {
+        const key = `${input.leagueId}:${input.userId}`;
+        const existing = leagueAccess.get(key);
+        if (existing && leagueRoleRank[existing.role] >= leagueRoleRank[input.role]) {
+          return existing;
+        }
+
         const record = {
           leagueId: input.leagueId,
           userId: input.userId,
@@ -1648,7 +1661,7 @@ function createHarness(config: HarnessConfig = {}) {
           createdAt: "2026-02-23T00:00:02.000Z",
           updatedAt: "2026-02-23T00:00:02.000Z",
         };
-        leagueAccess.set(`${input.leagueId}:${input.userId}`, record);
+        leagueAccess.set(key, record);
         grantedLeagueAccess.push(record);
         return record;
       },
@@ -2349,6 +2362,7 @@ test("core lambda lets joined players claim accounts and admins delegate scorer 
       "session-player": {
         sessionId: "session-player",
         email: "delegate@example.com",
+        subject: "cognito-delegate-sub",
         createdAt: "2026-02-23T00:00:00.000Z",
         expiresAt: "2026-02-24T00:00:00.000Z",
       },
@@ -2423,7 +2437,7 @@ test("core lambda lets joined players claim accounts and admins delegate scorer 
   );
 
   assert.equal(claimResponse.statusCode, 200);
-  assert.equal(harness.players.get("player-joined")?.claimedByUserId, "delegate@example.com");
+  assert.equal(harness.players.get("player-joined")?.claimedByUserId, "cognito-delegate-sub");
   assert.deepEqual(JSON.parse(claimResponse.body), {
     player: {
       playerId: "player-joined",
@@ -2455,7 +2469,7 @@ test("core lambda lets joined players claim accounts and admins delegate scorer 
         createdAt: "2026-02-23T00:00:00.000Z",
         updatedAt: "2026-02-23T00:00:01.000Z",
         access: {
-          userId: "delegate@example.com",
+          userId: "cognito-delegate-sub",
           role: null,
         },
       },
@@ -2470,7 +2484,7 @@ test("core lambda lets joined players claim accounts and admins delegate scorer 
         Cookie: "threefc_session=session-admin",
       },
       body: {
-        userId: "delegate@example.com",
+        userId: "cognito-delegate-sub",
         role: "scorekeeper",
       },
     }),
@@ -2479,6 +2493,41 @@ test("core lambda lets joined players claim accounts and admins delegate scorer 
   assert.equal(grantResponse.statusCode, 200);
   assert.equal(harness.grantedLeagueAccess.length, 1);
   assert.equal(harness.grantedLeagueAccess[0].role, "scorekeeper");
+
+  const adminGrantResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/leagues/league-1/access",
+      headers: {
+        Cookie: "threefc_session=session-admin",
+      },
+      body: {
+        userId: "cognito-delegate-sub",
+        role: "admin",
+      },
+    }),
+  );
+
+  assert.equal(adminGrantResponse.statusCode, 200);
+  assert.equal(JSON.parse(adminGrantResponse.body).role, "admin");
+
+  const staleScorerGrantResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/leagues/league-1/access",
+      headers: {
+        Cookie: "threefc_session=session-admin",
+      },
+      body: {
+        userId: "cognito-delegate-sub",
+        role: "scorekeeper",
+      },
+    }),
+  );
+
+  assert.equal(staleScorerGrantResponse.statusCode, 200);
+  assert.equal(JSON.parse(staleScorerGrantResponse.body).role, "admin");
+  assert.equal(harness.grantedLeagueAccess.length, 2);
 
   const delegatedPoolResponse = await harness.handler(
     createEvent({
@@ -2498,6 +2547,10 @@ test("core lambda lets joined players claim accounts and admins delegate scorer 
         nickname: "Delegate",
         createdAt: "2026-02-23T00:00:00.000Z",
         updatedAt: "2026-02-23T00:00:01.000Z",
+        access: {
+          userId: "cognito-delegate-sub",
+          role: "admin",
+        },
       },
     ],
   });
@@ -2985,6 +3038,81 @@ test("core lambda creates league for authenticated users", async () => {
   assert.equal(response.statusCode, 201);
   assert.equal(harness.createdLeagues.length, 1);
   assert.equal(harness.createdLeagues[0].createdByUserId, "admin@example.com");
+});
+
+test("core lambda lists subject-keyed and legacy email-keyed league access", async () => {
+  const harness = createHarness({
+    sessions: {
+      "session-1": {
+        sessionId: "session-1",
+        email: "delegate@example.com",
+        subject: "cognito-delegate-sub",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    leagues: {
+      "league-subject": {
+        leagueId: "league-subject",
+        name: "Subject League",
+        slug: null,
+        createdByUserId: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+      "league-email": {
+        leagueId: "league-email",
+        name: "Email League",
+        slug: null,
+        createdByUserId: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueAccess: {
+      "league-subject:cognito-delegate-sub": {
+        leagueId: "league-subject",
+        userId: "cognito-delegate-sub",
+        role: "scorekeeper",
+        grantedByUserId: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+      "league-subject:delegate@example.com": {
+        leagueId: "league-subject",
+        userId: "delegate@example.com",
+        role: "viewer",
+        grantedByUserId: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+      "league-email:delegate@example.com": {
+        leagueId: "league-email",
+        userId: "delegate@example.com",
+        role: "viewer",
+        grantedByUserId: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  const response = await harness.handler(
+    createEvent({
+      method: "GET",
+      path: "/v1/leagues",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+    }),
+  );
+
+  assert.equal(response.statusCode, 200);
+  const body = JSON.parse(response.body) as { leagues: Array<{ leagueId: string }> };
+  assert.deepEqual(
+    body.leagues.map((league) => league.leagueId).sort(),
+    ["league-email", "league-subject"],
+  );
 });
 
 test("core lambda includes caller league role on league reads", async () => {

--- a/api/src/tests/lambda-core.test.ts
+++ b/api/src/tests/lambda-core.test.ts
@@ -27,6 +27,7 @@ import {
   GameTimerTransitionError,
   GoalCorrectionError,
   GoalCreationError,
+  PlayerClaimError,
 } from "../data/repository.js";
 
 interface MockSessionRecord {
@@ -347,6 +348,7 @@ function createHarness(config: HarnessConfig = {}) {
     consistentRead: boolean;
     repairLegacyJoinCode: boolean;
   }> = [];
+  const grantedLeagueAccess: MockLeagueAccessRecord[] = [];
   const listTeamsForSeasonCalls: Array<{ seasonId: string; consistentRead: boolean }> = [];
   const listTeamsForGameCalls: Array<{ gameId: string; consistentRead: boolean }> = [];
   const idempotencyRecords = new Map<string, StoredIdempotencyRecord>();
@@ -403,6 +405,9 @@ function createHarness(config: HarnessConfig = {}) {
   );
   const gamePlayers = new Map<string, MockGamePlayerRecord>(
     Object.entries(config.gamePlayers ?? {}),
+  );
+  const leagueAccess = new Map<string, MockLeagueAccessRecord>(
+    Object.entries(config.leagueAccess ?? {}),
   );
   const goalEvents = new Map<string, MockGoalEventRecord>();
   const goalAuditEntries: Array<{
@@ -1326,6 +1331,32 @@ function createHarness(config: HarnessConfig = {}) {
       async getPlayer(playerId: string) {
         return players.get(playerId) ?? null;
       },
+      async claimPlayer(input) {
+        const player = players.get(input.playerId);
+        if (!player) {
+          return null;
+        }
+
+        if (player.claimedByUserId === input.userId) {
+          return player;
+        }
+
+        if (player.claimedByUserId !== null) {
+          throw new PlayerClaimError(
+            "player_already_claimed",
+            409,
+            `Player ${input.playerId} has already been claimed.`,
+          );
+        }
+
+        const updated = {
+          ...player,
+          claimedByUserId: input.userId,
+          updatedAt: "2026-02-23T00:00:01.000Z",
+        };
+        players.set(input.playerId, updated);
+        return updated;
+      },
       async listPlayers(input = {}) {
         const search = input.search?.toLowerCase() ?? "";
         return [...players.values()]
@@ -1606,7 +1637,20 @@ function createHarness(config: HarnessConfig = {}) {
         };
       },
       async getLeagueAccess(leagueId: string, userId: string) {
-        return config.leagueAccess?.[`${leagueId}:${userId}`] ?? null;
+        return leagueAccess.get(`${leagueId}:${userId}`) ?? null;
+      },
+      async grantLeagueAccess(input) {
+        const record = {
+          leagueId: input.leagueId,
+          userId: input.userId,
+          role: input.role,
+          grantedByUserId: input.grantedByUserId,
+          createdAt: "2026-02-23T00:00:02.000Z",
+          updatedAt: "2026-02-23T00:00:02.000Z",
+        };
+        leagueAccess.set(`${input.leagueId}:${input.userId}`, record);
+        grantedLeagueAccess.push(record);
+        return record;
       },
       async getSeason(seasonId: string) {
         return seasons.get(seasonId) ?? null;
@@ -1663,12 +1707,15 @@ function createHarness(config: HarnessConfig = {}) {
     magicLinkStarts,
     magicLinkCompletes,
     magicLinkRateLimitChecks,
+    grantedLeagueAccess,
     getGameCalls,
     listTeamsForSeasonCalls,
     listTeamsForGameCalls,
     idempotencyRecords,
     goalAuditEntries,
     games,
+    players,
+    leagueAccess,
   };
 }
 
@@ -2294,6 +2341,217 @@ test("core lambda lets players join an active game by join code and appear in th
   assert.deepEqual(JSON.parse(playerPoolResponse.body), {
     players: [joinBody.player],
   });
+});
+
+test("core lambda lets joined players claim accounts and admins delegate scorer access", async () => {
+  const harness = createHarness({
+    sessions: {
+      "session-player": {
+        sessionId: "session-player",
+        email: "delegate@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+      "session-admin": {
+        sessionId: "session-admin",
+        email: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    leagues: {
+      "league-1": {
+        leagueId: "league-1",
+        name: "League One",
+        slug: "league-one",
+        createdByUserId: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    games: {
+      "game-1": {
+        gameId: "game-1",
+        joinCode: "JNABCD23",
+        leagueId: "league-1",
+        seasonId: "season-1",
+        sessionId: "session-1",
+        status: "live",
+        gameStartTs: "2026-02-23T10:00:00.000Z",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    players: {
+      "player-joined": {
+        playerId: "player-joined",
+        nickname: "Delegate",
+        claimedByUserId: null,
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    gamePlayers: {
+      "game-1:player-joined": {
+        gameId: "game-1",
+        playerId: "player-joined",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueAccess: {
+      "league-1:admin@example.com": {
+        leagueId: "league-1",
+        userId: "admin@example.com",
+        role: "admin",
+        grantedByUserId: "owner@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  const claimResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/players/player-joined/claim",
+      headers: {
+        Cookie: "threefc_session=session-player",
+      },
+      body: {},
+    }),
+  );
+
+  assert.equal(claimResponse.statusCode, 200);
+  assert.equal(harness.players.get("player-joined")?.claimedByUserId, "delegate@example.com");
+  assert.deepEqual(JSON.parse(claimResponse.body), {
+    player: {
+      playerId: "player-joined",
+      nickname: "Delegate",
+      createdAt: "2026-02-23T00:00:00.000Z",
+      updatedAt: "2026-02-23T00:00:01.000Z",
+    },
+    claim: {
+      claimedByCurrentUser: true,
+    },
+  });
+
+  const adminPoolBeforeGrant = await harness.handler(
+    createEvent({
+      method: "GET",
+      path: "/v1/games/game-1/players",
+      headers: {
+        Cookie: "threefc_session=session-admin",
+      },
+    }),
+  );
+
+  assert.equal(adminPoolBeforeGrant.statusCode, 200);
+  assert.deepEqual(JSON.parse(adminPoolBeforeGrant.body), {
+    players: [
+      {
+        playerId: "player-joined",
+        nickname: "Delegate",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:01.000Z",
+        access: {
+          userId: "delegate@example.com",
+          role: null,
+        },
+      },
+    ],
+  });
+
+  const grantResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/leagues/league-1/access",
+      headers: {
+        Cookie: "threefc_session=session-admin",
+      },
+      body: {
+        userId: "delegate@example.com",
+        role: "scorekeeper",
+      },
+    }),
+  );
+
+  assert.equal(grantResponse.statusCode, 200);
+  assert.equal(harness.grantedLeagueAccess.length, 1);
+  assert.equal(harness.grantedLeagueAccess[0].role, "scorekeeper");
+
+  const delegatedPoolResponse = await harness.handler(
+    createEvent({
+      method: "GET",
+      path: "/v1/games/game-1/players",
+      headers: {
+        Cookie: "threefc_session=session-player",
+      },
+    }),
+  );
+
+  assert.equal(delegatedPoolResponse.statusCode, 200);
+  assert.deepEqual(JSON.parse(delegatedPoolResponse.body), {
+    players: [
+      {
+        playerId: "player-joined",
+        nickname: "Delegate",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:01.000Z",
+      },
+    ],
+  });
+});
+
+test("core lambda rejects scorer access delegation from non-admins", async () => {
+  const harness = createHarness({
+    sessions: {
+      "session-scorekeeper": {
+        sessionId: "session-scorekeeper",
+        email: "scorekeeper@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    leagues: {
+      "league-1": {
+        leagueId: "league-1",
+        name: "League One",
+        slug: "league-one",
+        createdByUserId: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueAccess: {
+      "league-1:scorekeeper@example.com": {
+        leagueId: "league-1",
+        userId: "scorekeeper@example.com",
+        role: "scorekeeper",
+        grantedByUserId: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  const response = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/leagues/league-1/access",
+      headers: {
+        Cookie: "threefc_session=session-scorekeeper",
+      },
+      body: {
+        userId: "delegate@example.com",
+        role: "scorekeeper",
+      },
+    }),
+  );
+
+  assert.equal(response.statusCode, 403);
+  assert.equal(harness.grantedLeagueAccess.length, 0);
+  assert.equal(JSON.parse(response.body).code, "admin_required");
 });
 
 test("core lambda replays public join retries by idempotency key", async () => {

--- a/api/src/tests/magic-link.test.ts
+++ b/api/src/tests/magic-link.test.ts
@@ -8,7 +8,11 @@ import {
   type AttributeValue,
 } from "@aws-sdk/client-dynamodb";
 
-import { MagicLinkAuthError, MagicLinkService } from "../auth/magic-link.js";
+import {
+  magicLinkSubjectForEmail,
+  MagicLinkAuthError,
+  MagicLinkService,
+} from "../auth/magic-link.js";
 
 type Item = Record<string, AttributeValue>;
 
@@ -220,6 +224,7 @@ test("magic complete consumes token once and creates a session", async () => {
   const firstCompletion = await service.complete(token);
   assert.equal(firstCompletion.sessionId, "session-1");
   assert.equal(firstCompletion.email, "player@example.com");
+  assert.equal(firstCompletion.subject, magicLinkSubjectForEmail("player@example.com"));
   assert.equal(firstCompletion.maxAgeSeconds, 3600);
 
   const tokenItem = client.getItem("AUTH_MAGIC#token-1", "METADATA");
@@ -229,10 +234,12 @@ test("magic complete consumes token once and creates a session", async () => {
   const sessionItem = client.getItem("AUTH_SESSION#session-1", "METADATA");
   assert(sessionItem);
   assert.equal(sessionItem.email?.S, "player@example.com");
+  assert.equal(sessionItem.subject?.S, magicLinkSubjectForEmail("player@example.com"));
 
   const persistedSession = await service.getSession("session-1");
   assert(persistedSession);
   assert.equal(persistedSession.email, "player@example.com");
+  assert.equal(persistedSession.subject, magicLinkSubjectForEmail("player@example.com"));
 
   await assert.rejects(
     service.complete(token),

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -1405,6 +1405,48 @@ test("repository rejects quick player creation if the game finalizes before the 
   assert.equal((await repository.getGame("game-1"))?.status, "finished");
 });
 
+test("repository quick player creation preserves existing player claims", async () => {
+  const repository = createRepository();
+
+  await repository.createGame({
+    gameId: "game-1",
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "session-1",
+    status: "live",
+    gameStartTs: "2026-02-22T10:00:00Z",
+  });
+  await repository.createPlayer({
+    playerId: "player-claimed",
+    nickname: "Claimed",
+    claimedByUserId: "delegate@example.com",
+  });
+
+  const linked = await repository.createAndLinkGamePlayer({
+    gameId: "game-1",
+    playerId: "player-claimed",
+    nickname: "Replacement",
+  });
+
+  assert.equal(linked.nickname, "Claimed");
+  assert.equal(linked.claimedByUserId, "delegate@example.com");
+  assert.deepEqual(await repository.listGamePlayers("game-1"), [
+    {
+      gameId: "game-1",
+      playerId: "player-claimed",
+      createdAt: "2026-02-22T00:00:02.000Z",
+      updatedAt: "2026-02-22T00:00:02.000Z",
+    },
+  ]);
+  assert.deepEqual(await repository.getPlayer("player-claimed"), {
+    playerId: "player-claimed",
+    nickname: "Claimed",
+    claimedByUserId: "delegate@example.com",
+    createdAt: "2026-02-22T00:00:01.000Z",
+    updatedAt: "2026-02-22T00:00:01.000Z",
+  });
+});
+
 test("repository gives legacy games default timer state without repairing join codes by default", async () => {
   const { repository, client } = createRepositoryHarness();
 

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -593,6 +593,37 @@ test("repository claims players idempotently for one user and rejects another us
   );
 });
 
+test("repository grants league access monotonically without downgrading admins", async () => {
+  const { repository } = createRepositoryHarness();
+
+  const scorerGrant = await repository.grantLeagueAccess({
+    leagueId: "league-1",
+    userId: "delegate-subject",
+    role: "scorekeeper",
+    grantedByUserId: "admin-subject",
+  });
+  assert.equal(scorerGrant.role, "scorekeeper");
+
+  const adminGrant = await repository.grantLeagueAccess({
+    leagueId: "league-1",
+    userId: "delegate-subject",
+    role: "admin",
+    grantedByUserId: "admin-subject",
+  });
+  assert.equal(adminGrant.role, "admin");
+
+  const staleScorerGrant = await repository.grantLeagueAccess({
+    leagueId: "league-1",
+    userId: "delegate-subject",
+    role: "scorekeeper",
+    grantedByUserId: "admin-subject",
+  });
+  assert.equal(staleScorerGrant.role, "admin");
+
+  const storedAccess = await repository.getLeagueAccess("league-1", "delegate-subject");
+  assert.equal(storedAccess?.role, "admin");
+});
+
 test("repository rejects creating games directly as finished", async () => {
   const repository = createRepository();
 

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -24,6 +24,7 @@ import {
   GameJoinRegistrationError,
   GameMutationStateError,
   GameTimerTransitionError,
+  PlayerClaimError,
   ThreeFcRepository,
 } from "../data/repository.js";
 
@@ -552,6 +553,38 @@ test("repository supports round-trip create/read for core entities", async () =>
   });
   assert.deepEqual(await repository.listGameRoster("game-1"), [reassignedRoster]);
   assert.equal(reassignedRoster.teamId, "blue");
+});
+
+test("repository claims players idempotently for one user and rejects another user", async () => {
+  const repository = createRepository();
+
+  await repository.createPlayer({
+    playerId: "player-claim",
+    nickname: "Claim Me",
+  });
+
+  const claimed = await repository.claimPlayer({
+    playerId: "player-claim",
+    userId: "delegate@example.com",
+  });
+  assert.equal(claimed?.claimedByUserId, "delegate@example.com");
+
+  const replayed = await repository.claimPlayer({
+    playerId: "player-claim",
+    userId: "delegate@example.com",
+  });
+  assert.deepEqual(replayed, claimed);
+
+  await assert.rejects(
+    repository.claimPlayer({
+      playerId: "player-claim",
+      userId: "other@example.com",
+    }),
+    (error: unknown) =>
+      error instanceof PlayerClaimError &&
+      error.code === "player_already_claimed" &&
+      error.statusCode === 409,
+  );
 });
 
 test("repository rejects creating games directly as finished", async () => {

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -556,7 +556,7 @@ test("repository supports round-trip create/read for core entities", async () =>
 });
 
 test("repository claims players idempotently for one user and rejects another user", async () => {
-  const repository = createRepository();
+  const { repository, client } = createRepositoryHarness();
 
   await repository.createPlayer({
     playerId: "player-claim",
@@ -568,6 +568,12 @@ test("repository claims players idempotently for one user and rejects another us
     userId: "delegate@example.com",
   });
   assert.equal(claimed?.claimedByUserId, "delegate@example.com");
+  const claimItem = client.readItem("USER#delegate@example.com", "PLAYER#player-claim");
+  assert.equal(claimItem?.entityType?.S, "playerClaim");
+  assert.equal(claimItem?.data?.S, JSON.stringify({
+    userId: "delegate@example.com",
+    playerId: "player-claim",
+  }));
 
   const replayed = await repository.claimPlayer({
     playerId: "player-claim",

--- a/api/src/tests/session-guard.test.ts
+++ b/api/src/tests/session-guard.test.ts
@@ -5,7 +5,10 @@ import { resolveSessionFromCookie, type SessionLookup } from "../auth/session-gu
 
 class InMemorySessionLookup implements SessionLookup {
   constructor(
-    private readonly sessions: Record<string, { sessionId: string; email: string; createdAt: string; expiresAt: string }>,
+    private readonly sessions: Record<
+      string,
+      { sessionId: string; email: string; subject: string; createdAt: string; expiresAt: string }
+    >,
   ) {}
 
   async getSession(sessionId: string) {
@@ -43,6 +46,7 @@ test("resolveSessionFromCookie returns session when cookie maps to active sessio
       "session-1": {
         sessionId: "session-1",
         email: "player@example.com",
+        subject: "subject-player",
         createdAt: "2026-02-22T00:00:00.000Z",
         expiresAt: "2026-02-23T00:00:00.000Z",
       },
@@ -53,4 +57,5 @@ test("resolveSessionFromCookie returns session when cookie maps to active sessio
   assert(result.session);
   assert.equal(result.session.sessionId, "session-1");
   assert.equal(result.session.email, "player@example.com");
+  assert.equal(result.session.subject, "subject-player");
 });

--- a/api/src/tests/session.test.ts
+++ b/api/src/tests/session.test.ts
@@ -52,6 +52,8 @@ test("isAuthenticatedApiRoute marks protected routes only", () => {
   assert.equal(isAuthenticatedApiRoute("PATCH", "/v1/games/game-1/goals/goal-1"), true);
   assert.equal(isAuthenticatedApiRoute("DELETE", "/v1/games/game-1/goals/goal-1"), true);
   assert.equal(isAuthenticatedApiRoute("POST", "/v1/games/game-1/goals/undo-last"), true);
+  assert.equal(isAuthenticatedApiRoute("POST", "/v1/players/player-1/claim"), true);
+  assert.equal(isAuthenticatedApiRoute("POST", "/v1/leagues/league-1/access"), true);
   assert.equal(isAuthenticatedApiRoute("GET", "/v1/auth/session"), true);
   assert.equal(isAuthenticatedApiRoute("POST", "/v1/leagues"), true);
   assert.equal(isAuthenticatedApiRoute("POST", "/v1/leagues/league-1/seasons"), true);

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -3888,11 +3888,11 @@ test("setup smoke completes live game through finish", async () => {
   assert(resultSummary instanceof gamePage.window.HTMLElement);
   assert.equal(finishGameButton.disabled, true);
   assert.equal(joinCodeValue.textContent, "SMOKE123");
-  assert.equal(joinLink.getAttribute("href"), "http://localhost:3000/join/SMOKE123");
-  assert.equal(joinLink.textContent, "http://localhost:3000/join/SMOKE123");
+  assert.equal(joinLink.getAttribute("href"), "http://localhost:3000/join?code=SMOKE123");
+  assert.equal(joinLink.textContent, "http://localhost:3000/join?code=SMOKE123");
   const joinQrSvg = joinQr.querySelector("svg");
   assert(joinQrSvg instanceof gamePage.window.SVGElement);
-  assert.equal(joinQrSvg.getAttribute("aria-label"), "Join QR code for http://localhost:3000/join/SMOKE123");
+  assert.equal(joinQrSvg.getAttribute("aria-label"), "Join QR code for http://localhost:3000/join?code=SMOKE123");
   assert.match(joinQrSvg.innerHTML, /<path/);
   assert.equal(resultSummary.hidden, true);
 
@@ -4371,8 +4371,8 @@ test("join page registers a player without organizer authentication", async () =
   });
 
   const joinPage = await bootPage({
-    html: renderJoinPage("http://localhost:3001", "join0001"),
-    url: "http://localhost:3000/join/join0001",
+    html: renderJoinPage("http://localhost:3001", ""),
+    url: "http://localhost:3000/join?code=join0001",
     scriptFile: "setup-flow.js",
     apiState,
   });
@@ -4414,12 +4414,12 @@ test("join page registers a player without organizer authentication", async () =
   assert.match(signInHref, /^\/sign-in\?returnTo=/);
   assert.equal(
     new URL(signInHref, "http://localhost:3000").searchParams.get("returnTo"),
-    `/join/join0001?playerId=${player.playerId}`,
+    `/join?code=join0001&playerId=${player.playerId}`,
   );
 
   const secondJoinPage = await bootPage({
-    html: renderJoinPage("http://localhost:3001", "join0001"),
-    url: "http://localhost:3000/join/join0001",
+    html: renderJoinPage("http://localhost:3001", ""),
+    url: "http://localhost:3000/join?code=join0001",
     scriptFile: "setup-flow.js",
     apiState,
   });
@@ -4509,8 +4509,8 @@ test("join page claims a joined player after returning from sign-in", async () =
   });
 
   const joinPage = await bootPage({
-    html: renderJoinPage("http://localhost:3001", "join0002"),
-    url: "http://localhost:3000/join/join0002?playerId=player-returned",
+    html: renderJoinPage("http://localhost:3001", ""),
+    url: "http://localhost:3000/join?code=join0002&playerId=player-returned",
     scriptFile: "setup-flow.js",
     apiState,
   });

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -149,6 +149,7 @@ interface MockApiState {
   goalEvents: Map<string, MockGoalEvent>;
   goalSequence: number;
   lastPublicJoinRequest: { body: Record<string, unknown>; idempotencyKey: string | null } | null;
+  lastGrantAccessRequest: { leagueId: string; body: Record<string, unknown> } | null;
 }
 
 function readUiScript(fileName: string): string {
@@ -175,6 +176,7 @@ function createMockApiState(): MockApiState {
     goalEvents: new Map<string, MockGoalEvent>(),
     goalSequence: 0,
     lastPublicJoinRequest: null,
+    lastGrantAccessRequest: null,
   };
 }
 
@@ -309,6 +311,23 @@ function publicPlayer(player: MockPlayer): Omit<MockPlayer, "claimedByUserId"> {
     nickname: player.nickname,
     createdAt: player.createdAt,
     updatedAt: player.updatedAt,
+  };
+}
+
+function gamePlayerResponse(state: MockApiState, game: MockGame, player: MockPlayer): Record<string, unknown> {
+  const response = publicPlayer(player);
+  const league = state.leagues.get(game.leagueId);
+  const callerRole = league ? mockLeagueRoleForSession(state, league) : null;
+  if (callerRole !== "admin" || !player.claimedByUserId) {
+    return response;
+  }
+
+  return {
+    ...response,
+    access: {
+      userId: player.claimedByUserId,
+      role: state.leagueAccess.get(leagueAccessKey(game.leagueId, player.claimedByUserId)) ?? null,
+    },
   };
 }
 
@@ -725,6 +744,39 @@ function createMockFetch(state: MockApiState) {
       });
     }
 
+    const claimPlayerMatch = path.match(/^\/v1\/players\/([^/]+)\/claim$/);
+    if (method === "POST" && claimPlayerMatch) {
+      const playerId = decodeURIComponent(claimPlayerMatch[1]);
+      const player = state.players.get(playerId);
+      if (!player) {
+        return createJsonResponse(404, {
+          error: "not_found",
+          message: `Player ${playerId} was not found.`,
+        });
+      }
+
+      if (player.claimedByUserId && player.claimedByUserId !== state.session.email) {
+        return createJsonResponse(409, {
+          error: "conflict",
+          code: "player_already_claimed",
+          message: `Player ${playerId} has already been claimed.`,
+        });
+      }
+
+      const updated = {
+        ...player,
+        claimedByUserId: state.session.email,
+        updatedAt: "2026-03-28T11:00:13.000Z",
+      };
+      state.players.set(playerId, updated);
+      return createJsonResponse(200, {
+        player: publicPlayer(updated),
+        claim: {
+          claimedByCurrentUser: true,
+        },
+      });
+    }
+
     if (method === "GET" && path === "/v1/leagues") {
       return createJsonResponse(200, {
         leagues: [...state.leagues.values()].sort((left, right) => left.name.localeCompare(right.name)),
@@ -769,6 +821,44 @@ function createMockFetch(state: MockApiState) {
         access: {
           role,
         },
+      });
+    }
+
+    const leagueAccessMatch = path.match(/^\/v1\/leagues\/([^/]+)\/access$/);
+    if (method === "POST" && leagueAccessMatch) {
+      const leagueId = decodeURIComponent(leagueAccessMatch[1]);
+      const league = state.leagues.get(leagueId);
+      if (!league) {
+        return createJsonResponse(404, { error: "not_found", message: "League not found." });
+      }
+
+      const callerRole = mockLeagueRoleForSession(state, league);
+      if (callerRole !== "admin") {
+        return createJsonResponse(403, {
+          error: "forbidden",
+          code: "admin_required",
+          message: `Admin role is required for league ${leagueId}.`,
+        });
+      }
+
+      const userId = String(body.userId ?? "");
+      const role = body.role === "admin" ? "admin" : body.role === "scorekeeper" ? "scorekeeper" : null;
+      if (!userId || !role) {
+        return createJsonResponse(400, {
+          error: "bad_request",
+          message: "userId and role are required.",
+        });
+      }
+
+      state.lastGrantAccessRequest = { leagueId, body };
+      grantMockLeagueAccess(state, leagueId, userId, role);
+      return createJsonResponse(200, {
+        leagueId,
+        userId,
+        role,
+        grantedByUserId: state.session.email,
+        createdAt: "2026-03-28T11:00:14.000Z",
+        updatedAt: "2026-03-28T11:00:14.000Z",
       });
     }
 
@@ -1099,7 +1189,7 @@ function createMockFetch(state: MockApiState) {
       const players = [...state.players.values()]
         .filter((player) => linkedPlayerIds.has(player.playerId))
         .filter((player) => search.length === 0 || player.nickname.toLowerCase().includes(search))
-        .map((player) => publicPlayer(player));
+        .map((player) => gamePlayerResponse(state, game, player));
       return createJsonResponse(200, {
         players,
       });
@@ -2043,6 +2133,93 @@ test("game page quick-creates and assigns roster players", async () => {
   assert.equal(apiState.games.get("game-1")?.thirds[1].startedAt, "2026-03-28T11:00:10.000Z");
   assert.equal(saveGoalButton.disabled, false);
   assert.match(goalFormNote.textContent ?? "", /third 2/);
+});
+
+test("game page lets league admins promote claimed players to scorers", async () => {
+  const apiState = createMockApiState();
+  seedGoalScoringGame(apiState, {
+    gameId: "game-delegate-scorer",
+    role: "admin",
+    sessionEmail: "organizer@3fc.football",
+  });
+  apiState.players.set("player-delegate", {
+    playerId: "player-delegate",
+    nickname: "Delegate",
+    claimedByUserId: "delegate@3fc.football",
+    createdAt: "2026-03-28T11:00:09.000Z",
+    updatedAt: "2026-03-28T11:00:09.000Z",
+  });
+  apiState.gamePlayers.set("game-delegate-scorer:player-delegate", {
+    gameId: "game-delegate-scorer",
+    playerId: "player-delegate",
+    createdAt: "2026-03-28T11:00:09.000Z",
+    updatedAt: "2026-03-28T11:00:09.000Z",
+  });
+
+  const page = await bootPage({
+    html: renderGamePage("http://localhost:3001", { gameId: "game-delegate-scorer" }),
+    url: "http://localhost:3000/games/game-delegate-scorer",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+
+  const playerPool = page.document.getElementById("player-pool");
+  const makeScorerButton = page.document.querySelector(
+    '[data-action="grant-player-access"][data-user-id="delegate@3fc.football"][data-role="scorekeeper"]',
+  );
+  assert(playerPool instanceof page.window.HTMLElement);
+  assert(makeScorerButton instanceof page.window.HTMLButtonElement);
+  assert.match(playerPool.textContent ?? "", /delegate@3fc\.football/);
+
+  dispatchClick(makeScorerButton);
+  await flushAsync();
+
+  assert.equal(
+    apiState.leagueAccess.get(leagueAccessKey("three-sided-football-club", "delegate@3fc.football")),
+    "scorekeeper",
+  );
+  assert.deepEqual(apiState.lastGrantAccessRequest, {
+    leagueId: "three-sided-football-club",
+    body: {
+      userId: "delegate@3fc.football",
+      role: "scorekeeper",
+    },
+  });
+  assert.equal(page.document.getElementById("setup-status")?.textContent, "Player can now score this league's games.");
+});
+
+test("game page hides claimed-player emails and access controls from scorekeepers", async () => {
+  const apiState = createMockApiState();
+  seedGoalScoringGame(apiState, {
+    gameId: "game-delegate-hidden",
+    role: "scorekeeper",
+    sessionEmail: "scorekeeper@3fc.football",
+  });
+  apiState.players.set("player-delegate", {
+    playerId: "player-delegate",
+    nickname: "Delegate",
+    claimedByUserId: "delegate@3fc.football",
+    createdAt: "2026-03-28T11:00:09.000Z",
+    updatedAt: "2026-03-28T11:00:09.000Z",
+  });
+  apiState.gamePlayers.set("game-delegate-hidden:player-delegate", {
+    gameId: "game-delegate-hidden",
+    playerId: "player-delegate",
+    createdAt: "2026-03-28T11:00:09.000Z",
+    updatedAt: "2026-03-28T11:00:09.000Z",
+  });
+
+  const page = await bootPage({
+    html: renderGamePage("http://localhost:3001", { gameId: "game-delegate-hidden" }),
+    url: "http://localhost:3000/games/game-delegate-hidden",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+
+  const playerPool = page.document.getElementById("player-pool");
+  assert(playerPool instanceof page.window.HTMLElement);
+  assert.equal(page.document.querySelector('[data-action="grant-player-access"]'), null);
+  assert.doesNotMatch(playerPool.textContent ?? "", /delegate@3fc\.football/);
 });
 
 test("game page mode panels switch without resetting a goal draft", async () => {
@@ -4150,6 +4327,20 @@ test("join page registers a player without organizer authentication", async () =
   assert.equal(joinPage.document.getElementById("join-result")?.hidden, false);
   assert.equal(joinPage.document.getElementById("join-result-player")?.textContent, "Cy");
   assert.equal(joinPage.document.getElementById("join-result-game")?.textContent, "game-join-1");
+  const claimActions = joinPage.document.getElementById("join-claim-actions");
+  const signInLink = joinPage.document.getElementById("join-signin-link");
+  const claimButton = joinPage.document.querySelector('[data-testid="claim-player"]');
+  assert(claimActions instanceof joinPage.window.HTMLElement);
+  assert(signInLink instanceof joinPage.window.HTMLAnchorElement);
+  assert(claimButton instanceof joinPage.window.HTMLButtonElement);
+  assert.equal(claimActions.hidden, false);
+  assert.equal(claimButton.hidden, true);
+  const signInHref = signInLink.getAttribute("href") ?? "";
+  assert.match(signInHref, /^\/sign-in\?returnTo=/);
+  assert.equal(
+    new URL(signInHref, "http://localhost:3000").searchParams.get("returnTo"),
+    `/join/join0001?playerId=${player.playerId}`,
+  );
 
   const secondJoinPage = await bootPage({
     html: renderJoinPage("http://localhost:3001", "join0001"),
@@ -4172,6 +4363,87 @@ test("join page registers a player without organizer authentication", async () =
   assert.notEqual(secondJoinKey, firstJoinKey);
   assert.equal(apiState.players.size, 2);
   assert.equal(apiState.storage.has("threefc-idempotency:join-player:JOIN0001-Cy"), false);
+});
+
+test("join page lets a signed-in participant claim their joined player", async () => {
+  const apiState = createMockApiState();
+  apiState.session = {
+    sessionId: "session-player",
+    email: "delegate@3fc.football",
+    createdAt: "2026-03-28T11:00:00.000Z",
+    expiresAt: "2026-03-29T11:00:00.000Z",
+  };
+  apiState.cookieJar = "threefc_session=session-player";
+  apiState.games.set("game-join-claim", {
+    gameId: "game-join-claim",
+    joinCode: "JOIN0002",
+    leagueId: "autumn-league",
+    seasonId: "autumn-cup",
+    sessionId: "20260328",
+    status: "scheduled",
+    gameStartTs: "2026-03-28T10:00:00.000Z",
+    thirdLengthMinutes: DEFAULT_THIRD_LENGTH_MINUTES,
+    thirds: createDefaultThirdTimerSegments(),
+    finishedAt: null,
+    result: null,
+    createdAt: "2026-03-28T11:00:03.000Z",
+    updatedAt: "2026-03-28T11:00:03.000Z",
+  });
+
+  const joinPage = await bootPage({
+    html: renderJoinPage("http://localhost:3001", "join0002"),
+    url: "http://localhost:3000/join/join0002",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+
+  const nicknameInput = joinPage.document.getElementById("join-player-nickname");
+  const form = joinPage.document.getElementById("join-game-form");
+  assert(nicknameInput instanceof joinPage.window.HTMLInputElement);
+  assert(form instanceof joinPage.window.HTMLFormElement);
+
+  nicknameInput.value = "Dee";
+  nicknameInput.dispatchEvent(new joinPage.window.Event("input", { bubbles: true }));
+  dispatchSubmit(form);
+  await flushAsync();
+
+  const player = [...apiState.players.values()][0];
+  assert(player);
+  assert.equal(player.claimedByUserId, "delegate@3fc.football");
+  assert.equal(joinPage.document.getElementById("join-claim-status")?.textContent, "Player claimed. The organiser can now make this account a scorer.");
+  const claimButton = joinPage.document.querySelector('[data-testid="claim-player"]');
+  assert(claimButton instanceof joinPage.window.HTMLButtonElement);
+  assert.equal(claimButton.disabled, true);
+});
+
+test("join page claims a joined player after returning from sign-in", async () => {
+  const apiState = createMockApiState();
+  apiState.session = {
+    sessionId: "session-player",
+    email: "delegate@3fc.football",
+    createdAt: "2026-03-28T11:00:00.000Z",
+    expiresAt: "2026-03-29T11:00:00.000Z",
+  };
+  apiState.cookieJar = "threefc_session=session-player";
+  apiState.players.set("player-returned", {
+    playerId: "player-returned",
+    nickname: "Dee",
+    claimedByUserId: null,
+    createdAt: "2026-03-28T11:00:12.000Z",
+    updatedAt: "2026-03-28T11:00:12.000Z",
+  });
+
+  const joinPage = await bootPage({
+    html: renderJoinPage("http://localhost:3001", "join0002"),
+    url: "http://localhost:3000/join/join0002?playerId=player-returned",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+
+  await flushAsync();
+
+  assert.equal(apiState.players.get("player-returned")?.claimedByUserId, "delegate@3fc.football");
+  assert.equal(joinPage.document.getElementById("join-claim-status")?.textContent, "Player claimed. The organiser can now make this account a scorer.");
 });
 
 test("join page preserves distinct retry keys for similar public nicknames", async () => {

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -4517,8 +4517,100 @@ test("join page claims a joined player after returning from sign-in", async () =
 
   await flushAsync();
 
+  assert.equal(apiState.players.get("player-returned")?.claimedByUserId, null);
+  assert.equal(joinPage.document.getElementById("join-claim-status")?.textContent, "Signed in as delegate@3fc.football. Claim this player for scorer access.");
+  const claimButton = joinPage.document.querySelector('[data-testid="claim-player"]');
+  assert(claimButton instanceof joinPage.window.HTMLButtonElement);
+  assert.equal(claimButton.hidden, false);
+  assert.equal(claimButton.disabled, false);
+
+  dispatchClick(claimButton);
+  await flushAsync();
+
   assert.equal(apiState.players.get("player-returned")?.claimedByUserId, "delegate@3fc.football");
   assert.equal(joinPage.document.getElementById("join-claim-status")?.textContent, "Player claimed. The organiser can now make this account a scorer.");
+});
+
+test("join page keeps successful join state when signed-in claim fails", async () => {
+  const apiState = createMockApiState();
+  apiState.session = {
+    sessionId: "session-player",
+    email: "delegate@3fc.football",
+    createdAt: "2026-03-28T11:00:00.000Z",
+    expiresAt: "2026-03-29T11:00:00.000Z",
+  };
+  apiState.cookieJar = "threefc_session=session-player";
+  apiState.games.set("game-join-claim-fail", {
+    gameId: "game-join-claim-fail",
+    joinCode: "JOIN0003",
+    leagueId: "autumn-league",
+    seasonId: "autumn-cup",
+    sessionId: "20260328",
+    status: "scheduled",
+    gameStartTs: "2026-03-28T10:00:00.000Z",
+    thirdLengthMinutes: DEFAULT_THIRD_LENGTH_MINUTES,
+    thirds: createDefaultThirdTimerSegments(),
+    finishedAt: null,
+    result: null,
+    createdAt: "2026-03-28T11:00:03.000Z",
+    updatedAt: "2026-03-28T11:00:03.000Z",
+  });
+
+  const defaultFetch = createMockFetch(apiState);
+  const failingClaimFetch: ReturnType<typeof createMockFetch> = async (input, init = {}) => {
+    const target =
+      typeof input === "string" || input instanceof URL
+        ? new URL(String(input))
+        : new URL(input.url);
+    const method = (init.method ?? "GET").toUpperCase();
+
+    if (method === "POST" && target.pathname.startsWith("/v1/players/") && target.pathname.endsWith("/claim")) {
+      return createJsonResponse(503, {
+        error: "temporary_failure",
+        message: "Claim service unavailable.",
+      });
+    }
+
+    return defaultFetch(input, init);
+  };
+
+  const joinPage = await bootPage({
+    html: renderJoinPage("http://localhost:3001", ""),
+    url: "http://localhost:3000/join?code=join0003",
+    scriptFile: "setup-flow.js",
+    apiState,
+    fetch: failingClaimFetch,
+  });
+
+  const nicknameInput = joinPage.document.getElementById("join-player-nickname");
+  const form = joinPage.document.getElementById("join-game-form");
+  const joinButton = joinPage.document.querySelector('[data-testid="join-game"]');
+  assert(nicknameInput instanceof joinPage.window.HTMLInputElement);
+  assert(form instanceof joinPage.window.HTMLFormElement);
+  assert(joinButton instanceof joinPage.window.HTMLButtonElement);
+
+  nicknameInput.value = "Ez";
+  nicknameInput.dispatchEvent(new joinPage.window.Event("input", { bubbles: true }));
+  dispatchSubmit(form);
+  await flushAsync();
+
+  const player = [...apiState.players.values()][0];
+  assert(player);
+  assert.equal(player.nickname, "Ez");
+  assert.equal(player.claimedByUserId, null);
+  assert.equal(apiState.players.size, 1);
+  assert.equal(apiState.gamePlayers.has(`game-join-claim-fail:${player.playerId}`), true);
+  assert.equal(joinPage.document.getElementById("join-result")?.hidden, false);
+  assert.equal(joinPage.document.getElementById("join-result-player")?.textContent, "Ez");
+  assert.equal(joinPage.document.getElementById("setup-status")?.textContent, "Joined game. Player claim failed.");
+  assert.equal(joinPage.document.getElementById("setup-error")?.textContent, "Claim service unavailable.");
+  assert.equal(nicknameInput.disabled, true);
+  assert.equal(joinButton.disabled, true);
+
+  const claimButton = joinPage.document.querySelector('[data-testid="claim-player"]');
+  assert(claimButton instanceof joinPage.window.HTMLButtonElement);
+  assert.equal(claimButton.hidden, false);
+  assert.equal(claimButton.disabled, false);
 });
 
 test("join page preserves distinct retry keys for similar public nicknames", async () => {

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -2360,6 +2360,7 @@ test("game page mode panels advance from setup to run and finalisation", async (
   const startThirdButton = page.document.querySelector('[data-action="start-active-third"]');
   const finishThirdButton = page.document.querySelector('[data-action="finish-active-third"]');
   const finishGameButton = page.document.querySelector('[data-action="finish-game"]');
+  const timerDisplay = page.document.getElementById("timer-display");
   const resultSummary = page.document.getElementById("game-result-summary");
   const finalReadiness = page.document.getElementById("final-game-readiness");
   const thirdStatusList = page.document.getElementById("third-status-list");
@@ -2374,6 +2375,7 @@ test("game page mode panels advance from setup to run and finalisation", async (
   assert(startThirdButton instanceof page.window.HTMLButtonElement);
   assert(finishThirdButton instanceof page.window.HTMLButtonElement);
   assert(finishGameButton instanceof page.window.HTMLButtonElement);
+  assert(timerDisplay instanceof page.window.HTMLElement);
   assert(resultSummary instanceof page.window.HTMLElement);
   assert(finalReadiness instanceof page.window.HTMLElement);
   assert(thirdStatusList instanceof page.window.HTMLElement);
@@ -2412,7 +2414,7 @@ test("game page mode panels advance from setup to run and finalisation", async (
   dispatchClick(gameStateTab);
   await flushAsync();
   assert.equal(runMode.hidden, false);
-  assert.equal(page.document.activeElement, finishThirdButton);
+  assert.equal(page.document.activeElement, timerDisplay);
 
   dispatchClick(finishThirdButton);
   await flushAsync();
@@ -2672,6 +2674,79 @@ test("game page renders final team logs and aggregate player stats", async () =>
   assert.equal(fullGoalLog.querySelectorAll('[data-ui="final-goal-item"]').length, 3);
   assert.match(fullGoalLog.textContent ?? "", /43"/);
   assert.match(fullGoalLog.textContent ?? "", /Third 2/);
+});
+
+test("game page converts partial goal times into full-match football notation", async () => {
+  const apiState = createMockApiState();
+  const completeThirds = createDefaultThirdTimerSegments().map((third) => ({
+    ...third,
+    startedAt: `2026-03-28T11:0${third.third}:00.000Z`,
+    finishedAt: `2026-03-28T11:1${third.third}:00.000Z`,
+  }));
+  seedGoalScoringGame(apiState, {
+    gameId: "game-football-time-format",
+    status: "finished",
+    thirds: completeThirds,
+  });
+
+  const seededGame = apiState.games.get("game-football-time-format");
+  assert(seededGame);
+  seededGame.thirdLengthMinutes = 25;
+
+  apiState.goalEvents.set("goal-partial-second-third", {
+    gameId: "game-football-time-format",
+    eventId: "goal-partial-second-third",
+    third: 2,
+    thirdMinute: 18,
+    gameMinute: 0,
+    elapsedSeconds: 0,
+    stoppageMinute: null,
+    displayTime: "18:00",
+    scoringTeamId: "blue",
+    concedingTeamId: "yellow",
+    scorerPlayerId: "player-cy",
+    assistPlayerIds: [],
+    ownGoal: false,
+    createdAt: "2026-03-28T11:01:01.000Z",
+    updatedAt: "2026-03-28T11:01:01.000Z",
+  });
+  apiState.goalEvents.set("goal-partial-stoppage", {
+    gameId: "game-football-time-format",
+    eventId: "goal-partial-stoppage",
+    third: 1,
+    thirdMinute: 25,
+    gameMinute: 0,
+    elapsedSeconds: 1680,
+    stoppageMinute: 3,
+    displayTime: "25+03",
+    scoringTeamId: null,
+    concedingTeamId: "red",
+    scorerPlayerId: "player-bea",
+    assistPlayerIds: [],
+    ownGoal: true,
+    createdAt: "2026-03-28T11:01:02.000Z",
+    updatedAt: "2026-03-28T11:01:02.000Z",
+  });
+  refreshMockFinishedResult(apiState, seededGame, "2026-03-28T11:02:00.000Z");
+
+  const page = await bootPage({
+    html: renderGamePage("http://localhost:3001", { gameId: "game-football-time-format" }),
+    url: "http://localhost:3000/games/game-football-time-format",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+
+  const resultSummary = page.document.getElementById("game-result-summary");
+  const fullGoalLog = page.document.querySelector('[data-testid="final-full-goal-log"]');
+
+  assert(resultSummary instanceof page.window.HTMLElement);
+  assert(fullGoalLog instanceof page.window.HTMLElement);
+  assert.equal(resultSummary.hidden, false);
+  assert.match(resultSummary.textContent ?? "", /43"/);
+  assert.match(resultSummary.textContent ?? "", /25\+3"/);
+  assert.match(fullGoalLog.textContent ?? "", /43"/);
+  assert.match(fullGoalLog.textContent ?? "", /25\+3"/);
+  assert.doesNotMatch(resultSummary.textContent ?? "", /18:00|25\+03|UTC|Z\b/);
 });
 
 test("game page remains usable when goal timeline load fails", async () => {

--- a/app/src/tests/ui-layout.test.ts
+++ b/app/src/tests/ui-layout.test.ts
@@ -281,4 +281,7 @@ test("join page renders player registration shell", () => {
   assert.match(html, /id="join-player-nickname"/);
   assert.match(html, /data-testid="join-game"/);
   assert.match(html, /data-testid="join-result"/);
+  assert.match(html, /data-testid="join-claim-actions"/);
+  assert.match(html, /data-testid="join-signin-link"/);
+  assert.match(html, /data-testid="claim-player"/);
 });

--- a/app/src/tests/ui-layout.test.ts
+++ b/app/src/tests/ui-layout.test.ts
@@ -224,6 +224,7 @@ test("game page renders editable game metadata view", () => {
   assert.match(html, /data-testid="run-latest-goals"/);
   assert.match(html, /data-testid="panel-game-timer"/);
   assert.match(html, /data-testid="third-timer"/);
+  assert.match(html, /data-testid="timer-display"/);
   assert.match(html, /data-testid="start-third"/);
   assert.match(html, /data-testid="finish-third"/);
   assert.match(html, /data-testid="finish-game"/);

--- a/app/src/ui/layout.ts
+++ b/app/src/ui/layout.ts
@@ -802,7 +802,7 @@ export function renderGamePage(apiBaseUrl: string, input: GameContextPageInput):
     </header>
     <div data-ui="timer-board" data-testid="third-timer">
       <div data-ui="run-timer-bar" data-testid="run-timer-bar">
-        <div data-ui="timer-display">
+        <div data-ui="timer-display" id="timer-display" data-testid="timer-display" tabindex="-1">
           <span id="timer-third-label">Third 1</span>
           <strong id="timer-display-value">00:00</strong>
           <span id="timer-phase-label">Not started</span>

--- a/app/src/ui/layout.ts
+++ b/app/src/ui/layout.ts
@@ -689,7 +689,18 @@ export function renderJoinPage(apiBaseUrl: string, joinCode: string): string {
             <dl data-ui="id-preview" data-testid="join-result" id="join-result" hidden>
               <div><dt>Player</dt><dd id="join-result-player"></dd></div>
               <div><dt>Game</dt><dd id="join-result-game"></dd></div>
-            </dl>`,
+            </dl>
+            <section data-ui="claim-panel" data-testid="join-claim-actions" id="join-claim-actions" hidden>
+              <p data-ui="field-hint" id="join-claim-status">Sign in to claim this player for scoring access.</p>
+              <div data-ui="button-row">
+                <a data-ui="button-secondary" id="join-signin-link" data-testid="join-signin-link" href="/sign-in">Sign in to claim</a>
+                ${renderButton("Claim player", "primary", {
+                  type: "button",
+                  "data-action": "claim-player",
+                  "data-testid": "claim-player",
+                })}
+              </div>
+            </section>`,
             "",
             "panel-join-player",
           )}

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -672,6 +672,43 @@
     };
   }
 
+  function normalizePositiveInteger(value) {
+    return Number.isInteger(value) && value > 0 ? value : null;
+  }
+
+  function normalizePositiveNumber(value) {
+    return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : null;
+  }
+
+  function regulationMinuteForElapsedSeconds(totalSeconds, thirdLengthMinutes) {
+    const safeSeconds = Math.max(0, Math.floor(totalSeconds));
+    const nominalSeconds = thirdLengthMinutes * 60;
+    return Math.max(1, Math.min(thirdLengthMinutes, Math.floor(Math.min(safeSeconds, nominalSeconds) / 60) + 1));
+  }
+
+  function fullMatchMinuteForThird(third, thirdMinute, thirdLengthMinutes) {
+    const safeThird = normalizePositiveInteger(third);
+    const safeThirdMinute = normalizePositiveInteger(thirdMinute);
+    if (!safeThird || !safeThirdMinute) {
+      return null;
+    }
+
+    return (safeThird - 1) * thirdLengthMinutes + Math.min(safeThirdMinute, thirdLengthMinutes);
+  }
+
+  function fullMatchMinuteForThirdElapsed(third, elapsedSecondsValue, thirdLengthMinutes) {
+    const safeThird = normalizePositiveInteger(third);
+    const safeElapsedSeconds = normalizePositiveNumber(elapsedSecondsValue);
+    if (!safeThird || safeElapsedSeconds === null) {
+      return null;
+    }
+
+    return (
+      (safeThird - 1) * thirdLengthMinutes +
+      regulationMinuteForElapsedSeconds(safeElapsedSeconds, thirdLengthMinutes)
+    );
+  }
+
   function humanTimerStatus(value) {
     const labels = {
       not_started: "Not started",
@@ -1390,6 +1427,7 @@
     const timerThirdLength = document.getElementById("timer-third-length");
     const timerStatus = document.getElementById("timer-status");
     const timerActiveThird = document.getElementById("timer-active-third");
+    const timerDisplayElement = document.getElementById("timer-display");
     const thirdStatusList = document.getElementById("third-status-list");
     const startThirdButton = root.querySelector('[data-action="start-active-third"]');
     const finishThirdButton = root.querySelector('[data-action="finish-active-third"]');
@@ -1741,7 +1779,7 @@
 
       setGameMode("run");
       const activeSegment = timer.thirds.find((third) => third.status === "running") ?? null;
-      focusElementAction(activeSegment ? finishThirdButton : startThirdButton);
+      focusElementAction(activeSegment ? timerDisplayElement : startThirdButton);
       return true;
     }
 
@@ -2318,33 +2356,53 @@
     }
 
     function goalDisplayTime(goal) {
-      if (Number.isInteger(goal.gameMinute) && goal.gameMinute > 0) {
-        if (Number.isInteger(goal.stoppageMinute) && goal.stoppageMinute > 0) {
-          return `${goal.gameMinute}+${goal.stoppageMinute}"`;
+      const thirdLength = parseThirdLengthMinutes(currentGame?.thirdLengthMinutes ?? currentGame?.timer?.thirdLengthMinutes);
+      const stoppageMinute = normalizePositiveInteger(goal.stoppageMinute);
+      const safeThird = normalizePositiveInteger(goal.third);
+      if (stoppageMinute) {
+        const stoppageBaseMinute = safeThird
+          ? safeThird * thirdLength
+          : normalizePositiveInteger(goal.gameMinute);
+        if (stoppageBaseMinute) {
+          return `${stoppageBaseMinute}+${stoppageMinute}"`;
         }
-
-        return `${goal.gameMinute}"`;
       }
 
-      const thirdLength = parseThirdLengthMinutes(currentGame?.thirdLengthMinutes ?? currentGame?.timer?.thirdLengthMinutes);
-      if (Number.isInteger(goal.third) && Number.isInteger(goal.thirdMinute) && goal.third > 0 && goal.thirdMinute > 0) {
-        const regulationMinute = (goal.third - 1) * thirdLength + Math.min(goal.thirdMinute, thirdLength);
-        if (Number.isInteger(goal.stoppageMinute) && goal.stoppageMinute > 0) {
-          return `${goal.third * thirdLength}+${goal.stoppageMinute}"`;
-        }
-
+      const regulationMinute = fullMatchMinuteForThird(goal.third, goal.thirdMinute, thirdLength);
+      if (regulationMinute) {
         return `${regulationMinute}"`;
+      }
+
+      const elapsedMinute = fullMatchMinuteForThirdElapsed(goal.third, goal.elapsedSeconds, thirdLength);
+      if (elapsedMinute) {
+        return `${elapsedMinute}"`;
+      }
+
+      if (Number.isInteger(goal.gameMinute) && goal.gameMinute > 0) {
+        return `${goal.gameMinute}"`;
       }
 
       if (typeof goal.displayTime === "string" && goal.displayTime.length > 0) {
         const stoppageMatch = goal.displayTime.match(/^(\d+)\+0?(\d+)$/);
         if (stoppageMatch) {
-          return `${stoppageMatch[1]}+${Number.parseInt(stoppageMatch[2], 10)}"`;
+          const stoppageBaseMinute = safeThird
+            ? safeThird * thirdLength
+            : Number.parseInt(stoppageMatch[1], 10);
+          return `${stoppageBaseMinute}+${Number.parseInt(stoppageMatch[2], 10)}"`;
         }
 
         const clockMatch = goal.displayTime.match(/^(\d+):\d{2}$/);
         if (clockMatch) {
-          return `${Math.max(1, Number.parseInt(clockMatch[1], 10))}"`;
+          const periodMinute = Math.max(1, Number.parseInt(clockMatch[1], 10));
+          if (safeThird) {
+            return `${(safeThird - 1) * thirdLength + Math.min(periodMinute, thirdLength)}"`;
+          }
+          return `${periodMinute}"`;
+        }
+
+        const decimalMinuteMatch = goal.displayTime.match(/^(\d+(?:\.\d+)?)$/);
+        if (decimalMinuteMatch) {
+          return `${Math.max(1, Math.ceil(Number.parseFloat(decimalMinuteMatch[1])))}"`;
         }
 
         const minuteMatch = goal.displayTime.match(/^(\d+)'?$/);

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -548,6 +548,15 @@
     return result.body;
   }
 
+  async function currentAuthenticatedSession() {
+    const result = await requestJson("/v1/auth/session", { method: "GET" });
+    if (!result.ok) {
+      return null;
+    }
+
+    return result.body?.session ?? null;
+  }
+
   function toIsoTimestamp(localDateTime) {
     const parsed = new Date(localDateTime);
     if (Number.isNaN(parsed.getTime())) {
@@ -2739,6 +2748,37 @@
         .join("");
     }
 
+    function playerAccessPanel(player) {
+      if (currentLeagueRole !== "admin") {
+        return "";
+      }
+
+      const access = player?.access;
+      if (!access || typeof access.userId !== "string" || access.userId.length === 0) {
+        return `<div data-ui="player-access" data-testid="player-access">
+          <small>Not claimed</small>
+        </div>`;
+      }
+
+      const role = normalizeLeagueRole(access.role);
+      const roleLabel =
+        role === "admin" ? "Co-organiser" : role === "scorekeeper" ? "Scorer" : "Claimed";
+      const scorerDisabled = role === "scorekeeper" || role === "admin" ? " disabled" : "";
+      const adminDisabled = role === "admin" ? " disabled" : "";
+
+      return `<div data-ui="player-access" data-testid="player-access">
+        <small>${escapeHtml(roleLabel)} · ${escapeHtml(access.userId)}</small>
+        <div data-ui="access-actions">
+          <button data-ui="row-action" type="button" data-action="grant-player-access" data-user-id="${escapeHtml(
+            access.userId,
+          )}" data-role="scorekeeper"${scorerDisabled}>Make scorer</button>
+          <button data-ui="row-action" type="button" data-action="grant-player-access" data-user-id="${escapeHtml(
+            access.userId,
+          )}" data-role="admin"${adminDisabled}>Make co-organiser</button>
+        </div>
+      </div>`;
+    }
+
     function renderPlayerPool() {
       if (!(playerPoolElement instanceof HTMLElement)) {
         return;
@@ -2753,16 +2793,17 @@
         .map((player) => {
           const assignment = assignmentByPlayerId(player.playerId);
           const assignedTeam = assignment ? teamById(assignment.teamId) : null;
-          const statusText = assignedTeam ? `Assigned to ${assignedTeam.name}` : "Unassigned";
-          return `<article data-ui="roster-player" data-player-id="${escapeHtml(player.playerId)}">
-            <figure data-ui="avatar"><span>${escapeHtml(initialsForName(player.nickname))}</span></figure>
-            <div data-ui="roster-player-main">
-              <strong>${escapeHtml(player.nickname)}</strong>
-              <span>${escapeHtml(statusText)}</span>
-            </div>
-            <div data-ui="row-action-buttons">
-              ${assignmentButtons(player.playerId, assignment?.teamId ?? null)}
-            </div>
+	          const statusText = assignedTeam ? `Assigned to ${assignedTeam.name}` : "Unassigned";
+	          return `<article data-ui="roster-player" data-player-id="${escapeHtml(player.playerId)}">
+	            <figure data-ui="avatar"><span>${escapeHtml(initialsForName(player.nickname))}</span></figure>
+	            <div data-ui="roster-player-main">
+	              <strong>${escapeHtml(player.nickname)}</strong>
+	              <span>${escapeHtml(statusText)}</span>
+	              ${playerAccessPanel(player)}
+	            </div>
+	            <div data-ui="row-action-buttons">
+	              ${assignmentButtons(player.playerId, assignment?.teamId ?? null)}
+	            </div>
           </article>`;
         })
         .join("");
@@ -2961,6 +3002,9 @@
         currentLeagueRole = null;
       }
 
+      if (rosterControlsAvailable()) {
+        renderRosterSetup();
+      }
       renderLiveScoring();
     }
 
@@ -3238,7 +3282,52 @@
           return;
         }
 
-        if (target.getAttribute("data-action") !== "assign-player") {
+        const action = target.getAttribute("data-action");
+        if (action === "grant-player-access") {
+          if (currentLeagueRole !== "admin") {
+            return;
+          }
+
+          const userId = target.getAttribute("data-user-id");
+          const role = target.getAttribute("data-role");
+          if (!currentLeagueId || !userId || (role !== "scorekeeper" && role !== "admin")) {
+            return;
+          }
+
+          target.disabled = true;
+          clearError();
+          setStatus("Updating scorer access…", "default");
+
+          try {
+            await requestJsonOrThrow(`/v1/leagues/${encodeURIComponent(currentLeagueId)}/access`, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                userId,
+                role,
+              }),
+            });
+
+            await loadRosterSetup({ updateStatus: false });
+            setStatus(
+              role === "admin"
+                ? "Player can now co-organise and score."
+                : "Player can now score this league's games.",
+              "success",
+            );
+          } catch (error) {
+            const message = error instanceof Error ? error.message : "Could not update scorer access.";
+            showError(message);
+            setStatus("Scorer access update failed.", "error");
+          } finally {
+            target.disabled = false;
+          }
+          return;
+        }
+
+        if (action !== "assign-player") {
           return;
         }
 
@@ -3498,9 +3587,7 @@
 
     syncGameModeState();
     await loadGame();
-    if (isGameFinished()) {
-      await loadLeagueAccess();
-    }
+    await loadLeagueAccess();
     await loadRosterSetup({ updateStatus: false });
     const goalsLoaded = await loadGameGoals();
     if (!manualGameModeSelected) {
@@ -3517,7 +3604,7 @@
       if (gameLeagueLink instanceof HTMLAnchorElement) {
         gameLeagueLink.href = `/leagues/${encodeURIComponent(currentLeagueId)}`;
       }
-      if (isGameFinished() && currentLeagueId !== previousLeagueId) {
+      if (currentLeagueId !== previousLeagueId) {
         await loadLeagueAccess();
       }
     } catch {
@@ -3539,6 +3626,12 @@
     const resultElement = document.getElementById("join-result");
     const resultPlayer = document.getElementById("join-result-player");
     const resultGame = document.getElementById("join-result-game");
+    const claimActions = document.getElementById("join-claim-actions");
+    const claimStatus = document.getElementById("join-claim-status");
+    const signInLink = document.getElementById("join-signin-link");
+    const claimButton = root.querySelector('[data-action="claim-player"]');
+    const initialPlayerId = new URLSearchParams(window.location.search).get("playerId") ?? "";
+    let claimPlayerId = initialPlayerId.trim();
 
     if (joinCodeValue) {
       joinCodeValue.textContent = joinCode || "Missing";
@@ -3559,6 +3652,117 @@
       clearError();
       setFieldMessage("join-player-nickname");
     });
+
+    function signInHrefForClaim(playerId) {
+      const returnTo = `${window.location.pathname}?playerId=${encodeURIComponent(playerId)}`;
+      return `/sign-in?returnTo=${encodeURIComponent(returnTo)}`;
+    }
+
+    function showClaimActions() {
+      if (claimActions instanceof HTMLElement) {
+        claimActions.hidden = false;
+      }
+    }
+
+    async function claimJoinedPlayer(playerId) {
+      if (!playerId) {
+        return;
+      }
+
+      showClaimActions();
+      if (claimStatus instanceof HTMLElement) {
+        claimStatus.textContent = "Claiming player for this account…";
+      }
+      if (claimButton instanceof HTMLButtonElement) {
+        claimButton.disabled = true;
+        claimButton.hidden = false;
+      }
+      if (signInLink instanceof HTMLAnchorElement) {
+        signInLink.hidden = true;
+      }
+
+      const result = await requestJsonOrThrow(`/v1/players/${encodeURIComponent(playerId)}/claim`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({}),
+      });
+
+      if (resultPlayer) {
+        resultPlayer.textContent = result?.player?.nickname ?? resultPlayer.textContent;
+      }
+      if (resultElement) {
+        resultElement.hidden = false;
+      }
+      if (claimStatus instanceof HTMLElement) {
+        claimStatus.textContent = "Player claimed. The organiser can now make this account a scorer.";
+      }
+      setStatus("Player claimed.", "success");
+    }
+
+    async function refreshClaimActions(playerId, options = {}) {
+      if (!playerId) {
+        return;
+      }
+
+      showClaimActions();
+      const session = await currentAuthenticatedSession();
+      if (session) {
+        if (signInLink instanceof HTMLAnchorElement) {
+          signInLink.hidden = true;
+        }
+        if (claimButton instanceof HTMLButtonElement) {
+          claimButton.hidden = false;
+          claimButton.disabled = false;
+        }
+        if (claimStatus instanceof HTMLElement) {
+          claimStatus.textContent = `Signed in as ${session.email}. Claim this player for scorer access.`;
+        }
+        if (options.autoClaim === true) {
+          await claimJoinedPlayer(playerId);
+        }
+        return;
+      }
+
+      if (claimStatus instanceof HTMLElement) {
+        claimStatus.textContent = "Sign in to claim this player so the organiser can make you a scorer.";
+      }
+      if (signInLink instanceof HTMLAnchorElement) {
+        signInLink.hidden = false;
+        signInLink.href = signInHrefForClaim(playerId);
+      }
+      if (claimButton instanceof HTMLButtonElement) {
+        claimButton.hidden = true;
+        claimButton.disabled = true;
+      }
+    }
+
+    if (claimPlayerId) {
+      void refreshClaimActions(claimPlayerId, { autoClaim: true }).catch((error) => {
+        const message = error instanceof Error ? error.message : "Could not claim player.";
+        showError(message);
+        setStatus("Player claim failed.", "error");
+        if (claimButton instanceof HTMLButtonElement) {
+          claimButton.disabled = false;
+          claimButton.hidden = false;
+        }
+      });
+    }
+
+    if (claimButton instanceof HTMLButtonElement) {
+      claimButton.addEventListener("click", async () => {
+        clearError();
+        try {
+          await claimJoinedPlayer(claimPlayerId);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : "Could not claim player.";
+          showError(message);
+          setStatus("Player claim failed.", "error");
+          claimButton.disabled = false;
+        }
+      });
+    }
 
     form.addEventListener("submit", async (event) => {
       event.preventDefault();
@@ -3590,6 +3794,7 @@
         });
 
         clearIdempotencyKeyForPublicJoin(joinCode, nickname);
+        claimPlayerId = result?.player?.playerId ?? "";
         setFieldMessage("join-player-nickname", "valid", "Joined.");
         setStatus("Joined game.", "success");
         if (resultPlayer) {
@@ -3601,6 +3806,7 @@
         if (resultElement) {
           resultElement.hidden = false;
         }
+        await refreshClaimActions(claimPlayerId, { autoClaim: true });
       } catch (error) {
         const message = error instanceof Error ? error.message : "Could not join game.";
         showError(message);

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -3007,7 +3007,7 @@
       }
       if (gameJoinLink instanceof HTMLAnchorElement) {
         if (typeof game.joinCode === "string" && game.joinCode.length > 0) {
-          const joinPath = `/join/${encodeURIComponent(game.joinCode)}`;
+          const joinPath = `/join?code=${encodeURIComponent(game.joinCode)}`;
           const joinUrl = new URL(joinPath, window.location.origin).toString();
           gameJoinLink.href = joinUrl;
           gameJoinLink.textContent = joinUrl;
@@ -3675,7 +3675,9 @@
   }
 
   async function initJoinPage() {
-    const routeJoinCode = resolveRouteEntityId("data-join-code", "join") ?? "";
+    const searchParams = new URLSearchParams(window.location.search);
+    const queryJoinCode = searchParams.get("code") ?? "";
+    const routeJoinCode = queryJoinCode || resolveRouteEntityId("data-join-code", "join") || "";
     const joinCode = routeJoinCode.trim().toUpperCase();
     const joinCodeValue = document.getElementById("join-code-value");
     const form = document.getElementById("join-game-form");
@@ -3688,7 +3690,7 @@
     const claimStatus = document.getElementById("join-claim-status");
     const signInLink = document.getElementById("join-signin-link");
     const claimButton = root.querySelector('[data-action="claim-player"]');
-    const initialPlayerId = new URLSearchParams(window.location.search).get("playerId") ?? "";
+    const initialPlayerId = searchParams.get("playerId") ?? "";
     let claimPlayerId = initialPlayerId.trim();
 
     if (joinCodeValue) {
@@ -3712,7 +3714,12 @@
     });
 
     function signInHrefForClaim(playerId) {
-      const returnTo = `${window.location.pathname}?playerId=${encodeURIComponent(playerId)}`;
+      const returnParams = new URLSearchParams(window.location.search);
+      returnParams.set("playerId", playerId);
+      if (!returnParams.has("code") && window.location.pathname === "/join" && joinCode) {
+        returnParams.set("code", joinCode);
+      }
+      const returnTo = `${window.location.pathname}?${returnParams.toString()}`;
       return `/sign-in?returnTo=${encodeURIComponent(returnTo)}`;
     }
 

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -3804,7 +3804,7 @@
     }
 
     if (claimPlayerId) {
-      void refreshClaimActions(claimPlayerId, { autoClaim: true }).catch((error) => {
+      void refreshClaimActions(claimPlayerId).catch((error) => {
         const message = error instanceof Error ? error.message : "Could not claim player.";
         showError(message);
         setStatus("Player claim failed.", "error");
@@ -3871,7 +3871,6 @@
         if (resultElement) {
           resultElement.hidden = false;
         }
-        await refreshClaimActions(claimPlayerId, { autoClaim: true });
       } catch (error) {
         const message = error instanceof Error ? error.message : "Could not join game.";
         showError(message);
@@ -3879,6 +3878,19 @@
         nicknameInput.disabled = false;
         if (joinButton instanceof HTMLButtonElement) {
           joinButton.disabled = false;
+        }
+        return;
+      }
+
+      try {
+        await refreshClaimActions(claimPlayerId, { autoClaim: true });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Could not claim player.";
+        showError(message);
+        setStatus("Joined game. Player claim failed.", "error");
+        if (claimButton instanceof HTMLButtonElement) {
+          claimButton.disabled = false;
+          claimButton.hidden = false;
         }
       }
     });

--- a/app/src/ui/styles.css
+++ b/app/src/ui/styles.css
@@ -601,6 +601,33 @@ body {
   }
 }
 
+[data-ui="claim-panel"],
+[data-ui="player-access"] {
+  display: grid;
+  gap: 0.45rem;
+  min-width: 0;
+  border-top: 1px solid #dce8e3;
+  padding-top: 0.55rem;
+}
+
+[data-ui="claim-panel"] {
+  margin-top: 0.7rem;
+}
+
+[data-ui="player-access"] {
+  small {
+    color: var(--ink-soft);
+    font-size: 0.76rem;
+    overflow-wrap: anywhere;
+  }
+}
+
+[data-ui="access-actions"] {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
 [data-ui="run-goal-form"] {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/app/src/ui/styles.css
+++ b/app/src/ui/styles.css
@@ -511,8 +511,9 @@ body {
 
 [data-ui="run-score-strip"] {
   position: sticky;
-  top: 4.45rem;
+  top: calc(4.45rem + env(safe-area-inset-top, 0px));
   z-index: 18;
+  align-self: start;
   border: 1px solid #c9ded7;
   border-radius: 8px;
   background: #f7fcfa;
@@ -632,6 +633,14 @@ body {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 0.6rem;
+
+  [data-ui="field"] {
+    min-width: 0;
+  }
+
+  [data-ui="input"] {
+    min-width: 0;
+  }
 }
 
 [data-ui="run-goal-form"] [data-ui="field"]:nth-of-type(3),
@@ -1386,7 +1395,7 @@ body {
 
 [data-ui="game-mode-nav"] {
   position: sticky;
-  top: 0.35rem;
+  top: calc(0.35rem + env(safe-area-inset-top, 0px));
   z-index: 20;
   width: 100%;
   max-width: 100%;

--- a/docs/openapi/v1-core-write.yaml
+++ b/docs/openapi/v1-core-write.yaml
@@ -78,6 +78,38 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "409":
           $ref: "#/components/responses/IdempotencyConflict"
+  /v1/leagues/{leagueId}/access:
+    post:
+      summary: Grant league scoring or co-organiser access
+      operationId: grantLeagueAccess
+      parameters:
+        - name: leagueId
+          in: path
+          required: true
+          schema:
+            type: string
+            minLength: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GrantLeagueAccessRequest"
+      responses:
+        "200":
+          description: League access granted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LeagueAccessGrant"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
   /v1/leagues/{leagueId}/seasons:
     post:
       summary: Create season
@@ -553,6 +585,38 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+  /v1/players/{playerId}/claim:
+    post:
+      summary: Claim a joined player for the signed-in user
+      operationId: claimPlayer
+      parameters:
+        - name: playerId
+          in: path
+          required: true
+          schema:
+            type: string
+            minLength: 1
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ClaimPlayerRequest"
+      responses:
+        "200":
+          description: Player claimed for the current signed-in user
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ClaimPlayerResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
   /v1/games/{gameId}/players:
     get:
       summary: List recent/searchable players for a game roster
@@ -876,6 +940,24 @@ components:
           type: string
           minLength: 1
           maxLength: 80
+    ClaimPlayerRequest:
+      type: object
+      additionalProperties: false
+    GrantLeagueAccessRequest:
+      type: object
+      additionalProperties: false
+      required:
+        - userId
+        - role
+      properties:
+        userId:
+          type: string
+          minLength: 1
+        role:
+          type: string
+          enum:
+            - admin
+            - scorekeeper
     AssignRosterPlayerRequest:
       type: object
       additionalProperties: false
@@ -1349,6 +1431,69 @@ components:
         playerId:
           type: string
         nickname:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        access:
+          $ref: "#/components/schemas/PlayerAccess"
+    PlayerAccess:
+      type: object
+      description: Present only to league admins when the player has claimed a signed-in user account.
+      required:
+        - userId
+        - role
+      properties:
+        userId:
+          type: string
+        role:
+          type:
+            - string
+            - "null"
+          enum:
+            - admin
+            - scorekeeper
+            - viewer
+            - null
+    ClaimPlayerResponse:
+      type: object
+      required:
+        - player
+        - claim
+      properties:
+        player:
+          $ref: "#/components/schemas/Player"
+        claim:
+          type: object
+          required:
+            - claimedByCurrentUser
+          properties:
+            claimedByCurrentUser:
+              type: boolean
+    LeagueAccessGrant:
+      type: object
+      required:
+        - leagueId
+        - userId
+        - role
+        - grantedByUserId
+        - createdAt
+        - updatedAt
+      properties:
+        leagueId:
+          type: string
+        userId:
+          type: string
+        role:
+          type: string
+          enum:
+            - admin
+            - scorekeeper
+            - viewer
+        grantedByUserId:
           type: string
         createdAt:
           type: string

--- a/scripts/deploy/deploy-site.sh
+++ b/scripts/deploy/deploy-site.sh
@@ -85,6 +85,30 @@ aws s3 cp "${STATIC_SITE_OUTPUT_DIR}/" "s3://${SITE_BUCKET_NAME}/" \
   --cache-control "no-cache, no-store, must-revalidate" \
   --content-type "text/html; charset=utf-8"
 
+upload_html_alias() {
+  local source_path="$1"
+  local object_key="$2"
+
+  if [[ ! -f "$source_path" ]]; then
+    return
+  fi
+
+  echo "[deploy] Uploading HTML alias /${object_key}"
+  aws s3 cp "$source_path" "s3://${SITE_BUCKET_NAME}/${object_key}" \
+    --cache-control "no-cache, no-store, must-revalidate" \
+    --content-type "text/html; charset=utf-8"
+}
+
+echo "[deploy] Uploading extensionless route aliases"
+upload_html_alias "${STATIC_SITE_OUTPUT_DIR}/setup/index.html" "setup"
+upload_html_alias "${STATIC_SITE_OUTPUT_DIR}/sign-in/index.html" "sign-in"
+upload_html_alias "${STATIC_SITE_OUTPUT_DIR}/auth/callback/index.html" "auth/callback"
+upload_html_alias "${STATIC_SITE_OUTPUT_DIR}/leagues/index.html" "leagues"
+upload_html_alias "${STATIC_SITE_OUTPUT_DIR}/seasons/index.html" "seasons"
+upload_html_alias "${STATIC_SITE_OUTPUT_DIR}/games/index.html" "games"
+upload_html_alias "${STATIC_SITE_OUTPUT_DIR}/join/index.html" "join"
+upload_html_alias "${STATIC_SITE_OUTPUT_DIR}/ui/components/index.html" "ui/components"
+
 echo "[deploy] Creating CloudFront invalidation for ${SITE_DISTRIBUTION_ID}"
 INVALIDATION_ID="$(
   aws cloudfront create-invalidation \

--- a/serverless.api-core.yml
+++ b/serverless.api-core.yml
@@ -119,6 +119,12 @@ functions:
           method: OPTIONS
           path: /v1/leagues/{leagueId}
       - httpApi:
+          method: POST
+          path: /v1/leagues/{leagueId}/access
+      - httpApi:
+          method: OPTIONS
+          path: /v1/leagues/{leagueId}/access
+      - httpApi:
           method: GET
           path: /v1/leagues/{leagueId}/seasons
       - httpApi:
@@ -247,6 +253,12 @@ functions:
       - httpApi:
           method: OPTIONS
           path: /v1/games/{gameId}/roster/{playerId}
+      - httpApi:
+          method: POST
+          path: /v1/players/{playerId}/claim
+      - httpApi:
+          method: OPTIONS
+          path: /v1/players/{playerId}/claim
       - httpApi:
           method: POST
           path: /v1/sessions/{sessionId}/games


### PR DESCRIPTION
<!-- review-packet-version:1 -->

## Behavioural claim

Fixes the QA join-link failure path by deploying `/join` as a static route alias, switching generated join links to `/join?code=...`, and retaining `/join/{code}` router support once the edge router is published. This also adds a joined-player delegation flow stacked on the mobile game workflow. A participant can join a game from the public link, sign in, claim their joined player with a stable session subject, and then a league admin can promote that claimed account from the game roster to scorer (`scorekeeper`) or co-organiser (`admin`). The promoted account then uses the existing authenticated scorekeeper/admin game routes, with subject/email fallback for legacy sessions and monotonic grants so stale scorer requests cannot downgrade admins. The stacked UI fixes also make run-panel goal summaries use full-match football notation, keep the live scoreboard sticky while scrolling, compact the scoring/conceding selectors, make the state chip jump to the running clock, and keep rendered timestamps in the user's local time.

## Specification and acceptance evidence

| Acceptance criterion | Evidence | Result |
| --- | --- | --- |
| Join route shells, generated join links, and deployment aliases route to the app shell instead of S3 XML errors. | `buildStaticSite exports static route shells and ui assets`; `CloudFront router maps deployed join deep links to the exported shell`; `join page registers a player without organizer authentication`; `.github/workflows/deploy-qa.yml` smokes `/join` and `/join?code=ABCDEFGH`; `npm test` at `36fd0e2` | PASS |
| Public join still registers a nickname player without organizer authentication and without accepting caller-supplied player IDs. | `join page registers a player without organizer authentication`; `join page keeps successful join state when signed-in claim fails`; `core lambda lets players join an active game by join code and appear in the player pool`; `npm test` at `36fd0e2` | PASS |
| A signed-in participant can claim the player they just joined as, including after returning from magic-link sign-in. | `join page lets a signed-in participant claim their joined player`; `join page claims a joined player after returning from sign-in`; `core lambda lets joined players claim accounts and admins delegate scorer access`; `repository claims players idempotently for one user and rejects another user`; `npm test` at `36fd0e2` | PASS |
| Player claims and user-keyed claim records use a stable session subject, while legacy sessions remain usable through email fallback. | `magic complete consumes token once and creates a session`; `core lambda lets joined players claim accounts and admins delegate scorer access`; `repository claims players idempotently for one user and rejects another user`; `resolveSessionFromCookie returns session when cookie maps to active session`; `npm test` at `36fd0e2` | PASS |
| Subject-keyed delegated ACLs work for protected routes and league discovery without breaking legacy email-keyed ACLs. | `core lambda lets joined players claim accounts and admins delegate scorer access`; `core lambda lists subject-keyed and legacy email-keyed league access`; `core lambda includes caller league role on league reads`; `npm test` at `36fd0e2` | PASS |
| Claiming a player does not itself grant scoring or organiser permissions. | Claim route writes `claimedByUserId` and the documented `USER#{userId}/PLAYER#{playerId}` claim item, but delegation is a separate `POST /v1/leagues/{leagueId}/access` admin route; `core lambda lets joined players claim accounts and admins delegate scorer access` verifies claimed access is `null` before admin grant; `npm test` at `36fd0e2` | PASS |
| League admins can promote a claimed player account to scorer or co-organiser from the game roster UI, and stale scorer grants cannot downgrade administrators. | `game page lets league admins promote claimed players to scorers`; `core lambda lets joined players claim accounts and admins delegate scorer access`; `repository grants league access monotonically without downgrading admins`; `npm test` at `36fd0e2` | PASS |
| Non-admin callers cannot delegate scorer/co-organiser access and cannot see claimed player email metadata in roster UI. | `game page hides claimed-player emails and access controls from scorekeepers`; `core lambda rejects scorer access delegation from non-admins`; `grantLeagueAccess mutation requires league admin`; `npm test` at `36fd0e2` | PASS |
| Goal summaries and timelines render full-match football notation, including later thirds and stoppage, instead of raw timer/decimal-like values. | `game page renders final team logs and aggregate player stats`; `game page converts partial goal times into full-match football notation`; `npm test` at `36fd0e2` | PASS |
| The run panel keeps match context visible and compact on mobile: sticky scoreboard, scoring/conceding selectors on one row, and the live state chip jumps to the active clock while running. | `game page renders editable game metadata view`; `game page mode panels advance from setup to run and finalisation`; `app/src/ui/styles.css`; `npm test` at `36fd0e2` | PASS |
| User-facing kickoff, third-history, and result timestamps render through local-time helpers rather than raw UTC strings. | `season page renders game kickoff times in the user local timezone`; `setup happy path runs from sign-in to created game context`; `game page mode panels advance from setup to run and finalisation`; `game page renders final team logs and aggregate player stats`; `npm test` at `36fd0e2` | PASS |
| API contract and deployment config expose the new claim and delegation endpoints plus admin-only player access metadata. | `docs/openapi/v1-core-write.yaml`; `api core deployment config registers claim and access routes`; QA/prod deploy workflows smoke unauthenticated claim/access POST routes; `npm test`; `npm run typecheck`; `git diff --check` at `36fd0e2` | PASS |
| Existing app/API/contracts checks remain green. | `npm run typecheck`; `npm test`; `git diff --check` at `36fd0e2` | PASS |

## Scope boundaries

Included: public join claim UI, sign-in return handling for player claims, stable session-subject storage for magic-link sessions, claimed-player repository mutation, authenticated claim API route, admin-only league access grant API route, monotonic ACL grants, subject/email ACL lookup fallback, admin roster delegation controls, admin-only player access metadata on game player listings, OpenAPI updates, QA join-link smoke checks, static route alias upload, run-panel sticky/compact/time-display refinements, and focused test coverage.

Excluded: per-game ACL roles, invite-token lifecycle, revoking league access, role expiry, concurrent multi-scorekeeper conflict resolution, new external identity provider integration, email delivery changes, data migrations for old records, and any change to goal scoring rules.

## Change classification

- Declared risk: `high`
- [ ] `documentation-only` - Documentation only
- [ ] `tests-only` - Tests only
- [x] `application-behaviour` - Application or API behaviour
- [ ] `backlog-maintenance` - Canonical backlog maintenance
- [ ] `dependency-tooling` - Dependency or tooling
- [x] `public-contract` - Public API or repository contract
- [ ] `data-migration` - Database schema or data migration
- [x] `permission-trust-boundary` - Permission or trust boundary
- [x] `durable-state-ownership` - Durable state or ownership
- [ ] `destructive-behaviour` - Destructive or difficult-to-reverse behaviour
- [ ] `new-production-dependency` - New production dependency
- [x] `authentication-authorisation` - Authentication or authorisation
- [x] `privacy-regulated-data` - Privacy or regulated data
- [x] `infrastructure-production-configuration` - Infrastructure or deployment control
- [ ] `review-policy` - Review policy, packet, or workflow

## Architecture and invariants

- [ ] `architecture:none`
- [x] `architecture:documented`
- [ ] `architecture:judgement-required`

### Affected invariants

| Invariant | How this PR affects it | Why it remains valid | Evidence |
| --- | --- | --- | --- |
| INV-001 | Adds claimed-user email metadata to game player list responses, but only when the caller is league admin, so the roster UI can show which account may be delegated. | Public join responses still return nickname/player fields only; scorekeepers do not receive `access` metadata and the UI test verifies claimed email text is hidden for scorekeepers. | `game page hides claimed-player emails and access controls from scorekeepers`; `core lambda lets joined players claim accounts and admins delegate scorer access`; `npm test` |
| INV-002 | Adds two protected writes: participant player claim and admin league access grant. The grant route can promote a user to the existing scorekeeper/admin trust boundary. | Claim requires a valid session but grants no league rights; grant requires existing league admin; scorekeeper delegation attempts are rejected; subject/email fallback preserves legacy ACLs; monotonic grants prevent stale requests from demoting admins. | `claimPlayer mutation is allowed for authenticated users without league access`; `grantLeagueAccess mutation requires league admin`; `core lambda rejects scorer access delegation from non-admins`; `core lambda lists subject-keyed and legacy email-keyed league access`; `repository grants league access monotonically without downgrading admins`; `npm test` |
| INV-004 | Updates player records by setting `claimedByUserId`, writes the documented `USER#{userId}/PLAYER#{playerId}` claim ownership item, and creates/updates league ACL records through the existing league ACL PK/SK ownership. | No new table/index ownership is introduced; claim uses the existing player profile plus user-keyed claim item from `docs/spec.md`, and delegation uses the existing league ACL record shape with a stable session subject where present. | `magic complete consumes token once and creates a session`; `repository claims players idempotently for one user and rejects another user`; `repository supports league discovery by user ACL`; `repository grants league access monotonically without downgrading admins`; `npm test` |

### Architecture or decision record

No ADR is required. This reuses the existing league-level `scorekeeper` and `admin` roles instead of introducing game-scoped permissions. That keeps scoring authorization on the current league ACL boundary while enabling a second scorer for any game in that league. Subject/email fallback is deliberately compatibility code for pre-existing sessions and ACLs; new player claims prefer the session subject.

## Failure and rollback

### Failure behaviour

If join static routing regresses, the QA deploy smoke now fails on `/join` or `/join?code=ABCDEFGH` instead of allowing an S3 AccessDenied XML page through. If participant claim fails after a durable join, the join result remains visible and retryable claim controls stay enabled instead of reporting the join as failed. If admin delegation fails, the target user keeps their prior league access and existing scoring permissions remain unchanged. If a stale scorer grant races after an admin promotion, the repository returns and preserves the higher admin role. If subject-keyed ACL lookup regresses, the Lambda tests fail delegated game access and league discovery. If API Gateway registration regresses for claim/access routes, deploy smoke fails on the protected unauthenticated POST checks. If admin-only metadata leaks are broken, scorekeeper UI/API tests should catch exposed claimed emails. If the run-panel presentation regresses, app E2E/layout tests should catch raw goal timer notation, raw UTC timestamp text, or the state chip failing to focus the running clock.

### Rollback approach

Revert the merge commit for this PR and redeploy the previous app/API/site workflow state. Claimed player fields, user-keyed claim items, session subjects, and ACL grants use the documented single-table item shapes; rollback does not require schema migration. Any access grants made during QA can be overwritten by a later admin grant if needed.

### Rollback evidence

The change is limited to app UI, core API routes, Serverless route registration, repository player/claim/ACL mutations, OpenAPI documentation, tests, deploy alias upload, and QA/prod route smoke coverage. Local validation passed on `36fd0e2`: `npm run typecheck`, `npm test`, and `git diff --check`.

## Automated and agent review disposition

### Unresolved blocking findings

None.

### Addressed findings and evidence

| Finding | Resolution | Evidence |
| --- | --- | --- |
| Require confirmation before claiming a URL-selected player. | Sign-in-return `playerId` no longer auto-claims; it renders the explicit claim button for the signed-in user to click. | `join page claims a joined player after returning from sign-in`; `npm test` |
| Persist claims under the documented user key. | `claimPlayer` transactionally writes `USER#{userId}/PLAYER#{playerId}` with the guarded player profile claim. | `repository claims players idempotently for one user and rejects another user`; `npm test` |
| Register the new endpoints with API Gateway. | Added POST/OPTIONS routes for `/v1/players/{playerId}/claim` and `/v1/leagues/{leagueId}/access` to `serverless.api-core.yml`, plus deploy smoke checks for both routes. | `api core deployment config registers claim and access routes`; `.github/workflows/deploy-qa.yml`; `.github/workflows/deploy-prod.yml`; `npm test` |
| Separate join success from claim failure. | The join submit handler treats the public join POST as complete before attempting optional claim, preserving the successful join state if claim fails. | `join page keeps successful join state when signed-in claim fails`; `npm test` |
| Prevent roster creation from erasing existing claims. | Authenticated quick-create links an existing player without mutating that player profile, so `claimedByUserId` is preserved. | `repository quick player creation preserves existing player claims`; `npm test` |
| Key player claims by stable subject. | Magic-link sessions now carry a stable subject; claim routes use that subject, and ACL checks/listing accept subject plus legacy email candidates. | `magic complete consumes token once and creates a session`; `core lambda lets joined players claim accounts and admins delegate scorer access`; `core lambda lists subject-keyed and legacy email-keyed league access`; `npm test` |
| Prevent stale grants from downgrading administrators. | `grantLeagueAccess` now reads the existing ACL consistently and writes only the higher role, retrying conditional races instead of overwriting with a lower role. | `repository grants league access monotonically without downgrading admins`; `core lambda lets joined players claim accounts and admins delegate scorer access`; `npm test` |

### Rejected findings and evidence

None.

## Human judgement

- [ ] `human-judgement:none`
- [x] `human-judgement:required`

### Decision requiring judgement

Whether league-scoped scorer/co-organiser delegation is acceptable for this milestone, rather than adding narrower game-scoped scorer delegation.

### Options considered

Use existing league `scorekeeper`/`admin` ACLs for the second scorer now, or introduce a new game-scoped access model before enabling delegated scorers.

### Reason selected

The requested near-term goal is a second scorer who can use the existing scoring flow. Reusing league ACLs keeps authorization on a tested boundary and avoids adding a new partial permission model before the end-to-end scoring workflow is stable.

### Reversal cost

Medium. The UI/API can be reverted cleanly, but any delegated league ACL entries created during QA remain durable records until overwritten or manually adjusted by a later admin flow.

## Review focus

Please inspect the trust-boundary changes in `api/src/auth/acl.ts`, `api/src/auth/magic-link.ts`, `api/src/server.ts`, and `api/src/lambda-core.ts`; the claim/grant persistence in `api/src/data/repository.ts`; the admin-only roster UI in `app/src/ui/setup-flow.js`; the public join claim/sign-in flow in `app/src/ui/layout.ts` and `app/src/ui/setup-flow.js`; the run-panel time/sticky/clock behaviour in `app/src/ui/layout.ts`, `app/src/ui/setup-flow.js`, and `app/src/ui/styles.css`; and the QA join-link smoke/deploy alias coverage in `.github/workflows/deploy-qa.yml`, `.github/workflows/deploy-prod.yml`, and `scripts/deploy/deploy-site.sh`.
