### PR TITLE
feat: add post-final joins and organiser invites

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -194,7 +194,7 @@ jobs:
           CLAIM_HTTP_CODE="$(curl -sS -o /tmp/prod-claim.json -w '%{http_code}' \
             -X POST "$CLAIM_ENDPOINT" \
             -H 'content-type: application/json' \
-            -H 'origin: https://app.3fc.football' \
+            -H 'origin: https://3fc.football' \
             -d '{}')"
 
           if [ "$CLAIM_HTTP_CODE" != "401" ]; then
@@ -209,7 +209,7 @@ jobs:
           ACCESS_HTTP_CODE="$(curl -sS -o /tmp/prod-access.json -w '%{http_code}' \
             -X POST "$ACCESS_ENDPOINT" \
             -H 'content-type: application/json' \
-            -H 'origin: https://app.3fc.football' \
+            -H 'origin: https://3fc.football' \
             -d '{"userId":"scorekeeper@3fc.football","role":"scorekeeper"}')"
 
           if [ "$ACCESS_HTTP_CODE" != "401" ]; then
@@ -224,7 +224,7 @@ jobs:
           MAGIC_HTTP_CODE="$(curl -sS -o /tmp/prod-magic.json -w '%{http_code}' \
             -X POST "$MAGIC_ENDPOINT" \
             -H 'content-type: application/json' \
-            -H 'origin: https://app.3fc.football' \
+            -H 'origin: https://3fc.football' \
             -d '{}')"
 
           if [ "$MAGIC_HTTP_CODE" != "400" ]; then

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains the product, technical, infrastructure, and delivery as
 ## Domain
 
 - Primary domain: `https://3fc.football`
-- Production app domain: `https://app.3fc.football`
+- Production app domain: `https://3fc.football`
 - QA app domain: `https://qa.3fc.football`
 - Production API domain: `https://api.3fc.football`
 - QA API domain: `https://qa-api.3fc.football`

--- a/api/src/auth/acl.ts
+++ b/api/src/auth/acl.ts
@@ -18,6 +18,7 @@ const ROUTES = {
   undoLastGoal: /^\/v1\/games\/([^/]+)\/goals\/undo-last$/,
   claimPlayer: /^\/v1\/players\/([^/]+)\/claim$/,
   grantLeagueAccess: /^\/v1\/leagues\/([^/]+)\/access$/,
+  createLeagueOrganiserInvite: /^\/v1\/leagues\/([^/]+)\/organiser-invites$/,
 } as const;
 
 export type ProtectedMutationOperation =
@@ -37,7 +38,8 @@ export type ProtectedMutationOperation =
   | "deleteGoal"
   | "undoLastGoal"
   | "claimPlayer"
-  | "grantLeagueAccess";
+  | "grantLeagueAccess"
+  | "createLeagueOrganiserInvite";
 
 export interface ProtectedMutationRoute {
   operation: ProtectedMutationOperation;
@@ -208,6 +210,15 @@ export function resolveProtectedMutationRoute(
     };
   }
 
+  const createLeagueOrganiserInviteMatch =
+    upperMethod === "POST" ? route.match(ROUTES.createLeagueOrganiserInvite) : null;
+  if (createLeagueOrganiserInviteMatch) {
+    return {
+      operation: "createLeagueOrganiserInvite",
+      leagueId: decodeRouteParam(createLeagueOrganiserInviteMatch[1]),
+    };
+  }
+
   return null;
 }
 
@@ -367,7 +378,10 @@ export async function authorizeProtectedMutation(
     };
   }
 
-  if (resolvedRoute.operation === "grantLeagueAccess") {
+  if (
+    resolvedRoute.operation === "grantLeagueAccess" ||
+    resolvedRoute.operation === "createLeagueOrganiserInvite"
+  ) {
     const leagueId = resolvedRoute.leagueId as string;
     const isAdmin = await verifyLeagueAdmin(userId, leagueId, aclLookup);
 

--- a/api/src/auth/http-security.ts
+++ b/api/src/auth/http-security.ts
@@ -1,6 +1,7 @@
 const DEFAULT_ALLOWED_ORIGINS = [
   "http://localhost:3000",
   "https://qa.3fc.football",
+  "https://3fc.football",
   "https://app.3fc.football",
 ] as const;
 

--- a/api/src/auth/magic-link.ts
+++ b/api/src/auth/magic-link.ts
@@ -52,6 +52,12 @@ export interface MagicLinkStartResult {
   messageId: string | null;
 }
 
+export interface MagicLinkStartOptions {
+  returnTo?: string | null;
+  subject?: string;
+  introLines?: string[];
+}
+
 export interface MagicLinkCompleteResult {
   sessionId: string;
   email: string;
@@ -183,11 +189,19 @@ function assertPositiveInteger(name: string, value: number): void {
   }
 }
 
-function buildMagicLinkUrl(appBaseUrl: string, callbackPath: string, token: string): string {
+function buildMagicLinkUrl(
+  appBaseUrl: string,
+  callbackPath: string,
+  token: string,
+  returnTo?: string | null,
+): string {
   const normalizedBase = appBaseUrl.endsWith("/") ? appBaseUrl.slice(0, -1) : appBaseUrl;
   const normalizedPath = callbackPath.startsWith("/") ? callbackPath : `/${callbackPath}`;
-  const query = new URLSearchParams({ token }).toString();
-  return `${normalizedBase}${normalizedPath}?${query}`;
+  const query = new URLSearchParams({ token });
+  if (returnTo && returnTo.startsWith("/") && !returnTo.startsWith("//")) {
+    query.set("returnTo", returnTo);
+  }
+  return `${normalizedBase}${normalizedPath}?${query.toString()}`;
 }
 
 export class MagicLinkService {
@@ -208,7 +222,7 @@ export class MagicLinkService {
     this.randomProvider = randomProvider;
   }
 
-  async start(email: string): Promise<MagicLinkStartResult> {
+  async start(email: string, options: MagicLinkStartOptions = {}): Promise<MagicLinkStartResult> {
     const normalizedEmail = normalizeMagicLinkEmail(email);
 
     if (!isMagicLinkEmailLike(normalizedEmail)) {
@@ -228,6 +242,7 @@ export class MagicLinkService {
       this.options.appBaseUrl,
       this.options.callbackPath,
       rawToken,
+      options.returnTo,
     );
 
     await this.client.send(
@@ -250,8 +265,10 @@ export class MagicLinkService {
 
     const emailResponse = await this.emailSender.sendMagicLink({
       to: normalizedEmail,
-      subject: "Your 3FC sign-in link",
+      subject: options.subject?.trim() || "Your 3FC sign-in link",
       body: [
+        ...(options.introLines ?? []),
+        ...(options.introLines && options.introLines.length > 0 ? [""] : []),
         "Use this link to sign in to 3FC:",
         magicLink,
         "",

--- a/api/src/auth/session.ts
+++ b/api/src/auth/session.ts
@@ -143,6 +143,14 @@ export function isAuthenticatedApiRoute(method: string, route: string): boolean 
     return true;
   }
 
+  if (method === "POST" && /^\/v1\/leagues\/[^/]+\/organiser-invites$/.test(route)) {
+    return true;
+  }
+
+  if (method === "POST" && /^\/v1\/invites\/[^/]+\/accept$/.test(route)) {
+    return true;
+  }
+
   if (method === "GET" && route === "/v1/auth/session") {
     return true;
   }

--- a/api/src/contracts/core-write.ts
+++ b/api/src/contracts/core-write.ts
@@ -85,6 +85,14 @@ export const grantLeagueAccessRequestSchema = z
   })
   .strict();
 
+export const createLeagueOrganiserInviteRequestSchema = z
+  .object({
+    email: z.string().trim().nullable().optional(),
+  })
+  .strict();
+
+export const acceptLeagueOrganiserInviteRequestSchema = z.object({}).strict();
+
 export function normalizeJoinCodePathParam(joinCode: string): string {
   return joinCode.trim().toUpperCase();
 }

--- a/api/src/data/keys.ts
+++ b/api/src/data/keys.ts
@@ -6,6 +6,7 @@ export const ENTITY_PK_PREFIX = {
   player: "PLAYER#",
   user: "USER#",
   joinCode: "JOIN_CODE#",
+  leagueInvite: "LEAGUE_INVITE#",
   idempotency: "IDEMPOTENCY#",
 } as const;
 
@@ -51,6 +52,14 @@ export function playerClaimSk(playerId: string): string {
 
 export function joinCodePk(joinCode: string): string {
   return `${ENTITY_PK_PREFIX.joinCode}${joinCode}`;
+}
+
+export function leagueInvitePk(inviteCode: string): string {
+  return `${ENTITY_PK_PREFIX.leagueInvite}${inviteCode}`;
+}
+
+export function leagueOrganiserShareInviteSk(): string {
+  return "INVITE#ORGANISER_SHARE";
 }
 
 export function idempotencyPk(scope: string, key: string): string {

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -40,6 +40,8 @@ import {
   goalSk,
   idempotencyPk,
   joinCodePk,
+  leagueInvitePk,
+  leagueOrganiserShareInviteSk,
   leaguePk,
   metadataSk,
   playerClaimSk,
@@ -61,8 +63,10 @@ import type {
   CreateGameInput,
   CreateGoalInput,
   CreateGoalResult,
+  CompleteIdempotencyRecordInput,
   CreateIdempotencyRecordInput,
   CreateLeagueInput,
+  CreateLeagueOrganiserInviteInput,
   CreatePlayerInput,
   CreateSeasonInput,
   CreateSessionGameInput,
@@ -70,6 +74,7 @@ import type {
   CreateTeamInput,
   DeleteGoalInput,
   DeleteGoalResult,
+  DeleteIdempotencyRecordInput,
   FinishGameInput,
   GameJoinCodeRecord,
   GameTeamRecord,
@@ -85,6 +90,7 @@ import type {
   JoinGameByCodeInput,
   JoinGameByCodeResult,
   LeagueAclRecord,
+  LeagueInviteRecord,
   LeagueRecord,
   ListPlayersInput,
   LinkGamePlayerInput,
@@ -95,6 +101,8 @@ import type {
   SessionRecord,
   TeamRecord,
   GrantLeagueAccessInput,
+  AcceptLeagueOrganiserInviteInput,
+  AcceptLeagueOrganiserInviteResult,
   ThirdTransitionInput,
   UndoLastGoalInput,
   UpdateGoalInput,
@@ -114,6 +122,8 @@ const ENTITY_TYPE = {
   player: "player",
   playerClaim: "playerClaim",
   acl: "acl",
+  leagueInvite: "leagueInvite",
+  leagueInvitePointer: "leagueInvitePointer",
   roster: "roster",
   goal: "goal",
   goalEventId: "goalEventId",
@@ -230,6 +240,28 @@ export class PlayerClaimError extends Error {
   ) {
     super(message);
     this.name = "PlayerClaimError";
+  }
+}
+
+export class LeagueInviteCodeCollisionError extends Error {
+  constructor(message = "League organiser invite code is already assigned.") {
+    super(message);
+    this.name = "LeagueInviteCodeCollisionError";
+  }
+}
+
+export class LeagueInviteError extends Error {
+  constructor(
+    readonly code:
+      | "invite_already_accepted"
+      | "invite_email_mismatch"
+      | "invite_scope_not_found"
+      | "invite_state_changed",
+    readonly statusCode: 403 | 404 | 409,
+    message: string,
+  ) {
+    super(message);
+    this.name = "LeagueInviteError";
   }
 }
 
@@ -483,6 +515,40 @@ function normalizeGameTeamPayload(data: unknown): Omit<GameTeamRecord, "createdA
     color: typeof raw.color === "string" ? raw.color : null,
     scored: normalizeNonNegativeInteger(raw.scored),
     conceded: normalizeNonNegativeInteger(raw.conceded),
+  };
+}
+
+function normalizeInviteEmail(value: string | null | undefined): string | null {
+  const normalized = value?.trim().toLowerCase() ?? "";
+  return normalized.length > 0 ? normalized : null;
+}
+
+function normalizeLeagueInvitePayload(data: unknown): Omit<LeagueInviteRecord, "createdAt" | "updatedAt"> {
+  const raw = data as Partial<Omit<LeagueInviteRecord, "createdAt" | "updatedAt">>;
+  const acceptedByUserId =
+    typeof raw.acceptedByUserId === "string" && raw.acceptedByUserId.trim().length > 0
+      ? raw.acceptedByUserId
+      : null;
+  const kind = raw.kind === "share" || raw.kind === "email" ? raw.kind : "email";
+
+  return {
+    leagueId: raw.leagueId ?? "",
+    inviteCode: typeof raw.inviteCode === "string" ? normalizeJoinCode(raw.inviteCode) : "",
+    kind,
+    role: "admin",
+    email: normalizeInviteEmail(raw.email),
+    createdByUserId: raw.createdByUserId ?? "",
+    acceptedByUserId,
+    acceptedAt: isValidTimestamp(raw.acceptedAt) ? raw.acceptedAt : null,
+  };
+}
+
+function normalizeLeagueInvitePointerPayload(data: unknown): { leagueId: string; inviteCode: string } {
+  const raw = data as Partial<{ leagueId: string; inviteCode: string }>;
+
+  return {
+    leagueId: raw.leagueId ?? "",
+    inviteCode: typeof raw.inviteCode === "string" ? normalizeJoinCode(raw.inviteCode) : "",
   };
 }
 
@@ -1553,14 +1619,6 @@ export class ThreeFcRepository {
       return existingReplay;
     }
 
-    if (game.status === "finished") {
-      throw new GameJoinRegistrationError(
-        "game_finished",
-        409,
-        `Game ${game.gameId} is finished. Join registration is closed.`,
-      );
-    }
-
     const now = this.clock.now();
     const playerPayload = {
       playerId: input.playerId,
@@ -2296,9 +2354,16 @@ export class ThreeFcRepository {
       throw new Error("Cannot delete league with existing seasons.");
     }
 
-    const aclEntries = await this.listLeagueAccess(leagueId);
+    const [aclEntries, inviteEntries] = await Promise.all([
+      this.listLeagueAccess(leagueId),
+      this.listLeagueOrganiserInviteEntities(leagueId),
+    ]);
     await Promise.all(
-      aclEntries.map((entry) => this.deleteEntity(leaguePk(leagueId), aclSk(entry.userId))),
+      [
+        ...inviteEntries.map((entry) => this.deleteEntity(entry.pk, entry.sk)),
+        this.deleteEntity(leaguePk(leagueId), leagueOrganiserShareInviteSk()),
+        ...aclEntries.map((entry) => this.deleteEntity(leaguePk(leagueId), aclSk(entry.userId))),
+      ],
     );
     await this.deleteEntity(leaguePk(leagueId), metadataSk());
     return true;
@@ -2720,6 +2785,411 @@ export class ThreeFcRepository {
       item.createdAt,
       item.updatedAt,
     );
+  }
+
+  async createLeagueOrganiserInvite(
+    input: CreateLeagueOrganiserInviteInput,
+  ): Promise<LeagueInviteRecord> {
+    requireNonEmpty("leagueId", input.leagueId);
+    requireNonEmpty("createdByUserId", input.createdByUserId);
+
+    const email = normalizeInviteEmail(input.email);
+    const kind = input.kind ?? "email";
+    if (kind === "share") {
+      return this.ensureLeagueOrganiserShareInvite({
+        leagueId: input.leagueId,
+        createdByUserId: input.createdByUserId,
+      });
+    }
+
+    const customInviteCode = input.inviteCode ? normalizeCustomJoinCode(input.inviteCode) : null;
+
+    for (let attempt = 0; attempt < JOIN_CODE_GENERATION_ATTEMPTS; attempt += 1) {
+      const inviteCode = customInviteCode ?? generateJoinCode();
+      const now = this.clock.now();
+      const payload: Omit<LeagueInviteRecord, "createdAt" | "updatedAt"> = {
+        leagueId: input.leagueId,
+        inviteCode,
+        kind,
+        role: "admin",
+        email,
+        createdByUserId: input.createdByUserId,
+        acceptedByUserId: null,
+        acceptedAt: null,
+      };
+
+      try {
+        await this.client.send(
+          new PutItemCommand({
+            TableName: this.tableName,
+            Item: buildItem(leagueInvitePk(inviteCode), metadataSk(), ENTITY_TYPE.leagueInvite, payload, now),
+            ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
+          }),
+        );
+        return withTimestamps(payload, now, now);
+      } catch (error) {
+        if (isConditionalWriteFailure(error)) {
+          if (customInviteCode) {
+            throw new LeagueInviteCodeCollisionError();
+          }
+          continue;
+        }
+
+        throw error;
+      }
+    }
+
+    throw new LeagueInviteCodeCollisionError();
+  }
+
+  private async getExistingLeagueOrganiserShareInvite(
+    leagueId: string,
+  ): Promise<LeagueInviteRecord | null> {
+    const pointerItem = await this.getEntity(leaguePk(leagueId), leagueOrganiserShareInviteSk(), {
+      consistentRead: true,
+    });
+    if (!pointerItem || pointerItem.entityType !== ENTITY_TYPE.leagueInvitePointer) {
+      return null;
+    }
+
+    const pointer = normalizeLeagueInvitePointerPayload(pointerItem.data);
+    if (pointer.leagueId !== leagueId || pointer.inviteCode.length === 0) {
+      return null;
+    }
+
+    const invite = await this.getLeagueOrganiserInvite(pointer.inviteCode);
+    if (
+      invite &&
+      invite.kind === "share" &&
+      invite.leagueId === leagueId &&
+      invite.email === null
+    ) {
+      return invite;
+    }
+
+    return null;
+  }
+
+  private async ensureLeagueOrganiserShareInvite(input: {
+    leagueId: string;
+    createdByUserId: string;
+  }): Promise<LeagueInviteRecord> {
+    for (let attempt = 0; attempt < JOIN_CODE_GENERATION_ATTEMPTS; attempt += 1) {
+      const existingInvite = await this.getExistingLeagueOrganiserShareInvite(input.leagueId);
+      if (existingInvite) {
+        return existingInvite;
+      }
+
+      const inviteCode = generateJoinCode();
+      const now = this.clock.now();
+      const payload: Omit<LeagueInviteRecord, "createdAt" | "updatedAt"> = {
+        leagueId: input.leagueId,
+        inviteCode,
+        kind: "share",
+        role: "admin",
+        email: null,
+        createdByUserId: input.createdByUserId,
+        acceptedByUserId: null,
+        acceptedAt: null,
+      };
+
+      try {
+        await this.client.send(
+          new TransactWriteItemsCommand({
+            TransactItems: [
+              {
+                Put: {
+                  TableName: this.tableName,
+                  Item: buildItem(
+                    leagueInvitePk(inviteCode),
+                    metadataSk(),
+                    ENTITY_TYPE.leagueInvite,
+                    payload,
+                    now,
+                  ),
+                  ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
+                },
+              },
+              {
+                Put: {
+                  TableName: this.tableName,
+                  Item: buildItem(
+                    leaguePk(input.leagueId),
+                    leagueOrganiserShareInviteSk(),
+                    ENTITY_TYPE.leagueInvitePointer,
+                    { leagueId: input.leagueId, inviteCode },
+                    now,
+                  ),
+                  ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
+                },
+              },
+            ],
+          }),
+        );
+        return withTimestamps(payload, now, now);
+      } catch (error) {
+        if (isConditionalWriteFailure(error)) {
+          continue;
+        }
+
+        throw error;
+      }
+    }
+
+    const existingInvite = await this.getExistingLeagueOrganiserShareInvite(input.leagueId);
+    if (existingInvite) {
+      return existingInvite;
+    }
+
+    throw new LeagueInviteCodeCollisionError();
+  }
+
+  async getLeagueOrganiserInvite(inviteCode: string): Promise<LeagueInviteRecord | null> {
+    const normalizedInviteCode = normalizeJoinCode(inviteCode);
+    requireNonEmpty("inviteCode", normalizedInviteCode);
+
+    const item = await this.getEntity(leagueInvitePk(normalizedInviteCode), metadataSk(), {
+      consistentRead: true,
+    });
+    if (!item || item.entityType !== ENTITY_TYPE.leagueInvite) {
+      return null;
+    }
+
+    return withTimestamps(
+      normalizeLeagueInvitePayload(item.data),
+      item.createdAt,
+      item.updatedAt,
+    );
+  }
+
+  private async listLeagueOrganiserInviteEntities(
+    leagueId: string,
+  ): Promise<Array<StoredEntity<Omit<LeagueInviteRecord, "createdAt" | "updatedAt">>>> {
+    const scanResult = (await this.client.send(
+      new ScanCommand({
+        TableName: this.tableName,
+      }),
+    )) as ScanCommandOutput;
+
+    return (scanResult.Items ?? [])
+      .filter((item) => item.entityType?.S === ENTITY_TYPE.leagueInvite)
+      .map((item) => parseStoredEntity<Omit<LeagueInviteRecord, "createdAt" | "updatedAt">>(item))
+      .map((item) => ({
+        ...item,
+        data: normalizeLeagueInvitePayload(item.data),
+      }))
+      .filter((item) => item.data.leagueId === leagueId);
+  }
+
+  async acceptLeagueOrganiserInvite(
+    input: AcceptLeagueOrganiserInviteInput,
+  ): Promise<AcceptLeagueOrganiserInviteResult | null> {
+    const normalizedInviteCode = normalizeJoinCode(input.inviteCode);
+    const normalizedEmail = normalizeInviteEmail(input.email);
+    requireNonEmpty("inviteCode", normalizedInviteCode);
+    requireNonEmpty("userId", input.userId);
+    requireNonEmpty("email", normalizedEmail ?? "");
+
+    for (;;) {
+      const inviteItem = await this.getEntity(leagueInvitePk(normalizedInviteCode), metadataSk(), {
+        consistentRead: true,
+      });
+      if (!inviteItem || inviteItem.entityType !== ENTITY_TYPE.leagueInvite) {
+        return null;
+      }
+
+      const invite = withTimestamps(
+        normalizeLeagueInvitePayload(inviteItem.data),
+        inviteItem.createdAt,
+        inviteItem.updatedAt,
+      );
+      if (invite.email && invite.email !== normalizedEmail) {
+        throw new LeagueInviteError(
+          "invite_email_mismatch",
+          403,
+          "This organiser invite was issued for a different email address.",
+        );
+      }
+
+      const isShareInvite = invite.kind === "share";
+      if (!isShareInvite && invite.acceptedByUserId !== null && invite.acceptedByUserId !== input.userId) {
+        throw new LeagueInviteError(
+          "invite_already_accepted",
+          409,
+          "This organiser invite has already been accepted.",
+        );
+      }
+
+      const leagueItem = await this.getEntity(leaguePk(invite.leagueId), metadataSk(), {
+        consistentRead: true,
+      });
+      if (!leagueItem || leagueItem.entityType !== ENTITY_TYPE.league) {
+        throw new LeagueInviteError(
+          "invite_scope_not_found",
+          404,
+          `League ${invite.leagueId} was not found for this organiser invite.`,
+        );
+      }
+
+      const accessItem = await this.getEntity(leaguePk(invite.leagueId), aclSk(input.userId), {
+        consistentRead: true,
+      });
+      const existingAccess =
+        accessItem?.entityType === ENTITY_TYPE.acl
+          ? withTimestamps(
+              accessItem.data as Omit<LeagueAclRecord, "createdAt" | "updatedAt">,
+              accessItem.createdAt,
+              accessItem.updatedAt,
+            )
+          : null;
+      const nextRole = existingAccess ? higherLeagueRole(existingAccess.role, invite.role) : invite.role;
+      const needsInviteAcceptance = !isShareInvite && invite.acceptedByUserId === null;
+      const needsAccessWrite = !existingAccess || nextRole !== existingAccess.role;
+
+      if (!needsInviteAcceptance && !needsAccessWrite && existingAccess) {
+        return {
+          invite,
+          access: existingAccess,
+        };
+      }
+
+      const now = this.clock.now();
+      const acceptedInvitePayload: Omit<LeagueInviteRecord, "createdAt" | "updatedAt"> = {
+        leagueId: invite.leagueId,
+        inviteCode: invite.inviteCode,
+        kind: invite.kind,
+        role: invite.role,
+        email: invite.email,
+        createdByUserId: invite.createdByUserId,
+        acceptedByUserId: isShareInvite ? null : invite.acceptedByUserId ?? input.userId,
+        acceptedAt: isShareInvite ? null : invite.acceptedAt ?? now,
+      };
+      const accessPayload: Omit<LeagueAclRecord, "createdAt" | "updatedAt"> = {
+        leagueId: invite.leagueId,
+        userId: input.userId,
+        role: nextRole,
+        grantedByUserId: invite.createdByUserId,
+      };
+      const transactionItems: TransactWriteItem[] = [
+        {
+          ConditionCheck: {
+            TableName: this.tableName,
+            Key: {
+              pk: { S: leaguePk(invite.leagueId) },
+              sk: { S: metadataSk() },
+            },
+            ConditionExpression: "#updatedAt = :expectedLeagueUpdatedAt AND #data = :expectedLeagueData",
+            ExpressionAttributeNames: {
+              "#updatedAt": "updatedAt",
+              "#data": "data",
+            },
+            ExpressionAttributeValues: {
+              ":expectedLeagueUpdatedAt": { S: leagueItem.updatedAt },
+              ":expectedLeagueData": { S: leagueItem.rawData },
+            },
+          },
+        },
+        needsInviteAcceptance
+          ? {
+              Put: {
+                TableName: this.tableName,
+                Item: buildItemWithTimestamps(
+                  leagueInvitePk(invite.inviteCode),
+                  metadataSk(),
+                  ENTITY_TYPE.leagueInvite,
+                  acceptedInvitePayload,
+                  invite.createdAt,
+                  now,
+                ),
+                ConditionExpression: "#updatedAt = :expectedInviteUpdatedAt AND #data = :expectedInviteData",
+                ExpressionAttributeNames: {
+                  "#updatedAt": "updatedAt",
+                  "#data": "data",
+                },
+                ExpressionAttributeValues: {
+                  ":expectedInviteUpdatedAt": { S: inviteItem.updatedAt },
+                  ":expectedInviteData": { S: inviteItem.rawData },
+                },
+              },
+            }
+          : {
+              ConditionCheck: {
+                TableName: this.tableName,
+                Key: {
+                  pk: { S: leagueInvitePk(invite.inviteCode) },
+                  sk: { S: metadataSk() },
+                },
+                ConditionExpression: "#updatedAt = :expectedInviteUpdatedAt AND #data = :expectedInviteData",
+                ExpressionAttributeNames: {
+                  "#updatedAt": "updatedAt",
+                  "#data": "data",
+                },
+                ExpressionAttributeValues: {
+                  ":expectedInviteUpdatedAt": { S: inviteItem.updatedAt },
+                  ":expectedInviteData": { S: inviteItem.rawData },
+                },
+              },
+            },
+      ];
+
+      if (needsAccessWrite) {
+        transactionItems.push({
+          Put: {
+            TableName: this.tableName,
+            Item: buildItemWithTimestamps(
+              leaguePk(invite.leagueId),
+              aclSk(input.userId),
+              ENTITY_TYPE.acl,
+              accessPayload,
+              existingAccess?.createdAt ?? now,
+              now,
+            ),
+            ...(accessItem
+              ? {
+                  ConditionExpression: "#updatedAt = :expectedAccessUpdatedAt AND #data = :expectedAccessData",
+                  ExpressionAttributeNames: {
+                    "#updatedAt": "updatedAt",
+                    "#data": "data",
+                  },
+                  ExpressionAttributeValues: {
+                    ":expectedAccessUpdatedAt": { S: accessItem.updatedAt },
+                    ":expectedAccessData": { S: accessItem.rawData },
+                  },
+                }
+              : {
+                  ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
+                }),
+          },
+        });
+      }
+
+      try {
+        await this.client.send(
+          new TransactWriteItemsCommand({
+            TransactItems: transactionItems,
+          }),
+        );
+      } catch (error) {
+        if (isConditionalWriteFailure(error)) {
+          continue;
+        }
+
+        throw error;
+      }
+
+      return {
+        invite: withTimestamps(
+          acceptedInvitePayload,
+          invite.createdAt,
+          needsInviteAcceptance ? now : invite.updatedAt,
+        ),
+        access: withTimestamps(
+          accessPayload,
+          existingAccess?.createdAt ?? now,
+          needsAccessWrite ? now : existingAccess?.updatedAt ?? now,
+        ),
+      };
+    }
   }
 
   async assignRosterPlayer(input: AssignRosterInput): Promise<RosterAssignmentRecord> {
@@ -4325,6 +4795,157 @@ export class ThreeFcRepository {
             now,
           ),
           ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
+        }),
+      );
+      return true;
+    } catch (error) {
+      const awsError = error as { name?: string };
+      if (awsError.name === "ConditionalCheckFailedException") {
+        return false;
+      }
+
+      throw error;
+    }
+  }
+
+  async completeIdempotencyRecord(input: CompleteIdempotencyRecordInput): Promise<boolean> {
+    requireNonEmpty("scope", input.scope);
+    requireNonEmpty("key", input.key);
+    requireNonEmpty("requestHash", input.requestHash);
+    requireNonEmpty("responseBody", input.responseBody);
+    requireNonEmpty("expectedResponseBody", input.expectedResponseBody);
+
+    if (
+      !Number.isInteger(input.responseStatusCode) ||
+      input.responseStatusCode < 100 ||
+      input.responseStatusCode > 599
+    ) {
+      throw new Error("responseStatusCode must be a valid HTTP status code.");
+    }
+    if (
+      !Number.isInteger(input.expectedResponseStatusCode) ||
+      input.expectedResponseStatusCode < 100 ||
+      input.expectedResponseStatusCode > 599
+    ) {
+      throw new Error("expectedResponseStatusCode must be a valid HTTP status code.");
+    }
+
+    const existing = await this.getIdempotencyRecord(input.scope, input.key);
+    if (
+      !existing ||
+      existing.requestHash !== input.requestHash ||
+      existing.responseStatusCode !== input.expectedResponseStatusCode ||
+      existing.responseBody !== input.expectedResponseBody ||
+      (input.expectedUpdatedAt !== undefined && existing.updatedAt !== input.expectedUpdatedAt)
+    ) {
+      return false;
+    }
+
+    const now = this.clock.now();
+    const payload = {
+      scope: input.scope,
+      key: input.key,
+      requestHash: input.requestHash,
+      responseStatusCode: input.responseStatusCode,
+      responseBody: input.responseBody,
+    };
+    const expectedPayload = {
+      scope: input.scope,
+      key: input.key,
+      requestHash: input.requestHash,
+      responseStatusCode: input.expectedResponseStatusCode,
+      responseBody: input.expectedResponseBody,
+    };
+
+    try {
+      await this.client.send(
+        new PutItemCommand({
+          TableName: this.tableName,
+          Item: buildItemWithTimestamps(
+            idempotencyPk(input.scope, input.key),
+            metadataSk(),
+            ENTITY_TYPE.idempotency,
+            payload,
+            existing.createdAt,
+            now,
+          ),
+          ConditionExpression:
+            "attribute_exists(pk) AND attribute_exists(sk) AND #data = :expectedData" +
+            (input.expectedUpdatedAt === undefined ? "" : " AND #updatedAt = :expectedUpdatedAt"),
+          ExpressionAttributeNames: {
+            "#data": "data",
+            ...(input.expectedUpdatedAt === undefined ? {} : { "#updatedAt": "updatedAt" }),
+          },
+          ExpressionAttributeValues: {
+            ":expectedData": { S: JSON.stringify(expectedPayload) },
+            ...(input.expectedUpdatedAt === undefined
+              ? {}
+              : { ":expectedUpdatedAt": { S: input.expectedUpdatedAt } }),
+          },
+        }),
+      );
+      return true;
+    } catch (error) {
+      const awsError = error as { name?: string };
+      if (awsError.name === "ConditionalCheckFailedException") {
+        return false;
+      }
+
+      throw error;
+    }
+  }
+
+  async deleteIdempotencyRecord(input: DeleteIdempotencyRecordInput): Promise<boolean> {
+    requireNonEmpty("scope", input.scope);
+    requireNonEmpty("key", input.key);
+    requireNonEmpty("requestHash", input.requestHash);
+    requireNonEmpty("responseBody", input.responseBody);
+    if (
+      !Number.isInteger(input.responseStatusCode) ||
+      input.responseStatusCode < 100 ||
+      input.responseStatusCode > 599
+    ) {
+      throw new Error("responseStatusCode must be a valid HTTP status code.");
+    }
+
+    const existing = await this.getIdempotencyRecord(input.scope, input.key);
+    if (
+      !existing ||
+      existing.requestHash !== input.requestHash ||
+      existing.responseStatusCode !== input.responseStatusCode ||
+      existing.responseBody !== input.responseBody ||
+      (input.updatedAt !== undefined && existing.updatedAt !== input.updatedAt)
+    ) {
+      return false;
+    }
+
+    const expectedPayload = {
+      scope: input.scope,
+      key: input.key,
+      requestHash: input.requestHash,
+      responseStatusCode: input.responseStatusCode,
+      responseBody: input.responseBody,
+    };
+
+    try {
+      await this.client.send(
+        new DeleteItemCommand({
+          TableName: this.tableName,
+          Key: {
+            pk: { S: idempotencyPk(input.scope, input.key) },
+            sk: { S: metadataSk() },
+          },
+          ConditionExpression:
+            "attribute_exists(pk) AND attribute_exists(sk) AND #data = :data" +
+            (input.updatedAt === undefined ? "" : " AND #updatedAt = :updatedAt"),
+          ExpressionAttributeNames: {
+            "#data": "data",
+            ...(input.updatedAt === undefined ? {} : { "#updatedAt": "updatedAt" }),
+          },
+          ExpressionAttributeValues: {
+            ":data": { S: JSON.stringify(expectedPayload) },
+            ...(input.updatedAt === undefined ? {} : { ":updatedAt": { S: input.updatedAt } }),
+          },
         }),
       );
       return true;

--- a/api/src/data/types.ts
+++ b/api/src/data/types.ts
@@ -115,6 +115,21 @@ export interface LeagueAclRecord {
   updatedAt: string;
 }
 
+export type LeagueInviteKind = "share" | "email";
+
+export interface LeagueInviteRecord {
+  leagueId: string;
+  inviteCode: string;
+  kind: LeagueInviteKind;
+  role: "admin";
+  email: string | null;
+  createdByUserId: string;
+  acceptedByUserId: string | null;
+  acceptedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface RosterAssignmentRecord {
   gameId: string;
   teamId: TeamId;
@@ -309,6 +324,25 @@ export interface GrantLeagueAccessInput {
   grantedByUserId: string;
 }
 
+export interface CreateLeagueOrganiserInviteInput {
+  leagueId: string;
+  email?: string | null;
+  createdByUserId: string;
+  inviteCode?: string | null;
+  kind?: LeagueInviteKind;
+}
+
+export interface AcceptLeagueOrganiserInviteInput {
+  inviteCode: string;
+  userId: string;
+  email: string;
+}
+
+export interface AcceptLeagueOrganiserInviteResult {
+  invite: LeagueInviteRecord;
+  access: LeagueAclRecord;
+}
+
 export interface AssignRosterInput {
   gameId: string;
   teamId: TeamId;
@@ -404,4 +438,19 @@ export interface CreateIdempotencyRecordInput {
   requestHash: string;
   responseStatusCode: number;
   responseBody: string;
+}
+
+export interface CompleteIdempotencyRecordInput extends CreateIdempotencyRecordInput {
+  expectedResponseStatusCode: number;
+  expectedResponseBody: string;
+  expectedUpdatedAt?: string;
+}
+
+export interface DeleteIdempotencyRecordInput {
+  scope: string;
+  key: string;
+  requestHash: string;
+  responseStatusCode: number;
+  responseBody: string;
+  updatedAt?: string;
 }

--- a/api/src/lambda-core.ts
+++ b/api/src/lambda-core.ts
@@ -41,8 +41,10 @@ import {
 } from "./auth/session.js";
 import {
   claimPlayerRequestSchema,
+  acceptLeagueOrganiserInviteRequestSchema,
   createGameRequestSchema,
   createGoalRequestSchema,
+  createLeagueOrganiserInviteRequestSchema,
   createLeagueRequestSchema,
   createSeasonRequestSchema,
   createSessionRequestSchema,
@@ -66,11 +68,20 @@ import {
   GameTimerTransitionError,
   GoalCorrectionError,
   GoalCreationError,
+  LeagueInviteCodeCollisionError,
+  LeagueInviteError,
   PlayerClaimError,
   ThreeFcRepository,
 } from "./data/repository.js";
-import type { CreateGoalResult, DeleteGoalResult, GameStatus, UpdateGoalResult } from "./data/types.js";
-import { logAuthRateLimit, logRequest, logRequestError } from "./logging.js";
+import type {
+  AcceptLeagueOrganiserInviteResult,
+  CreateGoalResult,
+  DeleteGoalResult,
+  GameStatus,
+  LeagueInviteRecord,
+  UpdateGoalResult,
+} from "./data/types.js";
+import { logAuthRateLimit, logMagicLinkEvent, logRequest, logRequestError } from "./logging.js";
 
 const FINISHED_REPAIR_RETRY_DELAYS_MS = [25, 50, 100] as const;
 const FINISHED_REPAIR_MAX_ATTEMPTS = 3;
@@ -117,7 +128,10 @@ interface SessionLookup {
 }
 
 interface MagicLinkServiceContract extends SessionLookup {
-  start(email: string): Promise<{
+  start(
+    email: string,
+    options?: { returnTo?: string | null; subject?: string; introLines?: string[] },
+  ): Promise<{
     email: string;
     expiresAt: string;
     messageId: string | null;
@@ -501,6 +515,19 @@ interface RepositoryContract {
     createdAt: string;
     updatedAt: string;
   }>;
+  createLeagueOrganiserInvite(input: {
+    leagueId: string;
+    email?: string | null;
+    createdByUserId: string;
+    inviteCode?: string | null;
+    kind?: LeagueInviteRecord["kind"];
+  }): Promise<LeagueInviteRecord>;
+  getLeagueOrganiserInvite(inviteCode: string): Promise<LeagueInviteRecord | null>;
+  acceptLeagueOrganiserInvite(input: {
+    inviteCode: string;
+    userId: string;
+    email: string;
+  }): Promise<AcceptLeagueOrganiserInviteResult | null>;
   getSeason(
     seasonId: string,
   ): Promise<
@@ -550,6 +577,24 @@ interface RepositoryContract {
     responseStatusCode: number;
     responseBody: string;
   }): Promise<boolean>;
+  completeIdempotencyRecord(input: {
+    scope: string;
+    key: string;
+    requestHash: string;
+    responseStatusCode: number;
+    responseBody: string;
+    expectedResponseStatusCode: number;
+    expectedResponseBody: string;
+    expectedUpdatedAt?: string;
+  }): Promise<boolean>;
+  deleteIdempotencyRecord(input: {
+    scope: string;
+    key: string;
+    requestHash: string;
+    responseStatusCode: number;
+    responseBody: string;
+    updatedAt?: string;
+  }): Promise<boolean>;
 }
 
 type LeagueListRecord = Awaited<ReturnType<RepositoryContract["listLeaguesForUser"]>>[number];
@@ -577,6 +622,8 @@ interface CoreHandlerDependencies {
   sessionCookieName: string;
   sessionCookieSecure: boolean;
   corsAllowedOrigins: string[];
+  appBaseUrl: string;
+  publicAppBaseUrl?: string;
 }
 
 function getRequestDetails(event: ApiGatewayHttpEvent): RequestDetails {
@@ -1097,7 +1144,7 @@ function gameJoinCodeCollisionConflictResponse(
 async function buildFinishedGameMutationBlock(input: {
   repository: RepositoryContract;
   game: Pick<RepositoryGameRecord, "gameId" | "leagueId" | "status">;
-  sessionEmail: string;
+  sessionUserIds: string | readonly string[];
   origin: string | undefined;
   allowedOrigins: string[];
 }): Promise<ApiGatewayHttpResponse | null> {
@@ -1105,12 +1152,12 @@ async function buildFinishedGameMutationBlock(input: {
     return null;
   }
 
-  const access = await ensureLeagueAccess(
+  const isAdmin = await ensureLeagueAdmin(
     input.repository,
     input.game.leagueId,
-    input.sessionEmail,
+    input.sessionUserIds,
   );
-  if (access.role === "admin") {
+  if (isAdmin) {
     return null;
   }
 
@@ -1517,6 +1564,19 @@ function buildIdempotencyRequestHash(scope: string, payload: unknown): string {
     .digest("hex");
 }
 
+function hashDiagnosticValue(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 16);
+}
+
+function hashMagicLinkTokenId(rawToken: string): string {
+  const tokenId = rawToken.trim().split(".")[0]?.trim() ?? "";
+  return hashDiagnosticValue(tokenId || "missing-token-id");
+}
+
+function hashEmailDiagnostic(email: string): string {
+  return hashDiagnosticValue(normalizeMagicLinkEmail(email));
+}
+
 function parseOptionalIdempotencyKey(value: string | undefined): string | null {
   if (!value) {
     return null;
@@ -1565,6 +1625,184 @@ function buildPublicJoinPlayerId(joinCode: string, idempotencyKey: string): stri
 }
 
 const PUBLIC_JOIN_IDEMPOTENCY_SUBJECT = "public-join";
+const IDEMPOTENCY_PENDING_STATUS_CODE = 202;
+const IDEMPOTENCY_PENDING_STALE_AFTER_MS = 2 * 60 * 1000;
+const IDEMPOTENCY_EXTERNAL_SIDE_EFFECT_EMAIL_DELIVERY_STARTED = "email_delivery_started";
+const INVITE_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+const INVITE_CODE_LENGTH = 8;
+
+interface PendingIdempotencyBody {
+  idempotencyState?: unknown;
+  reservationId?: unknown;
+  reservedAtEpochMs?: unknown;
+  externalSideEffect?: unknown;
+  externalSideEffectStartedAtEpochMs?: unknown;
+}
+
+interface ReservedIdempotencyMutationContext {
+  markExternalSideEffectStarted: () => Promise<void>;
+}
+
+class ReservedIdempotencyReservationChangedError extends Error {
+  constructor() {
+    super("Idempotency reservation changed before external side effect could be marked.");
+  }
+}
+
+function parsePendingIdempotencyBody(responseBody: string): PendingIdempotencyBody | null {
+  try {
+    const parsed = JSON.parse(responseBody) as unknown;
+    return typeof parsed === "object" && parsed !== null ? parsed as PendingIdempotencyBody : null;
+  } catch {
+    return null;
+  }
+}
+
+function buildPendingIdempotencyBody(input: {
+  reservationId?: string;
+  reservedAtEpochMs?: number;
+  externalSideEffect?: typeof IDEMPOTENCY_EXTERNAL_SIDE_EFFECT_EMAIL_DELIVERY_STARTED;
+  externalSideEffectStartedAtEpochMs?: number;
+} = {}): string {
+  const body: PendingIdempotencyBody = {
+    idempotencyState: "pending",
+    reservationId: input.reservationId ?? randomUUID(),
+    reservedAtEpochMs: input.reservedAtEpochMs ?? Date.now(),
+  };
+
+  if (input.externalSideEffect === IDEMPOTENCY_EXTERNAL_SIDE_EFFECT_EMAIL_DELIVERY_STARTED) {
+    body.externalSideEffect = IDEMPOTENCY_EXTERNAL_SIDE_EFFECT_EMAIL_DELIVERY_STARTED;
+    body.externalSideEffectStartedAtEpochMs =
+      input.externalSideEffectStartedAtEpochMs ?? Date.now();
+  }
+
+  return JSON.stringify(body);
+}
+
+function buildAppUrl(appBaseUrl: string, path: string): string {
+  const normalizedBase = appBaseUrl.endsWith("/") ? appBaseUrl.slice(0, -1) : appBaseUrl;
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${normalizedBase}${normalizedPath}`;
+}
+
+function buildOrganiserInvitePath(inviteCode: string): string {
+  return `/invites?code=${encodeURIComponent(inviteCode)}`;
+}
+
+type OrganiserInviteEmailDeliveryResponse =
+  | { status: "sent"; email: string; expiresAt: string; messageId: string | null }
+  | { status: "unknown"; email: string; expiresAt: null; messageId: null; message: string };
+
+function buildOrganiserInviteResponse(
+  invite: LeagueInviteRecord,
+  appBaseUrl: string,
+  emailDelivery: OrganiserInviteEmailDeliveryResponse | null = null,
+): Record<string, unknown> {
+  const invitePath = buildOrganiserInvitePath(invite.inviteCode);
+  return {
+    invite,
+    inviteCode: invite.inviteCode,
+    inviteLink: buildAppUrl(appBaseUrl, invitePath),
+    emailDelivery,
+  };
+}
+
+function buildOrganiserInviteIdempotencyCode(input: {
+  sessionEmail: string;
+  method: string;
+  route: string;
+  idempotencyKey: string | undefined;
+}): string | null {
+  const parsedIdempotencyKey = input.idempotencyKey
+    ? idempotencyKeyHeaderSchema.safeParse(input.idempotencyKey)
+    : null;
+
+  if (!parsedIdempotencyKey?.success) {
+    return null;
+  }
+
+  const scope = buildIdempotencyScope(input.sessionEmail, input.method, input.route);
+  const digest = createHash("sha256")
+    .update(`organiser-invite:${scope}:${parsedIdempotencyKey.data}`)
+    .digest();
+  let inviteCode = "";
+  for (let index = 0; index < INVITE_CODE_LENGTH; index += 1) {
+    inviteCode += INVITE_CODE_ALPHABET[digest[index] % INVITE_CODE_ALPHABET.length];
+  }
+  return inviteCode;
+}
+
+function isMatchingRecoveredOrganiserInvite(input: {
+  invite: LeagueInviteRecord;
+  leagueId: string;
+  email: string | null;
+  createdByUserId: string;
+  kind: LeagueInviteRecord["kind"];
+}): boolean {
+  return (
+    input.invite.leagueId === input.leagueId &&
+    input.invite.kind === input.kind &&
+    input.invite.role === "admin" &&
+    input.invite.email === input.email &&
+    input.invite.createdByUserId === input.createdByUserId
+  );
+}
+
+async function createOrRecoverLeagueOrganiserInvite(input: {
+  repository: RepositoryContract;
+  leagueId: string;
+  email: string | null;
+  createdByUserId: string;
+  inviteCode: string | null;
+  kind: LeagueInviteRecord["kind"];
+}): Promise<LeagueInviteRecord> {
+  try {
+    return await input.repository.createLeagueOrganiserInvite({
+      leagueId: input.leagueId,
+      email: input.email,
+      createdByUserId: input.createdByUserId,
+      inviteCode: input.inviteCode,
+      kind: input.kind,
+    });
+  } catch (error) {
+    if (!(error instanceof LeagueInviteCodeCollisionError) || !input.inviteCode) {
+      throw error;
+    }
+
+    const existingInvite = await input.repository.getLeagueOrganiserInvite(input.inviteCode);
+    if (
+      existingInvite &&
+      isMatchingRecoveredOrganiserInvite({
+        invite: existingInvite,
+        leagueId: input.leagueId,
+        email: input.email,
+        createdByUserId: input.createdByUserId,
+        kind: input.kind,
+      })
+    ) {
+      return existingInvite;
+    }
+
+    throw error;
+  }
+}
+
+function leagueInviteErrorResponse(
+  origin: string | undefined,
+  allowedOrigins: string[],
+  error: LeagueInviteError,
+): ApiGatewayHttpResponse {
+  const responseError = error.statusCode === 404 ? "not_found" : error.statusCode === 403 ? "forbidden" : "conflict";
+  return createJsonResponse(
+    error.statusCode,
+    {
+      error: responseError,
+      code: error.code,
+      message: error.message,
+    },
+    buildCorsHeaders(origin, allowedOrigins),
+  );
+}
 
 function buildGoalEventId(input: {
   idempotencyKey: string | undefined;
@@ -1640,6 +1878,95 @@ function idempotencyConflictResponse(
   );
 }
 
+function idempotencyInProgressResponse(
+  origin: string | undefined,
+  allowedOrigins: string[],
+): ApiGatewayHttpResponse {
+  return createJsonResponse(
+    409,
+    {
+      error: "idempotency_in_progress",
+      message: "A request with this idempotency key is still in progress. Retry shortly.",
+    },
+    buildCorsHeaders(origin, allowedOrigins),
+  );
+}
+
+function isPendingIdempotencyRecord(record: { responseStatusCode: number; responseBody: string }): boolean {
+  if (record.responseStatusCode !== IDEMPOTENCY_PENDING_STATUS_CODE) {
+    return false;
+  }
+
+  return parsePendingIdempotencyBody(record.responseBody)?.idempotencyState === "pending";
+}
+
+function pendingIdempotencyReservedAtEpochMs(record: {
+  responseBody: string;
+  createdAt?: string;
+}): number | null {
+  const parsed = parsePendingIdempotencyBody(record.responseBody);
+  if (
+    typeof parsed?.reservedAtEpochMs === "number" &&
+    Number.isFinite(parsed.reservedAtEpochMs)
+  ) {
+    return parsed.reservedAtEpochMs;
+  }
+
+  if (record.createdAt) {
+    const createdAtEpochMs = Date.parse(record.createdAt);
+    if (Number.isFinite(createdAtEpochMs)) {
+      return createdAtEpochMs;
+    }
+  }
+
+  return null;
+}
+
+function pendingIdempotencyBodyHasExternalSideEffectStarted(responseBody: string): boolean {
+  return parsePendingIdempotencyBody(responseBody)?.externalSideEffect ===
+    IDEMPOTENCY_EXTERNAL_SIDE_EFFECT_EMAIL_DELIVERY_STARTED;
+}
+
+function isStalePendingIdempotencyRecord(record: {
+  responseStatusCode: number;
+  responseBody: string;
+  createdAt?: string;
+}): boolean {
+  if (!isPendingIdempotencyRecord(record)) {
+    return false;
+  }
+
+  const reservedAtEpochMs = pendingIdempotencyReservedAtEpochMs(record);
+  return reservedAtEpochMs !== null && Date.now() - reservedAtEpochMs > IDEMPOTENCY_PENDING_STALE_AFTER_MS;
+}
+
+function isRecoverableStalePendingIdempotencyRecord(record: {
+  responseStatusCode: number;
+  responseBody: string;
+  createdAt?: string;
+}): boolean {
+  return (
+    isStalePendingIdempotencyRecord(record) &&
+    !pendingIdempotencyBodyHasExternalSideEffectStarted(record.responseBody)
+  );
+}
+
+function isRetryableReservedIdempotencyResponse(response: ApiGatewayHttpResponse): boolean {
+  return response.statusCode === 429 || response.statusCode >= 500;
+}
+
+function replayIdempotencyRecord(
+  record: { responseStatusCode: number; responseBody: string },
+  origin: string | undefined,
+  allowedOrigins: string[],
+): ApiGatewayHttpResponse {
+  return createJsonResponse(
+    record.responseStatusCode,
+    parseStoredIdempotencyResponseBody(record.responseBody),
+    buildCorsHeaders(origin, allowedOrigins),
+  );
+}
+
 async function executeIdempotentMutation(input: {
   repository: RepositoryContract;
   idempotencyKey: string | undefined;
@@ -1675,11 +2002,26 @@ async function executeIdempotentMutation(input: {
       return idempotencyConflictResponse(input.origin, input.allowedOrigins);
     }
 
-    return createJsonResponse(
-      existingRecord.responseStatusCode,
-      parseStoredIdempotencyResponseBody(existingRecord.responseBody),
-      buildCorsHeaders(input.origin, input.allowedOrigins),
-    );
+    if (isPendingIdempotencyRecord(existingRecord)) {
+      if (
+        isStalePendingIdempotencyRecord(existingRecord) &&
+        await input.repository.deleteIdempotencyRecord({
+          scope,
+          key: idempotencyKey,
+          requestHash,
+          responseStatusCode: existingRecord.responseStatusCode,
+          responseBody: existingRecord.responseBody,
+          updatedAt: existingRecord.updatedAt,
+        })
+      ) {
+        // Continue as a new mutation after clearing stale pending state.
+      } else {
+        const replay = await replayStoredIdempotencyMutation(input);
+        return replay ?? idempotencyInProgressResponse(input.origin, input.allowedOrigins);
+      }
+    } else {
+      return replayIdempotencyRecord(existingRecord, input.origin, input.allowedOrigins);
+    }
   }
 
   const mutationResponse = await input.execute();
@@ -1708,11 +2050,225 @@ async function executeIdempotentMutation(input: {
     return idempotencyConflictResponse(input.origin, input.allowedOrigins);
   }
 
-  return createJsonResponse(
-    raceRecord.responseStatusCode,
-    parseStoredIdempotencyResponseBody(raceRecord.responseBody),
-    buildCorsHeaders(input.origin, input.allowedOrigins),
-  );
+  if (isPendingIdempotencyRecord(raceRecord)) {
+    if (
+      isStalePendingIdempotencyRecord(raceRecord) &&
+      await input.repository.deleteIdempotencyRecord({
+        scope,
+        key: idempotencyKey,
+        requestHash,
+        responseStatusCode: raceRecord.responseStatusCode,
+        responseBody: raceRecord.responseBody,
+        updatedAt: raceRecord.updatedAt,
+      })
+    ) {
+      return mutationResponse;
+    }
+
+    const replay = await replayStoredIdempotencyMutation(input);
+    return replay ?? idempotencyInProgressResponse(input.origin, input.allowedOrigins);
+  }
+
+  return replayIdempotencyRecord(raceRecord, input.origin, input.allowedOrigins);
+}
+
+async function executeReservedIdempotentMutation(input: {
+  repository: RepositoryContract;
+  idempotencyKey: string | undefined;
+  sessionEmail: string;
+  method: string;
+  route: string;
+  requestPayload: unknown;
+  origin: string | undefined;
+  allowedOrigins: string[];
+  execute: (context: ReservedIdempotencyMutationContext) => Promise<ApiGatewayHttpResponse>;
+  recoverStartedExternalSideEffect?: (record: {
+    scope: string;
+    key: string;
+    requestHash: string;
+    responseStatusCode: number;
+    responseBody: string;
+    updatedAt: string;
+  }) => Promise<ApiGatewayHttpResponse | null>;
+}): Promise<ApiGatewayHttpResponse> {
+  if (!input.idempotencyKey) {
+    return input.execute({
+      markExternalSideEffectStarted: async () => undefined,
+    });
+  }
+
+  const parsedHeader = idempotencyKeyHeaderSchema.safeParse(input.idempotencyKey);
+  if (!parsedHeader.success) {
+    return badRequest(
+      input.origin,
+      input.allowedOrigins,
+      formatSchemaValidationError(parsedHeader.error),
+    );
+  }
+
+  const idempotencyKey = parsedHeader.data;
+  const scope = buildIdempotencyScope(input.sessionEmail, input.method, input.route);
+  const requestHash = buildIdempotencyRequestHash(scope, input.requestPayload);
+  let reserved = false;
+  let reservedResponseBody: string | null = null;
+
+  for (let reserveAttempt = 0; reserveAttempt < 2; reserveAttempt += 1) {
+    const pendingResponseBody = buildPendingIdempotencyBody();
+    reserved = await input.repository.createIdempotencyRecord({
+      scope,
+      key: idempotencyKey,
+      requestHash,
+      responseStatusCode: IDEMPOTENCY_PENDING_STATUS_CODE,
+      responseBody: pendingResponseBody,
+    });
+
+    if (reserved) {
+      reservedResponseBody = pendingResponseBody;
+      break;
+    }
+
+    const existingRecord = await input.repository.getIdempotencyRecord(scope, idempotencyKey);
+    if (!existingRecord) {
+      continue;
+    }
+
+    if (existingRecord.requestHash !== requestHash) {
+      return idempotencyConflictResponse(input.origin, input.allowedOrigins);
+    }
+
+    if (
+      isPendingIdempotencyRecord(existingRecord) &&
+      isRecoverableStalePendingIdempotencyRecord(existingRecord) &&
+      await input.repository.deleteIdempotencyRecord({
+        scope,
+        key: idempotencyKey,
+        requestHash,
+        responseStatusCode: existingRecord.responseStatusCode,
+        responseBody: existingRecord.responseBody,
+        updatedAt: existingRecord.updatedAt,
+      })
+    ) {
+      continue;
+    }
+
+    if (isPendingIdempotencyRecord(existingRecord)) {
+      if (
+        input.recoverStartedExternalSideEffect &&
+        isStalePendingIdempotencyRecord(existingRecord) &&
+        pendingIdempotencyBodyHasExternalSideEffectStarted(existingRecord.responseBody)
+      ) {
+        const recovered = await input.recoverStartedExternalSideEffect(existingRecord);
+        if (recovered) {
+          const completed = await input.repository.completeIdempotencyRecord({
+            scope,
+            key: idempotencyKey,
+            requestHash,
+            responseStatusCode: recovered.statusCode,
+            responseBody: recovered.body,
+            expectedResponseStatusCode: existingRecord.responseStatusCode,
+            expectedResponseBody: existingRecord.responseBody,
+            expectedUpdatedAt: existingRecord.updatedAt,
+          });
+          if (completed) {
+            return recovered;
+          }
+
+          const replayAfterRecoveryRace = await replayStoredIdempotencyMutation(input);
+          return replayAfterRecoveryRace ?? idempotencyInProgressResponse(
+            input.origin,
+            input.allowedOrigins,
+          );
+        }
+      }
+
+      const replay = await replayStoredIdempotencyMutation(input);
+      if (replay) {
+        return replay;
+      }
+
+      return idempotencyInProgressResponse(input.origin, input.allowedOrigins);
+    }
+
+    return replayIdempotencyRecord(existingRecord, input.origin, input.allowedOrigins);
+  }
+
+  if (!reserved) {
+    return idempotencyInProgressResponse(input.origin, input.allowedOrigins);
+  }
+  if (!reservedResponseBody) {
+    return idempotencyInProgressResponse(input.origin, input.allowedOrigins);
+  }
+  let ownedReservationBody = reservedResponseBody;
+
+  const markExternalSideEffectStarted = async (): Promise<void> => {
+    const parsed = parsePendingIdempotencyBody(ownedReservationBody);
+    const markedResponseBody = buildPendingIdempotencyBody({
+      reservationId: typeof parsed?.reservationId === "string" ? parsed.reservationId : undefined,
+      reservedAtEpochMs: typeof parsed?.reservedAtEpochMs === "number" ? parsed.reservedAtEpochMs : undefined,
+      externalSideEffect: IDEMPOTENCY_EXTERNAL_SIDE_EFFECT_EMAIL_DELIVERY_STARTED,
+    });
+    const marked = await input.repository.completeIdempotencyRecord({
+      scope,
+      key: idempotencyKey,
+      requestHash,
+      responseStatusCode: IDEMPOTENCY_PENDING_STATUS_CODE,
+      responseBody: markedResponseBody,
+      expectedResponseStatusCode: IDEMPOTENCY_PENDING_STATUS_CODE,
+      expectedResponseBody: ownedReservationBody,
+    });
+    if (!marked) {
+      throw new ReservedIdempotencyReservationChangedError();
+    }
+    ownedReservationBody = markedResponseBody;
+  };
+
+  let mutationResponse: ApiGatewayHttpResponse;
+  try {
+    mutationResponse = await input.execute({
+      markExternalSideEffectStarted,
+    });
+  } catch (error) {
+    if (error instanceof ReservedIdempotencyReservationChangedError) {
+      const replay = await replayStoredIdempotencyMutation(input);
+      return replay ?? idempotencyInProgressResponse(input.origin, input.allowedOrigins);
+    }
+
+    if (!pendingIdempotencyBodyHasExternalSideEffectStarted(ownedReservationBody)) {
+      await input.repository.deleteIdempotencyRecord({
+        scope,
+        key: idempotencyKey,
+        requestHash,
+        responseStatusCode: IDEMPOTENCY_PENDING_STATUS_CODE,
+        responseBody: ownedReservationBody,
+      });
+    }
+    throw error;
+  }
+
+  if (isRetryableReservedIdempotencyResponse(mutationResponse)) {
+    if (!pendingIdempotencyBodyHasExternalSideEffectStarted(ownedReservationBody)) {
+      await input.repository.deleteIdempotencyRecord({
+        scope,
+        key: idempotencyKey,
+        requestHash,
+        responseStatusCode: IDEMPOTENCY_PENDING_STATUS_CODE,
+        responseBody: ownedReservationBody,
+      });
+    }
+    return mutationResponse;
+  }
+
+  await input.repository.completeIdempotencyRecord({
+    scope,
+    key: idempotencyKey,
+    requestHash,
+    responseStatusCode: mutationResponse.statusCode,
+    responseBody: mutationResponse.body,
+    expectedResponseStatusCode: IDEMPOTENCY_PENDING_STATUS_CODE,
+    expectedResponseBody: ownedReservationBody,
+  });
+
+  return mutationResponse;
 }
 
 async function waitForIdempotencyRecord(): Promise<void> {
@@ -1741,6 +2297,7 @@ async function replayStoredIdempotencyMutation(input: {
   const idempotencyKey = parsedHeader.data;
   const scope = buildIdempotencyScope(input.sessionEmail, input.method, input.route);
   const requestHash = buildIdempotencyRequestHash(scope, input.requestPayload);
+  let sawPendingRecord = false;
 
   for (let attempt = 0; attempt < 3; attempt += 1) {
     const record = await input.repository.getIdempotencyRecord(scope, idempotencyKey);
@@ -1749,11 +2306,15 @@ async function replayStoredIdempotencyMutation(input: {
         return idempotencyConflictResponse(input.origin, input.allowedOrigins);
       }
 
-      return createJsonResponse(
-        record.responseStatusCode,
-        parseStoredIdempotencyResponseBody(record.responseBody),
-        buildCorsHeaders(input.origin, input.allowedOrigins),
-      );
+      if (isPendingIdempotencyRecord(record)) {
+        sawPendingRecord = true;
+        if (attempt < 2) {
+          await waitForIdempotencyRecord();
+        }
+        continue;
+      }
+
+      return replayIdempotencyRecord(record, input.origin, input.allowedOrigins);
     }
 
     if (attempt < 2) {
@@ -1761,7 +2322,7 @@ async function replayStoredIdempotencyMutation(input: {
     }
   }
 
-  return null;
+  return sawPendingRecord ? idempotencyInProgressResponse(input.origin, input.allowedOrigins) : null;
 }
 
 function decodeRouteParam(value: string): string {
@@ -1772,7 +2333,8 @@ function createDefaultDependencies(): CoreHandlerDependencies {
   const region = process.env.AWS_REGION ?? "ap-southeast-2";
   const tableName = process.env.DYNAMODB_TABLE ?? "threefc_local";
   const ddbEndpoint = process.env.DYNAMODB_ENDPOINT;
-  const appBaseUrl = process.env.APP_BASE_URL ?? "https://app.3fc.football";
+  const appBaseUrl = process.env.APP_BASE_URL ?? "https://3fc.football";
+  const publicAppBaseUrl = process.env.PUBLIC_APP_BASE_URL ?? appBaseUrl;
   const sessionCookieSecure = resolveSessionCookieSecureFlag(
     process.env.SESSION_COOKIE_SECURE,
     appBaseUrl,
@@ -1853,6 +2415,8 @@ function createDefaultDependencies(): CoreHandlerDependencies {
     sessionCookieName: process.env.SESSION_COOKIE_NAME ?? "threefc_session",
     sessionCookieSecure,
     corsAllowedOrigins: parseAllowedOrigins(process.env.CORS_ALLOWED_ORIGINS),
+    appBaseUrl,
+    publicAppBaseUrl,
   };
 }
 
@@ -1900,6 +2464,16 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
         const email = normalizeMagicLinkEmail(rawBody.email);
         if (!isMagicLinkEmailLike(email)) {
           status = 400;
+          logMagicLinkEvent({
+            requestId: details.requestId,
+            route,
+            method,
+            status,
+            action: "start",
+            outcome: "failure",
+            reason: "invalid_email",
+            emailHash: hashEmailDiagnostic(email),
+          });
           return magicLinkErrorResponse(
             origin,
             dependencies.corsAllowedOrigins,
@@ -1921,6 +2495,16 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
             dimension: rateLimitDecision.dimension,
             retryAfterSeconds: rateLimitDecision.retryAfterSeconds,
           });
+          logMagicLinkEvent({
+            requestId: details.requestId,
+            route,
+            method,
+            status,
+            action: "start",
+            outcome: "blocked",
+            reason: "rate_limited",
+            emailHash: hashEmailDiagnostic(email),
+          });
           return rateLimited(
             origin,
             dependencies.corsAllowedOrigins,
@@ -1931,6 +2515,17 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
         try {
           const startResult = await dependencies.magicLinkService.start(email);
           status = 202;
+          logMagicLinkEvent({
+            requestId: details.requestId,
+            route,
+            method,
+            status,
+            action: "start",
+            outcome: "success",
+            reason: "sent",
+            emailHash: hashEmailDiagnostic(email),
+            correlationId: startResult.messageId ?? undefined,
+          });
           return createJsonResponse(
             status,
             {
@@ -1944,6 +2539,16 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
         } catch (error) {
           if (error instanceof MagicLinkAuthError) {
             status = error.statusCode;
+            logMagicLinkEvent({
+              requestId: details.requestId,
+              route,
+              method,
+              status,
+              action: "start",
+              outcome: "failure",
+              reason: error.code,
+              emailHash: hashEmailDiagnostic(email),
+            });
             return magicLinkErrorResponse(origin, dependencies.corsAllowedOrigins, error);
           }
 
@@ -1962,12 +2567,31 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
 
         if (typeof rawBody.token !== "string") {
           status = 400;
+          logMagicLinkEvent({
+            requestId: details.requestId,
+            route,
+            method,
+            status,
+            action: "complete",
+            outcome: "failure",
+            reason: "missing_token",
+          });
           return badRequest(origin, dependencies.corsAllowedOrigins, "Field `token` is required.");
         }
 
         try {
           const completed = await dependencies.magicLinkService.complete(rawBody.token);
           status = 200;
+          logMagicLinkEvent({
+            requestId: details.requestId,
+            route,
+            method,
+            status,
+            action: "complete",
+            outcome: "success",
+            reason: "authenticated",
+            tokenIdHash: hashMagicLinkTokenId(rawBody.token),
+          });
           return createJsonResponse(
             status,
             {
@@ -1992,6 +2616,16 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
         } catch (error) {
           if (error instanceof MagicLinkAuthError) {
             status = error.statusCode;
+            logMagicLinkEvent({
+              requestId: details.requestId,
+              route,
+              method,
+              status,
+              action: "complete",
+              outcome: "failure",
+              reason: error.code,
+              tokenIdHash: hashMagicLinkTokenId(rawBody.token),
+            });
             return magicLinkErrorResponse(origin, dependencies.corsAllowedOrigins, error);
           }
 
@@ -2282,6 +2916,281 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
           );
         }
 
+        const createLeagueOrganiserInviteMatch = route.match(
+          /^\/v1\/leagues\/([^/]+)\/organiser-invites$/,
+        );
+        if (method === "POST" && createLeagueOrganiserInviteMatch) {
+          const leagueId = decodeRouteParam(createLeagueOrganiserInviteMatch[1]);
+          const league = await dependencies.repository.getLeague(leagueId);
+          if (!league) {
+            status = 404;
+            return notFound(origin, dependencies.corsAllowedOrigins, `League ${leagueId} was not found.`);
+          }
+
+          let rawBody: Record<string, unknown>;
+          try {
+            rawBody = parseJsonBody(event);
+          } catch {
+            status = 400;
+            return badRequest(origin, dependencies.corsAllowedOrigins, "Request body must be valid JSON.");
+          }
+
+          const parsedBody = createLeagueOrganiserInviteRequestSchema.safeParse(rawBody);
+          if (!parsedBody.success) {
+            status = 400;
+            return badRequest(
+              origin,
+              dependencies.corsAllowedOrigins,
+              formatSchemaValidationError(parsedBody.error),
+            );
+          }
+
+          const inviteEmail =
+            typeof parsedBody.data.email === "string" && parsedBody.data.email.trim().length > 0
+              ? normalizeMagicLinkEmail(parsedBody.data.email)
+              : null;
+          if (inviteEmail && !isMagicLinkEmailLike(inviteEmail)) {
+            status = 400;
+            return magicLinkErrorResponse(
+              origin,
+              dependencies.corsAllowedOrigins,
+              new MagicLinkAuthError("invalid_email", 400, "Email must be a valid email address."),
+            );
+          }
+
+          const createdByUserId = sessionSubject(session);
+          const inviteKind: LeagueInviteRecord["kind"] = inviteEmail ? "email" : "share";
+          const inviteCode = inviteEmail
+            ? buildOrganiserInviteIdempotencyCode({
+                sessionEmail: session.email,
+                method,
+                route,
+                idempotencyKey,
+              })
+            : null;
+          const recoverStartedExternalSideEffect = inviteEmail && inviteCode
+            ? async (): Promise<ApiGatewayHttpResponse | null> => {
+                const existingInvite = await dependencies.repository.getLeagueOrganiserInvite(inviteCode);
+                if (
+                  !existingInvite ||
+                  !isMatchingRecoveredOrganiserInvite({
+                    invite: existingInvite,
+                    leagueId,
+                    email: inviteEmail,
+                    createdByUserId,
+                    kind: inviteKind,
+                  })
+                ) {
+                  return null;
+                }
+
+                logMagicLinkEvent({
+                  requestId: details.requestId,
+                  route,
+                  method,
+                  status: 202,
+                  action: "organiser_invite_start",
+                  outcome: "unknown",
+                  reason: "stale_started_recovered",
+                  emailHash: hashEmailDiagnostic(inviteEmail),
+                });
+
+                return createJsonResponse(
+                  202,
+                  buildOrganiserInviteResponse(
+                    existingInvite,
+                    dependencies.publicAppBaseUrl ?? dependencies.appBaseUrl,
+                    {
+                      status: "unknown",
+                      email: inviteEmail,
+                      expiresAt: null,
+                      messageId: null,
+                      message: "Email delivery could not be confirmed. Share the invite link manually.",
+                    },
+                  ),
+                  buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
+                );
+              }
+            : undefined;
+
+          const inviteResponse = await executeReservedIdempotentMutation({
+            repository: dependencies.repository,
+            idempotencyKey,
+            sessionEmail: session.email,
+            method,
+            route,
+            requestPayload: { email: inviteEmail },
+            origin,
+            allowedOrigins: dependencies.corsAllowedOrigins,
+            ...(recoverStartedExternalSideEffect ? { recoverStartedExternalSideEffect } : {}),
+            execute: async ({ markExternalSideEffectStarted }) => {
+              if (inviteEmail) {
+                const rateLimitDecision = await dependencies.magicLinkRateLimiter.consumeMagicLinkStart({
+                  email: inviteEmail,
+                  clientIp,
+                });
+                if (!rateLimitDecision.allowed) {
+                  logAuthRateLimit({
+                    requestId: details.requestId,
+                    route,
+                    method,
+                    status: 429,
+                    dimension: rateLimitDecision.dimension,
+                    retryAfterSeconds: rateLimitDecision.retryAfterSeconds,
+                  });
+                  return rateLimited(
+                    origin,
+                    dependencies.corsAllowedOrigins,
+                    rateLimitDecision.retryAfterSeconds,
+                  );
+                }
+              }
+
+              let invite: LeagueInviteRecord;
+              try {
+                invite = await createOrRecoverLeagueOrganiserInvite({
+                  repository: dependencies.repository,
+                  leagueId,
+                  email: inviteEmail,
+                  createdByUserId,
+                  inviteCode,
+                  kind: inviteKind,
+                });
+              } catch (error) {
+                if (error instanceof LeagueInviteCodeCollisionError) {
+                  return createJsonResponse(
+                    409,
+                    {
+                      error: "conflict",
+                      code: "invite_code_collision",
+                      message: error.message,
+                    },
+                    buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
+                  );
+                }
+
+                throw error;
+              }
+              const invitePath = buildOrganiserInvitePath(invite.inviteCode);
+              let responseStatusCode = 201;
+              let emailDelivery: OrganiserInviteEmailDeliveryResponse | null = null;
+              if (inviteEmail) {
+                await markExternalSideEffectStarted();
+                try {
+                  const delivery = await dependencies.magicLinkService.start(inviteEmail, {
+                    returnTo: invitePath,
+                    subject: `You're invited to organise ${league.name} on 3FC`,
+                    introLines: [
+                      `You have been invited to help organise ${league.name} on 3FC.`,
+                    ],
+                  });
+                  emailDelivery = {
+                    status: "sent",
+                    email: delivery.email,
+                    expiresAt: delivery.expiresAt,
+                    messageId: delivery.messageId,
+                  };
+                  logMagicLinkEvent({
+                    requestId: details.requestId,
+                    route,
+                    method,
+                    status: responseStatusCode,
+                    action: "organiser_invite_start",
+                    outcome: "success",
+                    reason: "sent",
+                    emailHash: hashEmailDiagnostic(inviteEmail),
+                    correlationId: delivery.messageId ?? undefined,
+                  });
+                } catch {
+                  responseStatusCode = 202;
+                  emailDelivery = {
+                    status: "unknown",
+                    email: inviteEmail,
+                    expiresAt: null,
+                    messageId: null,
+                    message: "Email delivery could not be confirmed. Share the invite link manually.",
+                  };
+                  logMagicLinkEvent({
+                    requestId: details.requestId,
+                    route,
+                    method,
+                    status: responseStatusCode,
+                    action: "organiser_invite_start",
+                    outcome: "unknown",
+                    reason: "delivery_unconfirmed",
+                    emailHash: hashEmailDiagnostic(inviteEmail),
+                  });
+                }
+              }
+
+              return createJsonResponse(
+                responseStatusCode,
+                buildOrganiserInviteResponse(
+                  invite,
+                  dependencies.publicAppBaseUrl ?? dependencies.appBaseUrl,
+                  emailDelivery,
+                ),
+                buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
+              );
+            },
+          });
+          status = inviteResponse.statusCode;
+          return inviteResponse;
+        }
+
+        const acceptLeagueOrganiserInviteMatch = route.match(/^\/v1\/invites\/([^/]+)\/accept$/);
+        if (method === "POST" && acceptLeagueOrganiserInviteMatch) {
+          let rawBody: Record<string, unknown>;
+          try {
+            rawBody = parseJsonBody(event);
+          } catch {
+            status = 400;
+            return badRequest(origin, dependencies.corsAllowedOrigins, "Request body must be valid JSON.");
+          }
+
+          const parsedBody = acceptLeagueOrganiserInviteRequestSchema.safeParse(rawBody);
+          if (!parsedBody.success) {
+            status = 400;
+            return badRequest(
+              origin,
+              dependencies.corsAllowedOrigins,
+              formatSchemaValidationError(parsedBody.error),
+            );
+          }
+
+          try {
+            const result = await dependencies.repository.acceptLeagueOrganiserInvite({
+              inviteCode: decodeRouteParam(acceptLeagueOrganiserInviteMatch[1]),
+              userId: sessionSubject(session),
+              email: session.email,
+            });
+            if (!result) {
+              status = 404;
+              return notFound(origin, dependencies.corsAllowedOrigins, "Organiser invite was not found.");
+            }
+
+            status = 200;
+            return createJsonResponse(
+              status,
+              {
+                ...result,
+                inviteLink: buildAppUrl(
+                  dependencies.publicAppBaseUrl ?? dependencies.appBaseUrl,
+                  buildOrganiserInvitePath(result.invite.inviteCode),
+                ),
+              },
+              buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
+            );
+          } catch (error) {
+            if (error instanceof LeagueInviteError) {
+              status = error.statusCode;
+              return leagueInviteErrorResponse(origin, dependencies.corsAllowedOrigins, error);
+            }
+
+            throw error;
+          }
+        }
+
         const createSeasonMatch = route.match(/^\/v1\/leagues\/([^/]+)\/seasons$/);
         if (method === "POST" && createSeasonMatch) {
           let rawBody: Record<string, unknown>;
@@ -2456,7 +3365,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
           const access = await ensureLeagueAccess(
             dependencies.repository,
             season.leagueId,
-            session.email,
+            sessionUserIds(session),
           );
           if (!access.allowed) {
             status = 403;
@@ -2488,7 +3397,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
           const access = await ensureLeagueAccess(
             dependencies.repository,
             season.leagueId,
-            session.email,
+            sessionUserIds(session),
           );
           if (!access.allowed) {
             status = 403;
@@ -2533,7 +3442,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
           const access = await ensureLeagueAccess(
             dependencies.repository,
             season.leagueId,
-            session.email,
+            sessionUserIds(session),
           );
           if (!access.allowed) {
             status = 403;
@@ -2610,7 +3519,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
           const isAdmin = await ensureLeagueAdmin(
             dependencies.repository,
             season.leagueId,
-            session.email,
+            sessionUserIds(session),
           );
           if (!isAdmin) {
             status = 403;
@@ -2820,7 +3729,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
           const access = await ensureLeagueAccess(
             dependencies.repository,
             game.leagueId,
-            session.email,
+            sessionUserIds(session),
           );
           if (!access.allowed) {
             status = 403;
@@ -2864,7 +3773,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
           const finishedBlock = await buildFinishedGameMutationBlock({
             repository: dependencies.repository,
             game,
-            sessionEmail: session.email,
+            sessionUserIds: sessionUserIds(session),
             origin,
             allowedOrigins: dependencies.corsAllowedOrigins,
           });
@@ -2920,7 +3829,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
           const finishedBlock = await buildFinishedGameMutationBlock({
             repository: dependencies.repository,
             game,
-            sessionEmail: session.email,
+            sessionUserIds: sessionUserIds(session),
             origin,
             allowedOrigins: dependencies.corsAllowedOrigins,
           });
@@ -3201,7 +4110,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
                   const finishedBlock = await buildFinishedGameMutationBlock({
                     repository: dependencies.repository,
                     game: currentGame,
-                    sessionEmail: session.email,
+                    sessionUserIds: sessionUserIds(session),
                     origin,
                     allowedOrigins: dependencies.corsAllowedOrigins,
                   });
@@ -3323,7 +4232,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
                 const finishedBlock = await buildFinishedGameMutationBlock({
                   repository: dependencies.repository,
                   game: currentGame,
-                  sessionEmail: session.email,
+                  sessionUserIds: sessionUserIds(session),
                   origin,
                   allowedOrigins: dependencies.corsAllowedOrigins,
                 });
@@ -3413,7 +4322,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
                 const finishedBlock = await buildFinishedGameMutationBlock({
                   repository: dependencies.repository,
                   game: currentGame,
-                  sessionEmail: session.email,
+                  sessionUserIds: sessionUserIds(session),
                   origin,
                   allowedOrigins: dependencies.corsAllowedOrigins,
                 });
@@ -3518,7 +4427,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
                 const finishedBlock = await buildFinishedGameMutationBlock({
                   repository: dependencies.repository,
                   game: currentGame,
-                  sessionEmail: session.email,
+                  sessionUserIds: sessionUserIds(session),
                   origin,
                   allowedOrigins: dependencies.corsAllowedOrigins,
                 });
@@ -3577,7 +4486,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
           const access = await ensureLeagueAccess(
             dependencies.repository,
             game.leagueId,
-            session.email,
+            sessionUserIds(session),
           );
           if (!access.allowed) {
             status = 403;
@@ -3898,7 +4807,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
               const finishedBlock = await buildFinishedGameMutationBlock({
                 repository: dependencies.repository,
                 game: currentGame,
-                sessionEmail: session.email,
+                sessionUserIds: sessionUserIds(session),
                 origin,
                 allowedOrigins: dependencies.corsAllowedOrigins,
               });
@@ -3911,7 +4820,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
                 (await ensureLeagueAccess(
                   dependencies.repository,
                   currentGame.leagueId,
-                  session.email,
+                  sessionUserIds(session),
                 )).role === "admin";
               let player;
               try {
@@ -3928,7 +4837,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
                     const finishedBlockAfterRace = await buildFinishedGameMutationBlock({
                       repository: dependencies.repository,
                       game: latestGame,
-                      sessionEmail: session.email,
+                      sessionUserIds: sessionUserIds(session),
                       origin,
                       allowedOrigins: dependencies.corsAllowedOrigins,
                     });
@@ -3975,7 +4884,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
           const access = await ensureLeagueAccess(
             dependencies.repository,
             game.leagueId,
-            session.email,
+            sessionUserIds(session),
           );
           if (!access.allowed) {
             status = 403;
@@ -4009,7 +4918,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
           const finishedBlock = await buildFinishedGameMutationBlock({
             repository: dependencies.repository,
             game,
-            sessionEmail: session.email,
+            sessionUserIds: sessionUserIds(session),
             origin,
             allowedOrigins: dependencies.corsAllowedOrigins,
           });
@@ -4064,7 +4973,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
                 const finishedBlock = await buildFinishedGameMutationBlock({
                   repository: dependencies.repository,
                   game: currentGame,
-                  sessionEmail: session.email,
+                  sessionUserIds: sessionUserIds(session),
                   origin,
                   allowedOrigins: dependencies.corsAllowedOrigins,
                 });
@@ -4111,7 +5020,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
           const isAdmin = await ensureLeagueAdmin(
             dependencies.repository,
             existingGame.leagueId,
-            session.email,
+            sessionUserIds(session),
           );
           if (!isAdmin) {
             status = 403;
@@ -4187,7 +5096,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
           const isAdmin = await ensureLeagueAdmin(
             dependencies.repository,
             game.leagueId,
-            session.email,
+            sessionUserIds(session),
           );
           if (!isAdmin) {
             status = 403;

--- a/api/src/logging.ts
+++ b/api/src/logging.ts
@@ -16,6 +16,15 @@ interface AuthRateLimitLogFields extends RequestLogFields {
   retryAfterSeconds: number;
 }
 
+interface MagicLinkEventLogFields extends RequestLogFields {
+  action: "start" | "complete" | "organiser_invite_start";
+  outcome: "success" | "failure" | "blocked" | "unknown";
+  reason: string;
+  emailHash?: string;
+  tokenIdHash?: string;
+  correlationId?: string;
+}
+
 function writeLog(level: LogLevel, payload: Record<string, unknown>): void {
   const entry = JSON.stringify({
     level,
@@ -49,6 +58,13 @@ export function logRequestError(fields: RequestErrorLogFields): void {
 export function logAuthRateLimit(fields: AuthRateLimitLogFields): void {
   writeLog("info", {
     message: "auth_rate_limited",
+    ...fields,
+  });
+}
+
+export function logMagicLinkEvent(fields: MagicLinkEventLogFields): void {
+  writeLog(fields.outcome === "failure" ? "error" : "info", {
+    message: "magic_link_event",
     ...fields,
   });
 }

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -51,8 +51,10 @@ import {
 } from "./auth/session.js";
 import {
   claimPlayerRequestSchema,
+  acceptLeagueOrganiserInviteRequestSchema,
   createGameRequestSchema,
   createGoalRequestSchema,
+  createLeagueOrganiserInviteRequestSchema,
   createLeagueRequestSchema,
   createSeasonRequestSchema,
   createSessionRequestSchema,
@@ -76,12 +78,14 @@ import {
   GameTimerTransitionError,
   GoalCorrectionError,
   GoalCreationError,
+  LeagueInviteCodeCollisionError,
+  LeagueInviteError,
   PlayerClaimError,
   ThreeFcRepository,
 } from "./data/repository.js";
-import type { GameRecord } from "./data/types.js";
+import type { LeagueInviteRecord, GameRecord } from "./data/types.js";
 import { buildHealthResponse } from "./index.js";
-import { logAuthRateLimit, logRequest, logRequestError } from "./logging.js";
+import { logAuthRateLimit, logMagicLinkEvent, logRequest, logRequestError } from "./logging.js";
 
 const PORT = Number.parseInt(process.env.PORT ?? "3001", 10);
 const REGION = process.env.AWS_REGION ?? "ap-southeast-2";
@@ -90,6 +94,7 @@ const DYNAMODB_ENDPOINT = process.env.DYNAMODB_ENDPOINT ?? "http://localhost:800
 const FAKE_SES_URL = process.env.FAKE_SES_URL ?? "http://localhost:4025/send-email";
 const FAKE_SES_FROM = process.env.FAKE_SES_FROM ?? "noreply@3fc.football";
 const APP_BASE_URL = process.env.APP_BASE_URL ?? "http://localhost:3000";
+const PUBLIC_APP_BASE_URL = process.env.PUBLIC_APP_BASE_URL ?? APP_BASE_URL;
 const MAGIC_LINK_CALLBACK_PATH = process.env.MAGIC_LINK_CALLBACK_PATH ?? "/auth/callback";
 const MAGIC_LINK_TOKEN_TTL_SECONDS = Number.parseInt(
   process.env.MAGIC_LINK_TOKEN_TTL_SECONDS ?? "900",
@@ -181,10 +186,9 @@ type LocalUpdateGameTeamRouteRepository = Pick<
 
 type LocalDeleteGameRouteRepository = Pick<ThreeFcRepository, "getGame" | "getLeagueAccess" | "deleteGame">;
 
-type LocalIdempotencyRepository = Pick<
-  ThreeFcRepository,
-  "getIdempotencyRecord" | "createIdempotencyRecord"
->;
+type LocalIdempotencyRepository =
+  Pick<ThreeFcRepository, "getIdempotencyRecord" | "createIdempotencyRecord">
+  & Partial<Pick<ThreeFcRepository, "completeIdempotencyRecord" | "deleteIdempotencyRecord">>;
 
 type LocalCreateGameRouteRepository = LocalIdempotencyRepository &
   Pick<
@@ -315,6 +319,20 @@ function rateLimited(
     },
   );
   return 429;
+}
+
+function rateLimitedMutationResult(retryAfterSeconds: number): JsonMutationResult {
+  return {
+    statusCode: 429,
+    payload: {
+      error: "rate_limited",
+      message: "Too many sign-in link requests. Try again later.",
+      retryAfterSeconds,
+    },
+    headers: {
+      "Retry-After": String(retryAfterSeconds),
+    },
+  };
 }
 
 function forbidden(
@@ -547,15 +565,15 @@ function goalCorrectionError(
 
 async function buildFinishedGameMutationBlock(
   game: { gameId: string; leagueId: string; status: "scheduled" | "live" | "finished" },
-  sessionEmail: string,
+  userIds: UserIdCandidate | readonly UserIdCandidate[],
   repositoryClient: Pick<ThreeFcRepository, "getLeagueAccess"> = repository,
 ): Promise<{ statusCode: 409; payload: { error: "conflict"; code: "game_finished"; message: string } } | null> {
   if (game.status !== "finished") {
     return null;
   }
 
-  const access = await ensureLeagueAccess(game.leagueId, sessionEmail, repositoryClient);
-  if (access.role === "admin") {
+  const isAdmin = await ensureLeagueAdmin(game.leagueId, userIds, repositoryClient);
+  if (isAdmin) {
     return null;
   }
 
@@ -701,9 +719,9 @@ async function ensureFinishedGameMutationAllowed(
   request: IncomingMessage,
   response: ServerResponse,
   game: { gameId: string; leagueId: string; status: "scheduled" | "live" | "finished" },
-  sessionEmail: string,
+  userIds: UserIdCandidate | readonly UserIdCandidate[],
 ): Promise<{ allowed: boolean; status: number }> {
-  const block = await buildFinishedGameMutationBlock(game, sessionEmail);
+  const block = await buildFinishedGameMutationBlock(game, userIds);
   if (!block) {
     return { allowed: true, status: 200 };
   }
@@ -1030,6 +1048,77 @@ function idempotencyConflict(request: IncomingMessage, response: ServerResponse)
   return 409;
 }
 
+function idempotencyInProgress(request: IncomingMessage, response: ServerResponse): number {
+  sendJsonWithCors(request, response, 409, {
+    error: "idempotency_in_progress",
+    message: "A request with this idempotency key is still in progress. Retry shortly.",
+  });
+  return 409;
+}
+
+function isPendingIdempotencyRecord(record: { responseStatusCode: number; responseBody: string }): boolean {
+  if (record.responseStatusCode !== IDEMPOTENCY_PENDING_STATUS_CODE) {
+    return false;
+  }
+
+  return parsePendingIdempotencyBody(record.responseBody)?.idempotencyState === "pending";
+}
+
+function pendingIdempotencyReservedAtEpochMs(record: {
+  responseBody: string;
+  createdAt?: string;
+}): number | null {
+  const parsed = parsePendingIdempotencyBody(record.responseBody);
+  if (
+    typeof parsed?.reservedAtEpochMs === "number" &&
+    Number.isFinite(parsed.reservedAtEpochMs)
+  ) {
+    return parsed.reservedAtEpochMs;
+  }
+
+  if (record.createdAt) {
+    const createdAtEpochMs = Date.parse(record.createdAt);
+    if (Number.isFinite(createdAtEpochMs)) {
+      return createdAtEpochMs;
+    }
+  }
+
+  return null;
+}
+
+function pendingIdempotencyBodyHasExternalSideEffectStarted(responseBody: string): boolean {
+  return parsePendingIdempotencyBody(responseBody)?.externalSideEffect ===
+    IDEMPOTENCY_EXTERNAL_SIDE_EFFECT_EMAIL_DELIVERY_STARTED;
+}
+
+function isStalePendingIdempotencyRecord(record: {
+  responseStatusCode: number;
+  responseBody: string;
+  createdAt?: string;
+}): boolean {
+  if (!isPendingIdempotencyRecord(record)) {
+    return false;
+  }
+
+  const reservedAtEpochMs = pendingIdempotencyReservedAtEpochMs(record);
+  return reservedAtEpochMs !== null && Date.now() - reservedAtEpochMs > IDEMPOTENCY_PENDING_STALE_AFTER_MS;
+}
+
+function isRecoverableStalePendingIdempotencyRecord(record: {
+  responseStatusCode: number;
+  responseBody: string;
+  createdAt?: string;
+}): boolean {
+  return (
+    isStalePendingIdempotencyRecord(record) &&
+    !pendingIdempotencyBodyHasExternalSideEffectStarted(record.responseBody)
+  );
+}
+
+function isRetryableReservedIdempotencyResult(result: JsonMutationResult): boolean {
+  return result.statusCode === 429 || result.statusCode >= 500;
+}
+
 function readHeaderValue(request: IncomingMessage, name: string): string | undefined {
   const value = request.headers[name.toLowerCase()];
 
@@ -1064,6 +1153,19 @@ function buildIdempotencyRequestHash(scope: string, payload: unknown): string {
   return createHash("sha256")
     .update(`${scope}:${JSON.stringify(normalizePayloadForHashing(payload))}`)
     .digest("hex");
+}
+
+function hashDiagnosticValue(value: string): string {
+  return createHash("sha256").update(value).digest("hex").slice(0, 16);
+}
+
+function hashMagicLinkTokenId(rawToken: string): string {
+  const tokenId = rawToken.trim().split(".")[0]?.trim() ?? "";
+  return hashDiagnosticValue(tokenId || "missing-token-id");
+}
+
+function hashEmailDiagnostic(email: string): string {
+  return hashDiagnosticValue(normalizeMagicLinkEmail(email));
 }
 
 function parseOptionalIdempotencyKey(value: string | undefined): string | null {
@@ -1116,6 +1218,180 @@ function buildPublicJoinPlayerId(joinCode: string, idempotencyKey: string): stri
 }
 
 const PUBLIC_JOIN_IDEMPOTENCY_SUBJECT = "public-join";
+const IDEMPOTENCY_PENDING_STATUS_CODE = 202;
+const IDEMPOTENCY_PENDING_STALE_AFTER_MS = 2 * 60 * 1000;
+const IDEMPOTENCY_EXTERNAL_SIDE_EFFECT_EMAIL_DELIVERY_STARTED = "email_delivery_started";
+const INVITE_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+const INVITE_CODE_LENGTH = 8;
+
+interface PendingIdempotencyBody {
+  idempotencyState?: unknown;
+  reservationId?: unknown;
+  reservedAtEpochMs?: unknown;
+  externalSideEffect?: unknown;
+  externalSideEffectStartedAtEpochMs?: unknown;
+}
+
+interface ReservedIdempotencyMutationContext {
+  markExternalSideEffectStarted: () => Promise<void>;
+}
+
+class ReservedIdempotencyReservationChangedError extends Error {
+  constructor() {
+    super("Idempotency reservation changed before external side effect could be marked.");
+  }
+}
+
+function parsePendingIdempotencyBody(responseBody: string): PendingIdempotencyBody | null {
+  try {
+    const parsed = JSON.parse(responseBody) as unknown;
+    return typeof parsed === "object" && parsed !== null ? parsed as PendingIdempotencyBody : null;
+  } catch {
+    return null;
+  }
+}
+
+function buildPendingIdempotencyBody(input: {
+  reservationId?: string;
+  reservedAtEpochMs?: number;
+  externalSideEffect?: typeof IDEMPOTENCY_EXTERNAL_SIDE_EFFECT_EMAIL_DELIVERY_STARTED;
+  externalSideEffectStartedAtEpochMs?: number;
+} = {}): string {
+  const body: PendingIdempotencyBody = {
+    idempotencyState: "pending",
+    reservationId: input.reservationId ?? randomUUID(),
+    reservedAtEpochMs: input.reservedAtEpochMs ?? Date.now(),
+  };
+
+  if (input.externalSideEffect === IDEMPOTENCY_EXTERNAL_SIDE_EFFECT_EMAIL_DELIVERY_STARTED) {
+    body.externalSideEffect = IDEMPOTENCY_EXTERNAL_SIDE_EFFECT_EMAIL_DELIVERY_STARTED;
+    body.externalSideEffectStartedAtEpochMs =
+      input.externalSideEffectStartedAtEpochMs ?? Date.now();
+  }
+
+  return JSON.stringify(body);
+}
+
+function buildAppUrl(appBaseUrl: string, path: string): string {
+  const normalizedBase = appBaseUrl.endsWith("/") ? appBaseUrl.slice(0, -1) : appBaseUrl;
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+  return `${normalizedBase}${normalizedPath}`;
+}
+
+function buildOrganiserInvitePath(inviteCode: string): string {
+  return `/invites?code=${encodeURIComponent(inviteCode)}`;
+}
+
+type OrganiserInviteEmailDeliveryResponse =
+  | { status: "sent"; email: string; expiresAt: string; messageId: string | null }
+  | { status: "unknown"; email: string; expiresAt: null; messageId: null; message: string };
+
+function buildOrganiserInviteResponse(
+  invite: LeagueInviteRecord,
+  publicAppBaseUrl: string,
+  emailDelivery: OrganiserInviteEmailDeliveryResponse | null = null,
+): Record<string, unknown> {
+  const invitePath = buildOrganiserInvitePath(invite.inviteCode);
+  return {
+    invite,
+    inviteCode: invite.inviteCode,
+    inviteLink: buildAppUrl(publicAppBaseUrl, invitePath),
+    emailDelivery,
+  };
+}
+
+function buildOrganiserInviteIdempotencyCode(input: {
+  request: IncomingMessage;
+  sessionEmail: string;
+  method: string;
+  route: string;
+}): string | null {
+  const rawIdempotencyKey = readHeaderValue(input.request, "idempotency-key");
+  const parsedIdempotencyKey = rawIdempotencyKey
+    ? idempotencyKeyHeaderSchema.safeParse(rawIdempotencyKey)
+    : null;
+
+  if (!parsedIdempotencyKey?.success) {
+    return null;
+  }
+
+  const scope = buildIdempotencyScope(input.sessionEmail, input.method, input.route);
+  const digest = createHash("sha256")
+    .update(`organiser-invite:${scope}:${parsedIdempotencyKey.data}`)
+    .digest();
+  let inviteCode = "";
+  for (let index = 0; index < INVITE_CODE_LENGTH; index += 1) {
+    inviteCode += INVITE_CODE_ALPHABET[digest[index] % INVITE_CODE_ALPHABET.length];
+  }
+  return inviteCode;
+}
+
+function isMatchingRecoveredOrganiserInvite(input: {
+  invite: LeagueInviteRecord;
+  leagueId: string;
+  email: string | null;
+  createdByUserId: string;
+  kind: LeagueInviteRecord["kind"];
+}): boolean {
+  return (
+    input.invite.leagueId === input.leagueId &&
+    input.invite.kind === input.kind &&
+    input.invite.role === "admin" &&
+    input.invite.email === input.email &&
+    input.invite.createdByUserId === input.createdByUserId
+  );
+}
+
+async function createOrRecoverLeagueOrganiserInvite(input: {
+  leagueId: string;
+  email: string | null;
+  createdByUserId: string;
+  inviteCode: string | null;
+  kind: LeagueInviteRecord["kind"];
+}): Promise<LeagueInviteRecord> {
+  try {
+    return await repository.createLeagueOrganiserInvite({
+      leagueId: input.leagueId,
+      email: input.email,
+      createdByUserId: input.createdByUserId,
+      inviteCode: input.inviteCode,
+      kind: input.kind,
+    });
+  } catch (error) {
+    if (!(error instanceof LeagueInviteCodeCollisionError) || !input.inviteCode) {
+      throw error;
+    }
+
+    const existingInvite = await repository.getLeagueOrganiserInvite(input.inviteCode);
+    if (
+      existingInvite &&
+      isMatchingRecoveredOrganiserInvite({
+        invite: existingInvite,
+        leagueId: input.leagueId,
+        email: input.email,
+        createdByUserId: input.createdByUserId,
+        kind: input.kind,
+      })
+    ) {
+      return existingInvite;
+    }
+
+    throw error;
+  }
+}
+
+function sendLeagueInviteError(
+  request: IncomingMessage,
+  response: ServerResponse,
+  error: LeagueInviteError,
+): number {
+  sendJsonWithCors(request, response, error.statusCode, {
+    error: error.statusCode === 404 ? "not_found" : error.statusCode === 403 ? "forbidden" : "conflict",
+    code: error.code,
+    message: error.message,
+  });
+  return error.statusCode;
+}
 
 function buildGoalEventId(input: {
   request: IncomingMessage;
@@ -1182,6 +1458,7 @@ function parseStoredIdempotencyResponseBody(responseBody: string): unknown {
 interface JsonMutationResult {
   statusCode: number;
   payload: unknown;
+  headers?: Record<string, string>;
 }
 
 async function recoverLocalFinishedGameForFinishRoute(input: {
@@ -1282,7 +1559,13 @@ async function executeIdempotentMutation(input: {
 
   if (!idempotencyKeyRaw) {
     const mutation = await input.execute();
-    sendJsonWithCors(input.request, input.response, mutation.statusCode, mutation.payload);
+    sendJsonWithCors(
+      input.request,
+      input.response,
+      mutation.statusCode,
+      mutation.payload,
+      mutation.headers,
+    );
     return mutation.statusCode;
   }
 
@@ -1305,18 +1588,44 @@ async function executeIdempotentMutation(input: {
       return idempotencyConflict(input.request, input.response);
     }
 
-    sendJsonWithCors(
-      input.request,
-      input.response,
-      existing.responseStatusCode,
-      parseStoredIdempotencyResponseBody(existing.responseBody),
-    );
-    return existing.responseStatusCode;
+    if (isPendingIdempotencyRecord(existing)) {
+      if (
+        repositoryClient.deleteIdempotencyRecord &&
+        isStalePendingIdempotencyRecord(existing) &&
+        await repositoryClient.deleteIdempotencyRecord({
+          scope,
+          key,
+          requestHash,
+          responseStatusCode: existing.responseStatusCode,
+          responseBody: existing.responseBody,
+          updatedAt: existing.updatedAt,
+        })
+      ) {
+        // Continue as a new mutation after clearing stale pending state.
+      } else {
+        const replay = await replayStoredIdempotencyMutation(input);
+        return replay ?? idempotencyInProgress(input.request, input.response);
+      }
+    } else {
+      sendJsonWithCors(
+        input.request,
+        input.response,
+        existing.responseStatusCode,
+        parseStoredIdempotencyResponseBody(existing.responseBody),
+      );
+      return existing.responseStatusCode;
+    }
   }
 
   const mutation = await input.execute();
   if (input.shouldPersistResponse && !input.shouldPersistResponse(mutation)) {
-    sendJsonWithCors(input.request, input.response, mutation.statusCode, mutation.payload);
+    sendJsonWithCors(
+      input.request,
+      input.response,
+      mutation.statusCode,
+      mutation.payload,
+      mutation.headers,
+    );
     return mutation.statusCode;
   }
 
@@ -1336,6 +1645,33 @@ async function executeIdempotentMutation(input: {
         return idempotencyConflict(input.request, input.response);
       }
 
+      if (isPendingIdempotencyRecord(raceRecord)) {
+        if (
+          repositoryClient.deleteIdempotencyRecord &&
+          isStalePendingIdempotencyRecord(raceRecord) &&
+          await repositoryClient.deleteIdempotencyRecord({
+            scope,
+            key,
+            requestHash,
+            responseStatusCode: raceRecord.responseStatusCode,
+            responseBody: raceRecord.responseBody,
+            updatedAt: raceRecord.updatedAt,
+          })
+        ) {
+          sendJsonWithCors(
+            input.request,
+            input.response,
+            mutation.statusCode,
+            mutation.payload,
+            mutation.headers,
+          );
+          return mutation.statusCode;
+        }
+
+        const replay = await replayStoredIdempotencyMutation(input);
+        return replay ?? idempotencyInProgress(input.request, input.response);
+      }
+
       sendJsonWithCors(
         input.request,
         input.response,
@@ -1346,7 +1682,252 @@ async function executeIdempotentMutation(input: {
     }
   }
 
-  sendJsonWithCors(input.request, input.response, mutation.statusCode, mutation.payload);
+  sendJsonWithCors(
+    input.request,
+    input.response,
+    mutation.statusCode,
+    mutation.payload,
+    mutation.headers,
+  );
+  return mutation.statusCode;
+}
+
+async function executeReservedIdempotentMutation(input: {
+  request: IncomingMessage;
+  response: ServerResponse;
+  sessionEmail: string;
+  method: string;
+  route: string;
+  requestPayload: unknown;
+  execute: (context: ReservedIdempotencyMutationContext) => Promise<JsonMutationResult>;
+  recoverStartedExternalSideEffect?: (record: {
+    scope: string;
+    key: string;
+    requestHash: string;
+    responseStatusCode: number;
+    responseBody: string;
+    updatedAt: string;
+  }) => Promise<JsonMutationResult | null>;
+  repositoryClient?: LocalIdempotencyRepository;
+}): Promise<number> {
+  const repositoryClient = input.repositoryClient ?? repository;
+  if (!repositoryClient.completeIdempotencyRecord || !repositoryClient.deleteIdempotencyRecord) {
+    throw new Error("Reserved idempotency mutations require idempotency completion and deletion support.");
+  }
+  const completeIdempotencyRecord = repositoryClient.completeIdempotencyRecord;
+  const deleteIdempotencyRecord = repositoryClient.deleteIdempotencyRecord;
+
+  const idempotencyKeyRaw = readHeaderValue(input.request, "idempotency-key");
+
+  if (!idempotencyKeyRaw) {
+    const mutation = await input.execute({
+      markExternalSideEffectStarted: async () => undefined,
+    });
+    sendJsonWithCors(
+      input.request,
+      input.response,
+      mutation.statusCode,
+      mutation.payload,
+      mutation.headers,
+    );
+    return mutation.statusCode;
+  }
+
+  const parsedHeader = idempotencyKeyHeaderSchema.safeParse(idempotencyKeyRaw);
+  if (!parsedHeader.success) {
+    return badRequest(
+      input.request,
+      input.response,
+      formatSchemaValidationError(parsedHeader.error),
+    );
+  }
+
+  const scope = buildIdempotencyScope(input.sessionEmail, input.method, input.route);
+  const key = parsedHeader.data;
+  const requestHash = buildIdempotencyRequestHash(scope, input.requestPayload);
+  let reserved = false;
+  let reservedResponseBody: string | null = null;
+
+  for (let reserveAttempt = 0; reserveAttempt < 2; reserveAttempt += 1) {
+    const pendingResponseBody = buildPendingIdempotencyBody();
+    reserved = await repositoryClient.createIdempotencyRecord({
+      scope,
+      key,
+      requestHash,
+      responseStatusCode: IDEMPOTENCY_PENDING_STATUS_CODE,
+      responseBody: pendingResponseBody,
+    });
+
+    if (reserved) {
+      reservedResponseBody = pendingResponseBody;
+      break;
+    }
+
+    const existingRecord = await repositoryClient.getIdempotencyRecord(scope, key);
+    if (!existingRecord) {
+      continue;
+    }
+
+    if (existingRecord.requestHash !== requestHash) {
+      return idempotencyConflict(input.request, input.response);
+    }
+
+    if (
+      isPendingIdempotencyRecord(existingRecord) &&
+      isRecoverableStalePendingIdempotencyRecord(existingRecord) &&
+      await deleteIdempotencyRecord({
+        scope,
+        key,
+        requestHash,
+        responseStatusCode: existingRecord.responseStatusCode,
+        responseBody: existingRecord.responseBody,
+        updatedAt: existingRecord.updatedAt,
+      })
+    ) {
+      continue;
+    }
+
+    if (isPendingIdempotencyRecord(existingRecord)) {
+      if (
+        input.recoverStartedExternalSideEffect &&
+        isStalePendingIdempotencyRecord(existingRecord) &&
+        pendingIdempotencyBodyHasExternalSideEffectStarted(existingRecord.responseBody)
+      ) {
+        const recovered = await input.recoverStartedExternalSideEffect(existingRecord);
+        if (recovered) {
+          const completed = await completeIdempotencyRecord({
+            scope,
+            key,
+            requestHash,
+            responseStatusCode: recovered.statusCode,
+            responseBody: JSON.stringify(recovered.payload),
+            expectedResponseStatusCode: existingRecord.responseStatusCode,
+            expectedResponseBody: existingRecord.responseBody,
+            expectedUpdatedAt: existingRecord.updatedAt,
+          });
+          if (completed) {
+            sendJsonWithCors(
+              input.request,
+              input.response,
+              recovered.statusCode,
+              recovered.payload,
+              recovered.headers,
+            );
+            return recovered.statusCode;
+          }
+
+          const replayAfterRecoveryRace = await replayStoredIdempotencyMutation(input);
+          return replayAfterRecoveryRace ?? idempotencyInProgress(input.request, input.response);
+        }
+      }
+
+      const replay = await replayStoredIdempotencyMutation(input);
+      if (replay !== null) {
+        return replay;
+      }
+
+      return idempotencyInProgress(input.request, input.response);
+    }
+
+    sendJsonWithCors(
+      input.request,
+      input.response,
+      existingRecord.responseStatusCode,
+      parseStoredIdempotencyResponseBody(existingRecord.responseBody),
+    );
+    return existingRecord.responseStatusCode;
+  }
+
+  if (!reserved) {
+    return idempotencyInProgress(input.request, input.response);
+  }
+  if (!reservedResponseBody) {
+    return idempotencyInProgress(input.request, input.response);
+  }
+  let ownedReservationBody = reservedResponseBody;
+
+  const markExternalSideEffectStarted = async (): Promise<void> => {
+    const parsed = parsePendingIdempotencyBody(ownedReservationBody);
+    const markedResponseBody = buildPendingIdempotencyBody({
+      reservationId: typeof parsed?.reservationId === "string" ? parsed.reservationId : undefined,
+      reservedAtEpochMs: typeof parsed?.reservedAtEpochMs === "number" ? parsed.reservedAtEpochMs : undefined,
+      externalSideEffect: IDEMPOTENCY_EXTERNAL_SIDE_EFFECT_EMAIL_DELIVERY_STARTED,
+    });
+    const marked = await completeIdempotencyRecord({
+      scope,
+      key,
+      requestHash,
+      responseStatusCode: IDEMPOTENCY_PENDING_STATUS_CODE,
+      responseBody: markedResponseBody,
+      expectedResponseStatusCode: IDEMPOTENCY_PENDING_STATUS_CODE,
+      expectedResponseBody: ownedReservationBody,
+    });
+    if (!marked) {
+      throw new ReservedIdempotencyReservationChangedError();
+    }
+    ownedReservationBody = markedResponseBody;
+  };
+
+  let mutation: JsonMutationResult;
+  try {
+    mutation = await input.execute({
+      markExternalSideEffectStarted,
+    });
+  } catch (error) {
+    if (error instanceof ReservedIdempotencyReservationChangedError) {
+      const replay = await replayStoredIdempotencyMutation(input);
+      return replay ?? idempotencyInProgress(input.request, input.response);
+    }
+
+    if (!pendingIdempotencyBodyHasExternalSideEffectStarted(ownedReservationBody)) {
+      await deleteIdempotencyRecord({
+        scope,
+        key,
+        requestHash,
+        responseStatusCode: IDEMPOTENCY_PENDING_STATUS_CODE,
+        responseBody: ownedReservationBody,
+      });
+    }
+    throw error;
+  }
+
+  if (isRetryableReservedIdempotencyResult(mutation)) {
+    if (!pendingIdempotencyBodyHasExternalSideEffectStarted(ownedReservationBody)) {
+      await deleteIdempotencyRecord({
+        scope,
+        key,
+        requestHash,
+        responseStatusCode: IDEMPOTENCY_PENDING_STATUS_CODE,
+        responseBody: ownedReservationBody,
+      });
+    }
+    sendJsonWithCors(
+      input.request,
+      input.response,
+      mutation.statusCode,
+      mutation.payload,
+      mutation.headers,
+    );
+    return mutation.statusCode;
+  }
+
+  await completeIdempotencyRecord({
+    scope,
+    key,
+    requestHash,
+    responseStatusCode: mutation.statusCode,
+    responseBody: JSON.stringify(mutation.payload),
+    expectedResponseStatusCode: IDEMPOTENCY_PENDING_STATUS_CODE,
+    expectedResponseBody: ownedReservationBody,
+  });
+
+  sendJsonWithCors(
+    input.request,
+    input.response,
+    mutation.statusCode,
+    mutation.payload,
+    mutation.headers,
+  );
   return mutation.statusCode;
 }
 
@@ -1377,12 +1958,21 @@ async function replayStoredIdempotencyMutation(input: {
   const scope = buildIdempotencyScope(input.sessionEmail, input.method, input.route);
   const key = parsedHeader.data;
   const requestHash = buildIdempotencyRequestHash(scope, input.requestPayload);
+  let sawPendingRecord = false;
 
   for (let attempt = 0; attempt < 3; attempt += 1) {
     const record = await repositoryClient.getIdempotencyRecord(scope, key);
     if (record) {
       if (record.requestHash !== requestHash) {
         return idempotencyConflict(input.request, input.response);
+      }
+
+      if (isPendingIdempotencyRecord(record)) {
+        sawPendingRecord = true;
+        if (attempt < 2) {
+          await waitForIdempotencyRecord();
+        }
+        continue;
       }
 
       sendJsonWithCors(
@@ -1399,7 +1989,7 @@ async function replayStoredIdempotencyMutation(input: {
     }
   }
 
-  return null;
+  return sawPendingRecord ? idempotencyInProgress(input.request, input.response) : null;
 }
 
 export async function handleLocalGetGameRoute(input: {
@@ -1407,6 +1997,7 @@ export async function handleLocalGetGameRoute(input: {
   response: ServerResponse;
   gameId: string;
   sessionEmail: string;
+  sessionUserIds?: UserIdCandidate | readonly UserIdCandidate[];
   repositoryClient?: LocalGetGameRouteRepository;
 }): Promise<number> {
   const repositoryClient = input.repositoryClient ?? repository;
@@ -1415,7 +2006,11 @@ export async function handleLocalGetGameRoute(input: {
     return notFound(input.request, input.response, `Game ${input.gameId} was not found.`);
   }
 
-  const access = await ensureLeagueAccess(game.leagueId, input.sessionEmail, repositoryClient);
+  const access = await ensureLeagueAccess(
+    game.leagueId,
+    input.sessionUserIds ?? input.sessionEmail,
+    repositoryClient,
+  );
   if (!access.allowed) {
     return forbidden(
       input.request,
@@ -1682,6 +2277,7 @@ export async function handleLocalDeleteGameRoute(input: {
   response: ServerResponse;
   gameId: string;
   sessionEmail: string;
+  sessionUserIds?: UserIdCandidate | readonly UserIdCandidate[];
   repositoryClient?: LocalDeleteGameRouteRepository;
 }): Promise<number> {
   const repositoryClient = input.repositoryClient ?? repository;
@@ -1690,7 +2286,11 @@ export async function handleLocalDeleteGameRoute(input: {
     return notFound(input.request, input.response, `Game ${input.gameId} was not found.`);
   }
 
-  const isAdmin = await ensureLeagueAdmin(game.leagueId, input.sessionEmail, repositoryClient);
+  const isAdmin = await ensureLeagueAdmin(
+    game.leagueId,
+    input.sessionUserIds ?? input.sessionEmail,
+    repositoryClient,
+  );
   if (!isAdmin) {
     return forbidden(
       input.request,
@@ -2195,10 +2795,16 @@ function handleMagicLinkError(
   return error.statusCode;
 }
 
+interface RequestContext {
+  requestId: string;
+  route: string;
+  method: string;
+}
+
 async function handleMagicLinkStart(
   request: IncomingMessage,
   response: ServerResponse,
-  context: { requestId: string; route: string; method: string },
+  context: RequestContext,
 ): Promise<number> {
   if (
     !isMagicLinkStartOriginPermitted(
@@ -2225,6 +2831,16 @@ async function handleMagicLinkStart(
 
   const email = normalizeMagicLinkEmail(body.email);
   if (!isMagicLinkEmailLike(email)) {
+    logMagicLinkEvent({
+      requestId: context.requestId,
+      route: context.route,
+      method: context.method,
+      status: 400,
+      action: "start",
+      outcome: "failure",
+      reason: "invalid_email",
+      emailHash: hashEmailDiagnostic(email),
+    });
     return handleMagicLinkError(
       request,
       new MagicLinkAuthError("invalid_email", 400, "Email must be a valid email address."),
@@ -2245,11 +2861,32 @@ async function handleMagicLinkStart(
       dimension: rateLimitDecision.dimension,
       retryAfterSeconds: rateLimitDecision.retryAfterSeconds,
     });
+    logMagicLinkEvent({
+      requestId: context.requestId,
+      route: context.route,
+      method: context.method,
+      status: 429,
+      action: "start",
+      outcome: "blocked",
+      reason: "rate_limited",
+      emailHash: hashEmailDiagnostic(email),
+    });
     return rateLimited(request, response, rateLimitDecision.retryAfterSeconds);
   }
 
   try {
     const result = await magicLinkService.start(email);
+    logMagicLinkEvent({
+      requestId: context.requestId,
+      route: context.route,
+      method: context.method,
+      status: 202,
+      action: "start",
+      outcome: "success",
+      reason: "sent",
+      emailHash: hashEmailDiagnostic(email),
+      correlationId: result.messageId ?? undefined,
+    });
 
     sendJsonWithCors(request, response, 202, {
       status: "sent",
@@ -2260,6 +2897,18 @@ async function handleMagicLinkStart(
 
     return 202;
   } catch (error) {
+    if (error instanceof MagicLinkAuthError) {
+      logMagicLinkEvent({
+        requestId: context.requestId,
+        route: context.route,
+        method: context.method,
+        status: error.statusCode,
+        action: "start",
+        outcome: "failure",
+        reason: error.code,
+        emailHash: hashEmailDiagnostic(email),
+      });
+    }
     return handleMagicLinkError(request, error, response);
   }
 }
@@ -2267,6 +2916,7 @@ async function handleMagicLinkStart(
 async function handleMagicLinkComplete(
   request: IncomingMessage,
   response: ServerResponse,
+  context: RequestContext,
 ): Promise<number> {
   let body: Record<string, unknown>;
 
@@ -2277,11 +2927,30 @@ async function handleMagicLinkComplete(
   }
 
   if (typeof body.token !== "string") {
+    logMagicLinkEvent({
+      requestId: context.requestId,
+      route: context.route,
+      method: context.method,
+      status: 400,
+      action: "complete",
+      outcome: "failure",
+      reason: "missing_token",
+    });
     return badRequest(request, response, "Field `token` is required.");
   }
 
   try {
     const session = await magicLinkService.complete(body.token);
+    logMagicLinkEvent({
+      requestId: context.requestId,
+      route: context.route,
+      method: context.method,
+      status: 200,
+      action: "complete",
+      outcome: "success",
+      reason: "authenticated",
+      tokenIdHash: hashMagicLinkTokenId(body.token),
+    });
 
     sendJsonWithCors(
       request,
@@ -2308,6 +2977,18 @@ async function handleMagicLinkComplete(
 
     return 200;
   } catch (error) {
+    if (error instanceof MagicLinkAuthError) {
+      logMagicLinkEvent({
+        requestId: context.requestId,
+        route: context.route,
+        method: context.method,
+        status: error.statusCode,
+        action: "complete",
+        outcome: "failure",
+        reason: error.code,
+        tokenIdHash: hashMagicLinkTokenId(body.token),
+      });
+    }
     return handleMagicLinkError(request, error, response);
   }
 }
@@ -2442,7 +3123,7 @@ async function start(): Promise<void> {
       }
 
       if (method === "POST" && route === "/v1/auth/magic/complete") {
-        status = await handleMagicLinkComplete(request, response);
+        status = await handleMagicLinkComplete(request, response, { requestId, route, method });
         return;
       }
 
@@ -2662,6 +3343,276 @@ async function start(): Promise<void> {
         status = 200;
         sendJsonWithCors(request, response, status, accessGrant);
         return;
+      }
+
+      const createLeagueOrganiserInviteMatch = route.match(
+        /^\/v1\/leagues\/([^/]+)\/organiser-invites$/,
+      );
+      if (method === "POST" && createLeagueOrganiserInviteMatch) {
+        if (!authGate.session) {
+          status = 500;
+          sendJsonWithCors(request, response, status, {
+            error: "internal_error",
+            message: "Session should be available for authenticated route.",
+          });
+          return;
+        }
+
+        const session = authGate.session;
+        const leagueId = decodeURIComponent(createLeagueOrganiserInviteMatch[1]);
+        const league = await repository.getLeague(leagueId);
+        if (!league) {
+          status = notFound(request, response, `League ${leagueId} was not found.`);
+          return;
+        }
+
+        let rawBody: Record<string, unknown>;
+        try {
+          rawBody = await parseJsonBody(request);
+        } catch {
+          status = badRequest(request, response, "Request body must be valid JSON.");
+          return;
+        }
+
+        const parsedBody = createLeagueOrganiserInviteRequestSchema.safeParse(rawBody);
+        if (!parsedBody.success) {
+          status = badRequest(request, response, formatSchemaValidationError(parsedBody.error));
+          return;
+        }
+
+        const inviteEmail =
+          typeof parsedBody.data.email === "string" && parsedBody.data.email.trim().length > 0
+            ? normalizeMagicLinkEmail(parsedBody.data.email)
+            : null;
+        if (inviteEmail && !isMagicLinkEmailLike(inviteEmail)) {
+          status = handleMagicLinkError(
+            request,
+            new MagicLinkAuthError("invalid_email", 400, "Email must be a valid email address."),
+            response,
+          );
+          return;
+        }
+
+        const createdByUserId = sessionSubject(session);
+        const inviteKind: LeagueInviteRecord["kind"] = inviteEmail ? "email" : "share";
+        const inviteCode = inviteEmail
+          ? buildOrganiserInviteIdempotencyCode({
+              request,
+              sessionEmail: session.email,
+              method,
+              route,
+            })
+          : null;
+        const recoverStartedExternalSideEffect = inviteEmail && inviteCode
+          ? async (): Promise<JsonMutationResult | null> => {
+              const existingInvite = await repository.getLeagueOrganiserInvite(inviteCode);
+              if (
+                !existingInvite ||
+                !isMatchingRecoveredOrganiserInvite({
+                  invite: existingInvite,
+                  leagueId,
+                  email: inviteEmail,
+                  createdByUserId,
+                  kind: inviteKind,
+                })
+              ) {
+                return null;
+              }
+
+              logMagicLinkEvent({
+                requestId,
+                route,
+                method,
+                status: 202,
+                action: "organiser_invite_start",
+                outcome: "unknown",
+                reason: "stale_started_recovered",
+                emailHash: hashEmailDiagnostic(inviteEmail),
+              });
+
+              return {
+                statusCode: 202,
+                payload: buildOrganiserInviteResponse(
+                  existingInvite,
+                  PUBLIC_APP_BASE_URL,
+                  {
+                    status: "unknown",
+                    email: inviteEmail,
+                    expiresAt: null,
+                    messageId: null,
+                    message: "Email delivery could not be confirmed. Share the invite link manually.",
+                  },
+                ),
+              };
+            }
+          : undefined;
+
+        status = await executeReservedIdempotentMutation({
+          request,
+          response,
+          sessionEmail: session.email,
+          method,
+          route,
+          requestPayload: { email: inviteEmail },
+          ...(recoverStartedExternalSideEffect ? { recoverStartedExternalSideEffect } : {}),
+          execute: async ({ markExternalSideEffectStarted }) => {
+            if (inviteEmail) {
+              const rateLimitDecision = await magicLinkRateLimiter.consumeMagicLinkStart({
+                email: inviteEmail,
+                clientIp: getClientIp(request),
+              });
+              if (!rateLimitDecision.allowed) {
+                logAuthRateLimit({
+                  requestId,
+                  route,
+                  method,
+                  status: 429,
+                  dimension: rateLimitDecision.dimension,
+                  retryAfterSeconds: rateLimitDecision.retryAfterSeconds,
+                });
+                return rateLimitedMutationResult(rateLimitDecision.retryAfterSeconds);
+              }
+            }
+
+            let invite: LeagueInviteRecord;
+            try {
+              invite = await createOrRecoverLeagueOrganiserInvite({
+                leagueId,
+                email: inviteEmail,
+                createdByUserId,
+                inviteCode,
+                kind: inviteKind,
+              });
+            } catch (error) {
+              if (error instanceof LeagueInviteCodeCollisionError) {
+                return {
+                  statusCode: 409,
+                  payload: {
+                    error: "conflict",
+                    code: "invite_code_collision",
+                    message: error.message,
+                  },
+                };
+              }
+
+              throw error;
+            }
+
+            const invitePath = buildOrganiserInvitePath(invite.inviteCode);
+            let responseStatusCode = 201;
+            let emailDelivery: OrganiserInviteEmailDeliveryResponse | null = null;
+            if (inviteEmail) {
+              await markExternalSideEffectStarted();
+              try {
+                const delivery = await magicLinkService.start(inviteEmail, {
+                  returnTo: invitePath,
+                  subject: `You're invited to organise ${league.name} on 3FC`,
+                  introLines: [
+                    `You have been invited to help organise ${league.name} on 3FC.`,
+                  ],
+                });
+                emailDelivery = {
+                  status: "sent",
+                  email: delivery.email,
+                  expiresAt: delivery.expiresAt,
+                  messageId: delivery.messageId,
+                };
+                logMagicLinkEvent({
+                  requestId,
+                  route,
+                  method,
+                  status: responseStatusCode,
+                  action: "organiser_invite_start",
+                  outcome: "success",
+                  reason: "sent",
+                  emailHash: hashEmailDiagnostic(inviteEmail),
+                  correlationId: delivery.messageId ?? undefined,
+                });
+              } catch {
+                responseStatusCode = 202;
+                emailDelivery = {
+                  status: "unknown",
+                  email: inviteEmail,
+                  expiresAt: null,
+                  messageId: null,
+                  message: "Email delivery could not be confirmed. Share the invite link manually.",
+                };
+                logMagicLinkEvent({
+                  requestId,
+                  route,
+                  method,
+                  status: responseStatusCode,
+                  action: "organiser_invite_start",
+                  outcome: "unknown",
+                  reason: "delivery_unconfirmed",
+                  emailHash: hashEmailDiagnostic(inviteEmail),
+                });
+              }
+            }
+
+            return {
+              statusCode: responseStatusCode,
+              payload: buildOrganiserInviteResponse(
+                invite,
+                PUBLIC_APP_BASE_URL,
+                emailDelivery,
+              ),
+            };
+          },
+        });
+        return;
+      }
+
+      const acceptLeagueOrganiserInviteMatch = route.match(/^\/v1\/invites\/([^/]+)\/accept$/);
+      if (method === "POST" && acceptLeagueOrganiserInviteMatch) {
+        if (!authGate.session) {
+          status = 500;
+          sendJsonWithCors(request, response, status, {
+            error: "internal_error",
+            message: "Session should be available for authenticated route.",
+          });
+          return;
+        }
+
+        let rawBody: Record<string, unknown>;
+        try {
+          rawBody = await parseJsonBody(request);
+        } catch {
+          status = badRequest(request, response, "Request body must be valid JSON.");
+          return;
+        }
+
+        const parsedBody = acceptLeagueOrganiserInviteRequestSchema.safeParse(rawBody);
+        if (!parsedBody.success) {
+          status = badRequest(request, response, formatSchemaValidationError(parsedBody.error));
+          return;
+        }
+
+        try {
+          const result = await repository.acceptLeagueOrganiserInvite({
+            inviteCode: decodeURIComponent(acceptLeagueOrganiserInviteMatch[1]),
+            userId: sessionSubject(authGate.session),
+            email: authGate.session.email,
+          });
+          if (!result) {
+            status = notFound(request, response, "Organiser invite was not found.");
+            return;
+          }
+
+          status = 200;
+          sendJsonWithCors(request, response, status, {
+            ...result,
+            inviteLink: buildAppUrl(PUBLIC_APP_BASE_URL, buildOrganiserInvitePath(result.invite.inviteCode)),
+          });
+          return;
+        } catch (error) {
+          if (error instanceof LeagueInviteError) {
+            status = sendLeagueInviteError(request, response, error);
+            return;
+          }
+
+          throw error;
+        }
       }
 
       const createSeasonMatch = route.match(/^\/v1\/leagues\/([^/]+)\/seasons$/);
@@ -3023,6 +3974,7 @@ async function start(): Promise<void> {
           response,
           gameId: decodeURIComponent(getGameMatch[1]),
           sessionEmail: authGate.session.email,
+          sessionUserIds: sessionUserIds(authGate.session),
         });
         return;
       }
@@ -3148,6 +4100,7 @@ async function start(): Promise<void> {
 
         try {
           const sessionEmail = authGate.session.email;
+          const authUserIds = sessionUserIds(authGate.session);
           status = await executeIdempotentMutation({
             request,
             response,
@@ -3171,7 +4124,7 @@ async function start(): Promise<void> {
               if (currentGame.status === "finished") {
                 const finishedBlock = await buildFinishedGameMutationBlock(
                   currentGame,
-                  sessionEmail,
+                  authUserIds,
                 );
                 if (finishedBlock) {
                   return finishedBlock;
@@ -3266,6 +4219,7 @@ async function start(): Promise<void> {
 
         try {
           const sessionEmail = authGate.session.email;
+          const authUserIds = sessionUserIds(authGate.session);
           const correctionOperation = buildGoalCorrectionOperation({
             request,
             sessionEmail,
@@ -3294,7 +4248,7 @@ async function start(): Promise<void> {
 
               const finishedBlock = await buildFinishedGameMutationBlock(
                 currentGame,
-                sessionEmail,
+                authUserIds,
               );
               if (finishedBlock) {
                 return {
@@ -3363,6 +4317,7 @@ async function start(): Promise<void> {
 
         try {
           const sessionEmail = authGate.session.email;
+          const authUserIds = sessionUserIds(authGate.session);
           const requestPayload = { eventId };
           const correctionOperation = buildGoalCorrectionOperation({
             request,
@@ -3392,7 +4347,7 @@ async function start(): Promise<void> {
 
               const finishedBlock = await buildFinishedGameMutationBlock(
                 currentGame,
-                sessionEmail,
+                authUserIds,
               );
               if (finishedBlock) {
                 return {
@@ -3473,6 +4428,7 @@ async function start(): Promise<void> {
 
         try {
           const sessionEmail = authGate.session.email;
+          const authUserIds = sessionUserIds(authGate.session);
           const correctionOperation = buildGoalCorrectionOperation({
             request,
             sessionEmail,
@@ -3501,7 +4457,7 @@ async function start(): Promise<void> {
 
               const finishedBlock = await buildFinishedGameMutationBlock(
                 currentGame,
-                sessionEmail,
+                authUserIds,
               );
               if (finishedBlock) {
                 return {
@@ -3807,6 +4763,7 @@ async function start(): Promise<void> {
 
         const playerId = parsedBody.data.playerId ?? `player-${randomUUID()}`;
         const sessionEmail = authGate.session.email;
+        const authUserIds = sessionUserIds(authGate.session);
         status = await executeIdempotentMutation({
           request,
           response,
@@ -3828,7 +4785,7 @@ async function start(): Promise<void> {
 
             const finishedBlock = await buildFinishedGameMutationBlock(
               currentGame,
-              sessionEmail,
+              authUserIds,
             );
             if (finishedBlock) {
               return {
@@ -3839,7 +4796,7 @@ async function start(): Promise<void> {
 
             const allowFinished =
               currentGame.status === "finished" &&
-              (await ensureLeagueAdmin(currentGame.leagueId, sessionEmail));
+              (await ensureLeagueAdmin(currentGame.leagueId, authUserIds));
             let player;
             try {
               player = await repository.createAndLinkGamePlayer({
@@ -3854,7 +4811,7 @@ async function start(): Promise<void> {
                 if (latestGame) {
                   const finishedBlockAfterRace = await buildFinishedGameMutationBlock(
                     latestGame,
-                    sessionEmail,
+                    authUserIds,
                   );
                   if (finishedBlockAfterRace) {
                     return {
@@ -3944,7 +4901,7 @@ async function start(): Promise<void> {
           request,
           response,
           game,
-          authGate.session.email,
+          sessionUserIds(authGate.session),
         );
         if (!finishedLock.allowed) {
           status = finishedLock.status;
@@ -3994,7 +4951,7 @@ async function start(): Promise<void> {
                 request,
                 response,
                 currentGame,
-                authGate.session.email,
+                sessionUserIds(authGate.session),
               );
               if (!finishedLock.allowed) {
                 status = finishedLock.status;
@@ -4111,6 +5068,7 @@ async function start(): Promise<void> {
           response,
           gameId: decodeURIComponent(deleteGameMatch[1]),
           sessionEmail: authGate.session.email,
+          sessionUserIds: sessionUserIds(authGate.session),
         });
         return;
       }

--- a/api/src/tests/acl.test.ts
+++ b/api/src/tests/acl.test.ts
@@ -109,6 +109,10 @@ test("resolveProtectedMutationRoute maps supported mutation endpoints", () => {
     operation: "grantLeagueAccess",
     leagueId: "league-1",
   });
+  assert.deepEqual(resolveProtectedMutationRoute("POST", "/v1/leagues/league-1/organiser-invites"), {
+    operation: "createLeagueOrganiserInvite",
+    leagueId: "league-1",
+  });
   assert.equal(resolveProtectedMutationRoute("GET", "/v1/leagues"), null);
 });
 

--- a/api/src/tests/deployment-config.test.ts
+++ b/api/src/tests/deployment-config.test.ts
@@ -4,6 +4,8 @@ import { resolve } from "node:path";
 import test from "node:test";
 
 const serverlessCoreConfig = readFileSync(resolve(process.cwd(), "../serverless.api-core.yml"), "utf8");
+const productionTerraformConfig = readFileSync(resolve(process.cwd(), "../infra/prod/main.tf"), "utf8");
+const siteDeployScript = readFileSync(resolve(process.cwd(), "../scripts/deploy/deploy-site.sh"), "utf8");
 
 function assertServerlessRoute(method: string, path: string): void {
   assert.match(
@@ -17,4 +19,17 @@ test("api core deployment config registers claim and access routes", () => {
   assertServerlessRoute("OPTIONS", "/v1/players/{playerId}/claim");
   assertServerlessRoute("POST", "/v1/leagues/{leagueId}/access");
   assertServerlessRoute("OPTIONS", "/v1/leagues/{leagueId}/access");
+  assertServerlessRoute("POST", "/v1/leagues/{leagueId}/organiser-invites");
+  assertServerlessRoute("OPTIONS", "/v1/leagues/{leagueId}/organiser-invites");
+  assertServerlessRoute("POST", "/v1/invites/{inviteCode}/accept");
+  assertServerlessRoute("OPTIONS", "/v1/invites/{inviteCode}/accept");
+});
+
+test("api core deployment config sets canonical public invite link origins", () => {
+  assert.match(serverlessCoreConfig, /PUBLIC_APP_BASE_URL:/);
+  assert.match(serverlessCoreConfig, /appBaseUrls:\s+qa: https:\/\/qa\.3fc\.football\s+prod: https:\/\/3fc\.football\s+default: https:\/\/3fc\.football/);
+  assert.match(serverlessCoreConfig, /publicAppBaseUrls:\s+qa: https:\/\/qa\.3fc\.football\s+prod: https:\/\/3fc\.football\s+default: https:\/\/3fc\.football/);
+  assert.match(serverlessCoreConfig, /prod: https:\/\/3fc\.football,https:\/\/app\.3fc\.football,https:\/\/qa\.3fc\.football/);
+  assert.match(productionTerraformConfig, /site_domain\s+=\s+"3fc\.football"/);
+  assert.match(siteDeployScript, /SITE_DOMAIN="\$\{SITE_DOMAIN:-3fc\.football\}"/);
 });

--- a/api/src/tests/http-security.test.ts
+++ b/api/src/tests/http-security.test.ts
@@ -15,6 +15,7 @@ test("parseAllowedOrigins falls back to defaults when env is empty", () => {
   assert.deepEqual(origins, [
     "http://localhost:3000",
     "https://qa.3fc.football",
+    "https://3fc.football",
     "https://app.3fc.football",
   ]);
 });

--- a/api/src/tests/lambda-core.test.ts
+++ b/api/src/tests/lambda-core.test.ts
@@ -27,6 +27,7 @@ import {
   GameTimerTransitionError,
   GoalCorrectionError,
   GoalCreationError,
+  LeagueInviteError,
   PlayerClaimError,
 } from "../data/repository.js";
 
@@ -43,6 +44,19 @@ interface MockLeagueAccessRecord {
   userId: string;
   role: "admin" | "scorekeeper" | "viewer";
   grantedByUserId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface MockLeagueInviteRecord {
+  leagueId: string;
+  inviteCode: string;
+  kind: "share" | "email";
+  role: "admin";
+  email: string | null;
+  createdByUserId: string;
+  acceptedByUserId: string | null;
+  acceptedAt: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -220,6 +234,7 @@ interface StoredIdempotencyRecord {
 interface HarnessConfig {
   sessions?: Record<string, MockSessionRecord>;
   leagueAccess?: Record<string, MockLeagueAccessRecord>;
+  leagueInvites?: Record<string, MockLeagueInviteRecord>;
   leagues?: Record<string, MockLeagueRecord>;
   seasons?: Record<string, MockSeasonRecord>;
   seasonSessions?: Record<string, MockSessionEntity>;
@@ -245,6 +260,8 @@ interface HarnessConfig {
   rateLimitDecision?:
     | RateLimitDecision
     | ((input: { email: string; clientIp: string }) => RateLimitDecision);
+  magicLinkStartDelayMs?: number;
+  magicLinkStartError?: Error;
   beforeIdempotencyRecordRead?: (input: {
     scope: string;
     key: string;
@@ -300,6 +317,18 @@ function buildTestIdempotencyRequestHash(scope: string, payload: unknown): strin
     .digest("hex");
 }
 
+function buildTestOrganiserInviteCode(scope: string, idempotencyKey: string): string {
+  const alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+  const digest = createHash("sha256")
+    .update(`organiser-invite:${scope}:${idempotencyKey}`)
+    .digest();
+  let inviteCode = "";
+  for (let index = 0; index < 8; index += 1) {
+    inviteCode += alphabet[digest[index] % alphabet.length];
+  }
+  return inviteCode;
+}
+
 function completedThirdTimerSegments(): ThirdTimerSegment[] {
   return createDefaultThirdTimerSegments().map((third) => ({
     ...third,
@@ -347,7 +376,10 @@ function createHarness(config: HarnessConfig = {}) {
   const deletedGames: string[] = [];
   const assignedRosterPlayers: Array<{ gameId: string; teamId: TeamId; playerId: string }> = [];
   const linkedGamePlayers: Array<{ gameId: string; playerId: string }> = [];
-  const magicLinkStarts: string[] = [];
+  const magicLinkStarts: Array<{
+    email: string;
+    options?: { returnTo?: string | null; subject?: string; introLines?: string[] };
+  }> = [];
   const magicLinkCompletes: string[] = [];
   const magicLinkRateLimitChecks: Array<{ email: string; clientIp: string }> = [];
   const getGameCalls: Array<{
@@ -407,6 +439,15 @@ function createHarness(config: HarnessConfig = {}) {
     ]),
   );
   const players = new Map<string, MockPlayerRecord>(Object.entries(config.players ?? {}));
+  const leagueInvites = new Map<string, MockLeagueInviteRecord>(
+    Object.entries(config.leagueInvites ?? {}),
+  );
+  const leagueShareInviteCodes = new Map<string, string>();
+  for (const invite of leagueInvites.values()) {
+    if (invite.kind === "share") {
+      leagueShareInviteCodes.set(invite.leagueId, invite.inviteCode);
+    }
+  }
   const rosterAssignments = new Map<string, MockRosterAssignmentRecord>(
     Object.entries(config.rosterAssignments ?? {}),
   );
@@ -717,12 +758,19 @@ function createHarness(config: HarnessConfig = {}) {
     sessionCookieName: "threefc_session",
     sessionCookieSecure: false,
     corsAllowedOrigins: ["https://qa.3fc.football"],
+    appBaseUrl: "https://qa.3fc.football",
     magicLinkService: {
       async getSession(sessionId: string) {
         return config.sessions?.[sessionId] ?? null;
       },
-      async start(email: string) {
-        magicLinkStarts.push(email);
+      async start(email: string, options) {
+        magicLinkStarts.push({ email, options });
+        if (config.magicLinkStartDelayMs) {
+          await new Promise((resolve) => setTimeout(resolve, config.magicLinkStartDelayMs));
+        }
+        if (config.magicLinkStartError) {
+          throw config.magicLinkStartError;
+        }
         return {
           email,
           expiresAt: "2026-02-24T00:00:00.000Z",
@@ -981,14 +1029,6 @@ function createHarness(config: HarnessConfig = {}) {
           ) ?? null;
         if (!game) {
           return null;
-        }
-
-        if (game.status === "finished") {
-          throw new GameJoinRegistrationError(
-            "game_finished",
-            409,
-            `Game ${game.gameId} is finished. Join registration is closed.`,
-          );
         }
 
         if (joinGameByCodeStateChangedOnce) {
@@ -1280,7 +1320,23 @@ function createHarness(config: HarnessConfig = {}) {
         return seasons.delete(seasonId);
       },
       async deleteLeague(leagueId: string) {
-        return leagues.delete(leagueId);
+        const deleted = leagues.delete(leagueId);
+        if (!deleted) {
+          return false;
+        }
+
+        for (const [accessKey, access] of leagueAccess) {
+          if (access.leagueId === leagueId) {
+            leagueAccess.delete(accessKey);
+          }
+        }
+        for (const [inviteCode, invite] of leagueInvites) {
+          if (invite.leagueId === leagueId) {
+            leagueInvites.delete(inviteCode);
+          }
+        }
+        leagueShareInviteCodes.delete(leagueId);
+        return true;
       },
       async createPlayer(input) {
         createdPlayers.push(input);
@@ -1665,6 +1721,102 @@ function createHarness(config: HarnessConfig = {}) {
         grantedLeagueAccess.push(record);
         return record;
       },
+      async createLeagueOrganiserInvite(input) {
+        const inviteCodes = ["ABCD2345", "EFGH2345", "JKLM2345", "NPQR2345"];
+        if (input.kind === "share") {
+          const existingShareCode = leagueShareInviteCodes.get(input.leagueId);
+          if (existingShareCode) {
+            const existingShareInvite = leagueInvites.get(existingShareCode);
+            if (existingShareInvite) {
+              return existingShareInvite;
+            }
+          }
+        }
+
+        const inviteCode = input.inviteCode ?? inviteCodes[leagueInvites.size] ?? "STUV2345";
+        const record = {
+          leagueId: input.leagueId,
+          inviteCode,
+          kind: input.kind ?? "email",
+          role: "admin" as const,
+          email: input.email?.trim().toLowerCase() ?? null,
+          createdByUserId: input.createdByUserId,
+          acceptedByUserId: null,
+          acceptedAt: null,
+          createdAt: "2026-02-23T00:00:02.000Z",
+          updatedAt: "2026-02-23T00:00:02.000Z",
+        };
+        leagueInvites.set(inviteCode, record);
+        if (record.kind === "share") {
+          leagueShareInviteCodes.set(record.leagueId, record.inviteCode);
+        }
+        return record;
+      },
+      async getLeagueOrganiserInvite(inviteCode: string) {
+        return leagueInvites.get(inviteCode.trim().toUpperCase()) ?? null;
+      },
+      async acceptLeagueOrganiserInvite(input) {
+        const invite = leagueInvites.get(input.inviteCode.trim().toUpperCase()) ?? null;
+        if (!invite) {
+          return null;
+        }
+
+        const normalizedEmail = input.email.trim().toLowerCase();
+        if (invite.email && invite.email !== normalizedEmail) {
+          throw new LeagueInviteError(
+            "invite_email_mismatch",
+            403,
+            "This organiser invite was issued for a different email address.",
+          );
+        }
+
+        if (
+          invite.kind !== "share" &&
+          invite.acceptedByUserId !== null &&
+          invite.acceptedByUserId !== input.userId
+        ) {
+          throw new LeagueInviteError(
+            "invite_already_accepted",
+            409,
+            "This organiser invite has already been accepted.",
+          );
+        }
+
+        const acceptedInvite = {
+          ...invite,
+          acceptedByUserId: invite.kind === "share" ? null : invite.acceptedByUserId ?? input.userId,
+          acceptedAt: invite.kind === "share" ? null : invite.acceptedAt ?? "2026-02-23T00:00:03.000Z",
+          updatedAt:
+            invite.kind === "share" || invite.acceptedByUserId
+              ? invite.updatedAt
+              : "2026-02-23T00:00:03.000Z",
+        };
+        leagueInvites.set(invite.inviteCode, acceptedInvite);
+
+        const key = `${invite.leagueId}:${input.userId}`;
+        const existing = leagueAccess.get(key);
+        if (existing && leagueRoleRank[existing.role] >= leagueRoleRank.admin) {
+          return {
+            invite: acceptedInvite,
+            access: existing,
+          };
+        }
+
+        const access = {
+          leagueId: invite.leagueId,
+          userId: input.userId,
+          role: "admin" as const,
+          grantedByUserId: invite.createdByUserId,
+          createdAt: existing?.createdAt ?? "2026-02-23T00:00:03.000Z",
+          updatedAt: "2026-02-23T00:00:03.000Z",
+        };
+        leagueAccess.set(key, access);
+        grantedLeagueAccess.push(access);
+        return {
+          invite: acceptedInvite,
+          access,
+        };
+      },
       async getSeason(seasonId: string) {
         return seasons.get(seasonId) ?? null;
       },
@@ -1695,6 +1847,46 @@ function createHarness(config: HarnessConfig = {}) {
           updatedAt: "2026-02-23T00:00:00.000Z",
         });
 
+        return true;
+      },
+      async completeIdempotencyRecord(input) {
+        const recordKey = `${input.scope}:${input.key}`;
+        const existing = idempotencyRecords.get(recordKey);
+        if (
+          !existing ||
+          existing.requestHash !== input.requestHash ||
+          existing.responseStatusCode !== input.expectedResponseStatusCode ||
+          existing.responseBody !== input.expectedResponseBody ||
+          (input.expectedUpdatedAt !== undefined && existing.updatedAt !== input.expectedUpdatedAt)
+        ) {
+          return false;
+        }
+
+        idempotencyRecords.set(recordKey, {
+          scope: input.scope,
+          key: input.key,
+          requestHash: input.requestHash,
+          responseStatusCode: input.responseStatusCode,
+          responseBody: input.responseBody,
+          createdAt: existing.createdAt,
+          updatedAt: "2026-02-23T00:00:01.000Z",
+        });
+        return true;
+      },
+      async deleteIdempotencyRecord(input) {
+        const recordKey = `${input.scope}:${input.key}`;
+        const existing = idempotencyRecords.get(recordKey);
+        if (
+          !existing ||
+          existing.requestHash !== input.requestHash ||
+          existing.responseStatusCode !== input.responseStatusCode ||
+          existing.responseBody !== input.responseBody ||
+          (input.updatedAt !== undefined && existing.updatedAt !== input.updatedAt)
+        ) {
+          return false;
+        }
+
+        idempotencyRecords.delete(recordKey);
         return true;
       },
     },
@@ -1729,11 +1921,15 @@ function createHarness(config: HarnessConfig = {}) {
     games,
     players,
     leagueAccess,
+    leagueInvites,
   };
 }
 
 function createGoalHarness(input: {
   email?: string;
+  subject?: string;
+  accessUserId?: string;
+  extraLeagueAccess?: Record<string, "admin" | "scorekeeper" | "viewer">;
   role?: "admin" | "scorekeeper" | "viewer";
   runningThird?: boolean;
   completedThirds?: boolean;
@@ -1750,6 +1946,8 @@ function createGoalHarness(input: {
   gameTeams?: Record<string, MockGameTeamInput>;
 } = {}) {
   const email = input.email ?? "scorekeeper@example.com";
+  const subject = input.subject;
+  const accessUserId = input.accessUserId ?? email;
   const role = input.role ?? "scorekeeper";
   const runningThird = input.runningThird ?? true;
   const completedThirds = input.completedThirds ?? false;
@@ -1766,6 +1964,7 @@ function createGoalHarness(input: {
       "session-1": {
         sessionId: "session-1",
         email,
+        ...(subject ? { subject } : {}),
         createdAt: "2026-02-23T00:00:00.000Z",
         expiresAt: "2026-02-24T00:00:00.000Z",
       },
@@ -1807,14 +2006,27 @@ function createGoalHarness(input: {
       },
     },
     leagueAccess: {
-      [`league-1:${email}`]: {
+      [`league-1:${accessUserId}`]: {
         leagueId: "league-1",
-        userId: email,
+        userId: accessUserId,
         role,
         grantedByUserId: "admin@example.com",
         createdAt: "2026-02-23T00:00:00.000Z",
         updatedAt: "2026-02-23T00:00:00.000Z",
       },
+      ...Object.fromEntries(
+        Object.entries(input.extraLeagueAccess ?? {}).map(([userId, accessRole]) => [
+          `league-1:${userId}`,
+          {
+            leagueId: "league-1",
+            userId,
+            role: accessRole,
+            grantedByUserId: "admin@example.com",
+            createdAt: "2026-02-23T00:00:00.000Z",
+            updatedAt: "2026-02-23T00:00:00.000Z",
+          },
+        ]),
+      ),
     },
     gameTeams: input.gameTeams ?? {
       "game-1:red": {
@@ -1960,7 +2172,8 @@ test("core lambda starts magic-link auth without requiring a session", async () 
 
   assert.equal(response.statusCode, 202);
   assert.equal(harness.magicLinkStarts.length, 1);
-  assert.equal(harness.magicLinkStarts[0], "player@example.com");
+  assert.equal(harness.magicLinkStarts[0]?.email, "player@example.com");
+  assert.deepEqual(harness.magicLinkStarts[0]?.options, undefined);
   assert.deepEqual(harness.magicLinkRateLimitChecks, [
     {
       email: "player@example.com",
@@ -2607,6 +2820,868 @@ test("core lambda rejects scorer access delegation from non-admins", async () =>
   assert.equal(JSON.parse(response.body).code, "admin_required");
 });
 
+test("core lambda creates league organiser invites and sends direct email links", async () => {
+  const harness = createHarness({
+    sessions: {
+      "session-admin": {
+        sessionId: "session-admin",
+        email: "admin@example.com",
+        subject: "admin-subject",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    leagues: {
+      "league-1": {
+        leagueId: "league-1",
+        name: "League One",
+        slug: "league-one",
+        createdByUserId: "admin-subject",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueAccess: {
+      "league-1:admin-subject": {
+        leagueId: "league-1",
+        userId: "admin-subject",
+        role: "admin",
+        grantedByUserId: "owner@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  const response = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/leagues/league-1/organiser-invites",
+      headers: {
+        Cookie: "threefc_session=session-admin",
+        Origin: "https://qa.3fc.football",
+      },
+      sourceIp: "203.0.113.20",
+      body: {
+        email: "Coach@Example.COM",
+      },
+    }),
+  );
+
+  assert.equal(response.statusCode, 201);
+  assert.deepEqual(harness.magicLinkRateLimitChecks, [
+    {
+      email: "coach@example.com",
+      clientIp: "203.0.113.20",
+    },
+  ]);
+  assert.equal(harness.magicLinkStarts.length, 1);
+  assert.equal(harness.magicLinkStarts[0]?.email, "coach@example.com");
+  assert.equal(harness.magicLinkStarts[0]?.options?.returnTo, "/invites?code=ABCD2345");
+  assert.equal(harness.magicLinkStarts[0]?.options?.subject, "You're invited to organise League One on 3FC");
+
+  assert.deepEqual(JSON.parse(response.body), {
+    invite: {
+      leagueId: "league-1",
+      inviteCode: "ABCD2345",
+      kind: "email",
+      role: "admin",
+      email: "coach@example.com",
+      createdByUserId: "admin-subject",
+      acceptedByUserId: null,
+      acceptedAt: null,
+      createdAt: "2026-02-23T00:00:02.000Z",
+      updatedAt: "2026-02-23T00:00:02.000Z",
+    },
+    inviteCode: "ABCD2345",
+    inviteLink: "https://qa.3fc.football/invites?code=ABCD2345",
+    emailDelivery: {
+      status: "sent",
+      email: "coach@example.com",
+      expiresAt: "2026-02-24T00:00:00.000Z",
+      messageId: "msg-1",
+    },
+  });
+});
+
+test("core lambda ensures reusable league organiser share invites", async () => {
+  const harness = createHarness({
+    sessions: {
+      "session-admin": {
+        sessionId: "session-admin",
+        email: "admin@example.com",
+        subject: "admin-subject",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    leagues: {
+      "league-1": {
+        leagueId: "league-1",
+        name: "League One",
+        slug: "league-one",
+        createdByUserId: "admin-subject",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueAccess: {
+      "league-1:admin-subject": {
+        leagueId: "league-1",
+        userId: "admin-subject",
+        role: "admin",
+        grantedByUserId: "owner@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  const buildRequest = () =>
+    createEvent({
+      method: "POST",
+      path: "/v1/leagues/league-1/organiser-invites",
+      headers: {
+        Cookie: "threefc_session=session-admin",
+        Origin: "https://qa.3fc.football",
+      },
+      sourceIp: "203.0.113.20",
+      body: {
+        email: null,
+      },
+    });
+
+  const firstResponse = await harness.handler(buildRequest());
+  const secondResponse = await harness.handler(buildRequest());
+  const firstBody = JSON.parse(firstResponse.body);
+  const secondBody = JSON.parse(secondResponse.body);
+
+  assert.equal(firstResponse.statusCode, 201);
+  assert.equal(secondResponse.statusCode, 201);
+  assert.equal(firstBody.inviteCode, "ABCD2345");
+  assert.equal(secondBody.inviteCode, "ABCD2345");
+  assert.deepEqual(firstBody, secondBody);
+  assert.equal(firstBody.invite.kind, "share");
+  assert.equal(firstBody.invite.email, null);
+  assert.equal(firstBody.emailDelivery, null);
+  assert.equal(harness.leagueInvites.size, 1);
+  assert.equal(harness.magicLinkRateLimitChecks.length, 0);
+  assert.equal(harness.magicLinkStarts.length, 0);
+});
+
+test("core lambda reserves organiser invite idempotency before sending direct email", async () => {
+  const harness = createHarness({
+    magicLinkStartDelayMs: 35,
+    sessions: {
+      "session-admin": {
+        sessionId: "session-admin",
+        email: "admin@example.com",
+        subject: "admin-subject",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    leagues: {
+      "league-1": {
+        leagueId: "league-1",
+        name: "League One",
+        slug: "league-one",
+        createdByUserId: "admin-subject",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueAccess: {
+      "league-1:admin-subject": {
+        leagueId: "league-1",
+        userId: "admin-subject",
+        role: "admin",
+        grantedByUserId: "owner@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  const buildRequest = () =>
+    createEvent({
+      method: "POST",
+      path: "/v1/leagues/league-1/organiser-invites",
+      headers: {
+        Cookie: "threefc_session=session-admin",
+        Origin: "https://qa.3fc.football",
+        "Idempotency-Key": "invite-email-key-1",
+      },
+      sourceIp: "203.0.113.20",
+      body: {
+        email: "Coach@Example.COM",
+      },
+    });
+
+  const [firstResponse, secondResponse] = await Promise.all([
+    harness.handler(buildRequest()),
+    harness.handler(buildRequest()),
+  ]);
+
+  assert.equal(firstResponse.statusCode, 201);
+  assert.equal(secondResponse.statusCode, 201);
+  assert.deepEqual(JSON.parse(secondResponse.body), JSON.parse(firstResponse.body));
+  assert.equal(harness.leagueInvites.size, 1);
+  assert.equal(harness.magicLinkRateLimitChecks.length, 1);
+  assert.equal(harness.magicLinkStarts.length, 1);
+  assert.equal(harness.idempotencyRecords.size, 1);
+  const record = [...harness.idempotencyRecords.values()][0];
+  assert.equal(record?.responseStatusCode, 201);
+});
+
+test("core lambda does not persist transient organiser invite idempotency failures", async () => {
+  let rateLimited = true;
+  const harness = createHarness({
+    rateLimitDecision: ({ email }) => {
+      if (rateLimited && email === "coach@example.com") {
+        return {
+          allowed: false,
+          dimension: "email",
+          retryAfterSeconds: 120,
+        };
+      }
+
+      return { allowed: true };
+    },
+    sessions: {
+      "session-admin": {
+        sessionId: "session-admin",
+        email: "admin@example.com",
+        subject: "admin-subject",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    leagues: {
+      "league-1": {
+        leagueId: "league-1",
+        name: "League One",
+        slug: "league-one",
+        createdByUserId: "admin-subject",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueAccess: {
+      "league-1:admin-subject": {
+        leagueId: "league-1",
+        userId: "admin-subject",
+        role: "admin",
+        grantedByUserId: "owner@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  const buildRequest = () =>
+    createEvent({
+      method: "POST",
+      path: "/v1/leagues/league-1/organiser-invites",
+      headers: {
+        Cookie: "threefc_session=session-admin",
+        Origin: "https://qa.3fc.football",
+        "Idempotency-Key": "invite-email-retry-1",
+      },
+      sourceIp: "203.0.113.20",
+      body: {
+        email: "Coach@Example.COM",
+      },
+    });
+
+  const limitedResponse = await harness.handler(buildRequest());
+
+  assert.equal(limitedResponse.statusCode, 429);
+  assert.deepEqual(JSON.parse(limitedResponse.body), {
+    error: "rate_limited",
+    message: "Too many sign-in link requests. Try again later.",
+    retryAfterSeconds: 120,
+  });
+  assert.equal(harness.idempotencyRecords.size, 0);
+  assert.equal(harness.leagueInvites.size, 0);
+  assert.equal(harness.magicLinkStarts.length, 0);
+
+  rateLimited = false;
+  const retryResponse = await harness.handler(buildRequest());
+
+  assert.equal(retryResponse.statusCode, 201);
+  assert.equal(harness.idempotencyRecords.size, 1);
+  assert.equal(harness.leagueInvites.size, 1);
+  assert.equal(harness.magicLinkStarts.length, 1);
+});
+
+test("core lambda recovers stale share organiser invite idempotency reservations", async () => {
+  const harness = createHarness({
+    sessions: {
+      "session-admin": {
+        sessionId: "session-admin",
+        email: "admin@example.com",
+        subject: "admin-subject",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    leagues: {
+      "league-1": {
+        leagueId: "league-1",
+        name: "League One",
+        slug: "league-one",
+        createdByUserId: "admin-subject",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueAccess: {
+      "league-1:admin-subject": {
+        leagueId: "league-1",
+        userId: "admin-subject",
+        role: "admin",
+        grantedByUserId: "owner@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  const scope = "admin@example.com:POST:/v1/leagues/league-1/organiser-invites";
+  const requestHash = buildTestIdempotencyRequestHash(scope, { email: null });
+  harness.idempotencyRecords.set(`${scope}:stale-invite-code-1`, {
+    scope,
+    key: "stale-invite-code-1",
+    requestHash,
+    responseStatusCode: 202,
+    responseBody: JSON.stringify({
+      idempotencyState: "pending",
+      reservedAtEpochMs: Date.now() - 5 * 60 * 1000,
+    }),
+    createdAt: "2026-02-23T00:00:00.000Z",
+    updatedAt: "2026-02-23T00:00:00.000Z",
+  });
+
+  const response = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/leagues/league-1/organiser-invites",
+      headers: {
+        Cookie: "threefc_session=session-admin",
+        Origin: "https://qa.3fc.football",
+        "Idempotency-Key": "stale-invite-code-1",
+      },
+      sourceIp: "203.0.113.20",
+      body: {},
+    }),
+  );
+
+  assert.equal(response.statusCode, 201);
+  assert.equal(harness.idempotencyRecords.size, 1);
+  assert.equal(harness.leagueInvites.size, 1);
+  assert.equal(harness.magicLinkStarts.length, 0);
+  const record = [...harness.idempotencyRecords.values()][0];
+  assert.equal(record?.responseStatusCode, 201);
+});
+
+test("core lambda recovers stale direct-email organiser invite reservations before delivery starts", async () => {
+  const harness = createHarness({
+    sessions: {
+      "session-admin": {
+        sessionId: "session-admin",
+        email: "admin@example.com",
+        subject: "admin-subject",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    leagues: {
+      "league-1": {
+        leagueId: "league-1",
+        name: "League One",
+        slug: "league-one",
+        createdByUserId: "admin-subject",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueAccess: {
+      "league-1:admin-subject": {
+        leagueId: "league-1",
+        userId: "admin-subject",
+        role: "admin",
+        grantedByUserId: "owner@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  const scope = "admin@example.com:POST:/v1/leagues/league-1/organiser-invites";
+  const requestHash = buildTestIdempotencyRequestHash(scope, { email: "coach@example.com" });
+  harness.idempotencyRecords.set(`${scope}:stale-invite-email-unstarted-1`, {
+    scope,
+    key: "stale-invite-email-unstarted-1",
+    requestHash,
+    responseStatusCode: 202,
+    responseBody: JSON.stringify({
+      idempotencyState: "pending",
+      reservationId: "reservation-unstarted-email",
+      reservedAtEpochMs: Date.now() - 5 * 60 * 1000,
+    }),
+    createdAt: "2026-02-23T00:00:00.000Z",
+    updatedAt: "2026-02-23T00:00:00.000Z",
+  });
+
+  const response = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/leagues/league-1/organiser-invites",
+      headers: {
+        Cookie: "threefc_session=session-admin",
+        Origin: "https://qa.3fc.football",
+        "Idempotency-Key": "stale-invite-email-unstarted-1",
+      },
+      sourceIp: "203.0.113.20",
+      body: {
+        email: "Coach@Example.COM",
+      },
+    }),
+  );
+
+  assert.equal(response.statusCode, 201);
+  const body = JSON.parse(response.body);
+  assert.equal(body.emailDelivery.status, "sent");
+  assert.equal(body.emailDelivery.email, "coach@example.com");
+  assert.equal(body.emailDelivery.messageId, "msg-1");
+  assert.equal(harness.idempotencyRecords.size, 1);
+  assert.equal(harness.leagueInvites.size, 1);
+  assert.equal(harness.magicLinkRateLimitChecks.length, 1);
+  assert.equal(harness.magicLinkStarts.length, 1);
+  assert.equal(harness.magicLinkStarts[0]?.email, "coach@example.com");
+  assert.equal(harness.magicLinkStarts[0]?.options?.returnTo, `/invites?code=${body.inviteCode}`);
+  const record = [...harness.idempotencyRecords.values()][0];
+  assert.equal(record?.responseStatusCode, 201);
+});
+
+test("core lambda recovers stale direct-email organiser invite reservations after delivery starts", async () => {
+  const idempotencyKey = "stale-invite-email-started-1";
+  const scope = "admin@example.com:POST:/v1/leagues/league-1/organiser-invites";
+  const inviteCode = buildTestOrganiserInviteCode(scope, idempotencyKey);
+  const harness = createHarness({
+    sessions: {
+      "session-admin": {
+        sessionId: "session-admin",
+        email: "admin@example.com",
+        subject: "admin-subject",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    leagues: {
+      "league-1": {
+        leagueId: "league-1",
+        name: "League One",
+        slug: "league-one",
+        createdByUserId: "admin-subject",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueAccess: {
+      "league-1:admin-subject": {
+        leagueId: "league-1",
+        userId: "admin-subject",
+        role: "admin",
+        grantedByUserId: "owner@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueInvites: {
+      [inviteCode]: {
+        leagueId: "league-1",
+        inviteCode,
+        kind: "email",
+        role: "admin",
+        email: "coach@example.com",
+        createdByUserId: "admin-subject",
+        acceptedByUserId: null,
+        acceptedAt: null,
+        createdAt: "2026-02-23T00:00:02.000Z",
+        updatedAt: "2026-02-23T00:00:02.000Z",
+      },
+    },
+  });
+
+  const requestHash = buildTestIdempotencyRequestHash(scope, { email: "coach@example.com" });
+  harness.idempotencyRecords.set(`${scope}:${idempotencyKey}`, {
+    scope,
+    key: idempotencyKey,
+    requestHash,
+    responseStatusCode: 202,
+    responseBody: JSON.stringify({
+      idempotencyState: "pending",
+      reservationId: "reservation-started-email",
+      reservedAtEpochMs: Date.now() - 5 * 60 * 1000,
+      externalSideEffect: "email_delivery_started",
+      externalSideEffectStartedAtEpochMs: Date.now() - 5 * 60 * 1000,
+    }),
+    createdAt: "2026-02-23T00:00:00.000Z",
+    updatedAt: "2026-02-23T00:00:00.000Z",
+  });
+
+  const response = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/leagues/league-1/organiser-invites",
+      headers: {
+        Cookie: "threefc_session=session-admin",
+        Origin: "https://qa.3fc.football",
+        "Idempotency-Key": idempotencyKey,
+      },
+      sourceIp: "203.0.113.20",
+      body: {
+        email: "Coach@Example.COM",
+      },
+    }),
+  );
+
+  assert.equal(response.statusCode, 202);
+  const body = JSON.parse(response.body);
+  assert.equal(body.inviteCode, inviteCode);
+  assert.equal(body.invite.kind, "email");
+  assert.equal(body.invite.email, "coach@example.com");
+  assert.equal(body.inviteLink, `https://qa.3fc.football/invites?code=${inviteCode}`);
+  assert.deepEqual(body.emailDelivery, {
+    status: "unknown",
+    email: "coach@example.com",
+    expiresAt: null,
+    messageId: null,
+    message: "Email delivery could not be confirmed. Share the invite link manually.",
+  });
+  assert.equal(harness.idempotencyRecords.size, 1);
+  assert.equal(harness.leagueInvites.size, 1);
+  assert.equal(harness.magicLinkRateLimitChecks.length, 0);
+  assert.equal(harness.magicLinkStarts.length, 0);
+  const record = [...harness.idempotencyRecords.values()][0];
+  assert.equal(record?.responseStatusCode, 202);
+  assert.deepEqual(JSON.parse(record?.responseBody ?? "{}"), body);
+
+  const replayedResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/leagues/league-1/organiser-invites",
+      headers: {
+        Cookie: "threefc_session=session-admin",
+        Origin: "https://qa.3fc.football",
+        "Idempotency-Key": idempotencyKey,
+      },
+      sourceIp: "203.0.113.20",
+      body: {
+        email: "Coach@Example.COM",
+      },
+    }),
+  );
+
+  assert.equal(replayedResponse.statusCode, 202);
+  assert.deepEqual(JSON.parse(replayedResponse.body), body);
+  assert.equal(harness.magicLinkRateLimitChecks.length, 0);
+  assert.equal(harness.magicLinkStarts.length, 0);
+});
+
+test("core lambda replays the original invite when email delivery is uncertain", async () => {
+  const harness = createHarness({
+    magicLinkStartError: new Error("SES response timed out"),
+    sessions: {
+      "session-admin": {
+        sessionId: "session-admin",
+        email: "admin@example.com",
+        subject: "admin-subject",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    leagues: {
+      "league-1": {
+        leagueId: "league-1",
+        name: "League One",
+        slug: "league-one",
+        createdByUserId: "admin-subject",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueAccess: {
+      "league-1:admin-subject": {
+        leagueId: "league-1",
+        userId: "admin-subject",
+        role: "admin",
+        grantedByUserId: "owner@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  const buildRequest = () =>
+    createEvent({
+      method: "POST",
+      path: "/v1/leagues/league-1/organiser-invites",
+      headers: {
+        Cookie: "threefc_session=session-admin",
+        Origin: "https://qa.3fc.football",
+        "Idempotency-Key": "uncertain-invite-email-1",
+      },
+      sourceIp: "203.0.113.20",
+      body: {
+        email: "Coach@Example.COM",
+      },
+    });
+
+  const firstResponse = await harness.handler(buildRequest());
+  const firstBody = JSON.parse(firstResponse.body);
+  const secondResponse = await harness.handler(buildRequest());
+
+  assert.equal(firstResponse.statusCode, 202);
+  assert.deepEqual(firstBody.emailDelivery, {
+    status: "unknown",
+    email: "coach@example.com",
+    expiresAt: null,
+    messageId: null,
+    message: "Email delivery could not be confirmed. Share the invite link manually.",
+  });
+  assert.equal(secondResponse.statusCode, 202);
+  assert.deepEqual(JSON.parse(secondResponse.body), firstBody);
+  assert.equal(harness.leagueInvites.size, 1);
+  assert.equal(harness.magicLinkStarts.length, 1);
+});
+
+test("core lambda accepts organiser invite codes and grants league admin access", async () => {
+  const harness = createHarness({
+    sessions: {
+      "session-invitee": {
+        sessionId: "session-invitee",
+        email: "coach@example.com",
+        subject: "coach-subject",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    leagues: {
+      "league-1": {
+        leagueId: "league-1",
+        name: "League One",
+        slug: "league-one",
+        createdByUserId: "admin-subject",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueInvites: {
+      ABCD2345: {
+        leagueId: "league-1",
+        inviteCode: "ABCD2345",
+        kind: "email",
+        role: "admin",
+        email: "coach@example.com",
+        createdByUserId: "admin-subject",
+        acceptedByUserId: null,
+        acceptedAt: null,
+        createdAt: "2026-02-23T00:00:02.000Z",
+        updatedAt: "2026-02-23T00:00:02.000Z",
+      },
+    },
+  });
+
+  const response = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/invites/abcd2345/accept",
+      headers: {
+        Cookie: "threefc_session=session-invitee",
+        Origin: "https://qa.3fc.football",
+      },
+      body: {},
+    }),
+  );
+
+  assert.equal(response.statusCode, 200);
+  assert.deepEqual(JSON.parse(response.body), {
+    invite: {
+      leagueId: "league-1",
+      inviteCode: "ABCD2345",
+      kind: "email",
+      role: "admin",
+      email: "coach@example.com",
+      createdByUserId: "admin-subject",
+      acceptedByUserId: "coach-subject",
+      acceptedAt: "2026-02-23T00:00:03.000Z",
+      createdAt: "2026-02-23T00:00:02.000Z",
+      updatedAt: "2026-02-23T00:00:03.000Z",
+    },
+    access: {
+      leagueId: "league-1",
+      userId: "coach-subject",
+      role: "admin",
+      grantedByUserId: "admin-subject",
+      createdAt: "2026-02-23T00:00:03.000Z",
+      updatedAt: "2026-02-23T00:00:03.000Z",
+    },
+    inviteLink: "https://qa.3fc.football/invites?code=ABCD2345",
+  });
+  assert.equal(harness.leagueAccess.get("league-1:coach-subject")?.role, "admin");
+
+  const leagueResponse = await harness.handler(
+    createEvent({
+      method: "GET",
+      path: "/v1/leagues/league-1",
+      headers: {
+        Cookie: "threefc_session=session-invitee",
+      },
+    }),
+  );
+
+  assert.equal(leagueResponse.statusCode, 200);
+  assert.equal(JSON.parse(leagueResponse.body).access.role, "admin");
+});
+
+test("core lambda accepts reusable organiser share invites for multiple users", async () => {
+  const harness = createHarness({
+    sessions: {
+      "session-invitee-one": {
+        sessionId: "session-invitee-one",
+        email: "coach-one@example.com",
+        subject: "coach-one-subject",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+      "session-invitee-two": {
+        sessionId: "session-invitee-two",
+        email: "coach-two@example.com",
+        subject: "coach-two-subject",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    leagues: {
+      "league-1": {
+        leagueId: "league-1",
+        name: "League One",
+        slug: "league-one",
+        createdByUserId: "admin-subject",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueInvites: {
+      ABCD2345: {
+        leagueId: "league-1",
+        inviteCode: "ABCD2345",
+        kind: "share",
+        role: "admin",
+        email: null,
+        createdByUserId: "admin-subject",
+        acceptedByUserId: null,
+        acceptedAt: null,
+        createdAt: "2026-02-23T00:00:02.000Z",
+        updatedAt: "2026-02-23T00:00:02.000Z",
+      },
+    },
+  });
+
+  const firstResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/invites/ABCD2345/accept",
+      headers: {
+        Cookie: "threefc_session=session-invitee-one",
+        Origin: "https://qa.3fc.football",
+      },
+      body: {},
+    }),
+  );
+  const secondResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/invites/ABCD2345/accept",
+      headers: {
+        Cookie: "threefc_session=session-invitee-two",
+        Origin: "https://qa.3fc.football",
+      },
+      body: {},
+    }),
+  );
+
+  assert.equal(firstResponse.statusCode, 200);
+  assert.equal(secondResponse.statusCode, 200);
+  assert.equal(harness.leagueInvites.get("ABCD2345")?.acceptedByUserId, null);
+  assert.equal(harness.leagueInvites.get("ABCD2345")?.acceptedAt, null);
+  assert.equal(harness.leagueAccess.get("league-1:coach-one-subject")?.role, "admin");
+  assert.equal(harness.leagueAccess.get("league-1:coach-two-subject")?.role, "admin");
+  assert.equal(JSON.parse(firstResponse.body).invite.acceptedByUserId, null);
+  assert.equal(JSON.parse(secondResponse.body).invite.acceptedByUserId, null);
+});
+
+test("core lambda rejects direct email organiser invites for a different signed-in email", async () => {
+  const harness = createHarness({
+    sessions: {
+      "session-invitee": {
+        sessionId: "session-invitee",
+        email: "other@example.com",
+        subject: "other-subject",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    leagues: {
+      "league-1": {
+        leagueId: "league-1",
+        name: "League One",
+        slug: "league-one",
+        createdByUserId: "admin-subject",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueInvites: {
+      ABCD2345: {
+        leagueId: "league-1",
+        inviteCode: "ABCD2345",
+        kind: "email",
+        role: "admin",
+        email: "coach@example.com",
+        createdByUserId: "admin-subject",
+        acceptedByUserId: null,
+        acceptedAt: null,
+        createdAt: "2026-02-23T00:00:02.000Z",
+        updatedAt: "2026-02-23T00:00:02.000Z",
+      },
+    },
+  });
+
+  const response = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/invites/ABCD2345/accept",
+      headers: {
+        Cookie: "threefc_session=session-invitee",
+        Origin: "https://qa.3fc.football",
+      },
+      body: {},
+    }),
+  );
+
+  assert.equal(response.statusCode, 403);
+  assert.deepEqual(JSON.parse(response.body), {
+    error: "forbidden",
+    code: "invite_email_mismatch",
+    message: "This organiser invite was issued for a different email address.",
+  });
+  assert.equal(harness.leagueAccess.get("league-1:other-subject"), undefined);
+});
+
 test("core lambda replays public join retries by idempotency key", async () => {
   const harness = createHarness({
     games: {
@@ -2748,7 +3823,7 @@ test("core lambda retries retryable public join conflicts without persisting the
   assert.equal(harness.idempotencyRecords.size, 1);
 });
 
-test("core lambda does not persist closed-game public join conflicts", async () => {
+test("core lambda persists finished-game public join success for idempotent replay", async () => {
   const harness = createHarness({
     games: {
       "game-1": {
@@ -2766,6 +3841,7 @@ test("core lambda does not persist closed-game public join conflicts", async () 
     },
   });
 
+  let firstBody: unknown = null;
   for (let attempt = 0; attempt < 2; attempt += 1) {
     const response = await harness.handler(
       createEvent({
@@ -2781,17 +3857,20 @@ test("core lambda does not persist closed-game public join conflicts", async () 
       }),
     );
 
-    assert.equal(response.statusCode, 409);
-    assert.deepEqual(JSON.parse(response.body), {
-      error: "conflict",
-      code: "game_finished",
-      message: "Game game-1 is finished. Join registration is closed.",
-    });
+    assert.equal(response.statusCode, 201);
+    const body = JSON.parse(response.body);
+    if (attempt === 0) {
+      firstBody = body;
+      assert.equal(body.gameId, "game-1");
+      assert.equal(body.player.nickname, "Nia");
+    } else {
+      assert.deepEqual(body, firstBody);
+    }
   }
 
-  assert.equal(harness.createdPlayers.length, 0);
-  assert.equal(harness.linkedGamePlayers.length, 0);
-  assert.equal(harness.idempotencyRecords.size, 0);
+  assert.equal(harness.createdPlayers.length, 1);
+  assert.equal(harness.linkedGamePlayers.length, 1);
+  assert.equal(harness.idempotencyRecords.size, 1);
 });
 
 test("core lambda rejects oversized public join nicknames before persistence", async () => {
@@ -2941,7 +4020,7 @@ test("core lambda returns stable errors for invalid and missing join codes", asy
   assert.equal(harness.linkedGamePlayers.length, 0);
 });
 
-test("core lambda rejects join registration for finished games", async () => {
+test("core lambda allows join registration for finished games", async () => {
   const harness = createHarness({
     games: {
       "game-1": {
@@ -2971,14 +4050,19 @@ test("core lambda rejects join registration for finished games", async () => {
     }),
   );
 
-  assert.equal(response.statusCode, 409);
+  assert.equal(response.statusCode, 201);
+  assert.equal(harness.createdPlayers.length, 1);
+  assert.equal(harness.linkedGamePlayers.length, 1);
   assert.deepEqual(JSON.parse(response.body), {
-    error: "conflict",
-    code: "game_finished",
-    message: "Game game-1 is finished. Join registration is closed.",
+    gameId: "game-1",
+    joinCode: "FNSH2DAB",
+    player: {
+      playerId: harness.createdPlayers[0]?.playerId,
+      nickname: "Late",
+      createdAt: "2026-02-23T00:00:00.000Z",
+      updatedAt: "2026-02-23T00:00:00.000Z",
+    },
   });
-  assert.equal(harness.createdPlayers.length, 0);
-  assert.equal(harness.linkedGamePlayers.length, 0);
 });
 
 test("core lambda accepts session cookie from API Gateway cookies array", async () => {
@@ -4578,6 +5662,97 @@ test("core lambda allows admins to create corrective goals after finish", async 
   assert.equal(body.goal.thirdMinute, 20);
   assert.equal(body.goal.gameMinute, 60);
   assert.equal(body.goal.displayTime, "20:00");
+  assert.equal(harness.createdGoals.length, 1);
+  assert.equal(harness.createdGoals[0]?.allowFinished, true);
+});
+
+test("core lambda allows subject-keyed invited admins to create corrective goals after finish", async () => {
+  const harness = createGoalHarness({
+    email: "coach@example.com",
+    subject: "magic-link:coach-subject",
+    accessUserId: "magic-link:coach-subject",
+    role: "admin",
+    runningThird: false,
+    completedThirds: true,
+  });
+  const finishResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/games/game-1/finish",
+      headers: {
+        Cookie: "threefc_session=session-1",
+        "Idempotency-Key": "finish-before-invited-create-correction-1",
+      },
+    }),
+  );
+  assert.equal(finishResponse.statusCode, 200);
+
+  const response = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/games/game-1/goals",
+      headers: {
+        Cookie: "threefc_session=session-1",
+        "Idempotency-Key": "post-finish-invited-goal-correction-1",
+      },
+      body: {
+        scoringTeamId: "red",
+        concedingTeamId: "blue",
+        scorerPlayerId: "player-red",
+        assistPlayerIds: [],
+        ownGoal: false,
+      },
+    }),
+  );
+
+  assert.equal(response.statusCode, 201);
+  assert.equal(harness.createdGoals.length, 1);
+  assert.equal(harness.createdGoals[0]?.allowFinished, true);
+});
+
+test("core lambda allows post-finish corrections when any session identity is admin", async () => {
+  const harness = createGoalHarness({
+    email: "admin@example.com",
+    subject: "magic-link:lower-role-subject",
+    accessUserId: "magic-link:lower-role-subject",
+    role: "scorekeeper",
+    extraLeagueAccess: {
+      "admin@example.com": "admin",
+    },
+    runningThird: false,
+    completedThirds: true,
+  });
+  const finishResponse = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/games/game-1/finish",
+      headers: {
+        Cookie: "threefc_session=session-1",
+        "Idempotency-Key": "finish-before-mixed-identity-correction-1",
+      },
+    }),
+  );
+  assert.equal(finishResponse.statusCode, 200);
+
+  const response = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/games/game-1/goals",
+      headers: {
+        Cookie: "threefc_session=session-1",
+        "Idempotency-Key": "post-finish-mixed-identity-correction-1",
+      },
+      body: {
+        scoringTeamId: "red",
+        concedingTeamId: "blue",
+        scorerPlayerId: "player-red",
+        assistPlayerIds: [],
+        ownGoal: false,
+      },
+    }),
+  );
+
+  assert.equal(response.statusCode, 201);
   assert.equal(harness.createdGoals.length, 1);
   assert.equal(harness.createdGoals[0]?.allowFinished, true);
 });

--- a/api/src/tests/magic-link.test.ts
+++ b/api/src/tests/magic-link.test.ts
@@ -215,6 +215,25 @@ test("magic start stores TTL token and sends callback link email", async () => {
   assert.equal(tokenItem.ttlEpoch?.N, tokenItem.expiresAtEpoch?.N);
 });
 
+test("magic start can send invite-specific copy with a safe return target", async () => {
+  const { service, sentMessages } = createHarness();
+
+  await service.start("coach@example.com", {
+    returnTo: "/invites?code=ABCD2345",
+    subject: "You're invited to organise League One on 3FC",
+    introLines: ["You have been invited to help organise League One on 3FC."],
+  });
+
+  assert.equal(sentMessages.length, 1);
+  assert.equal(sentMessages[0].to, "coach@example.com");
+  assert.equal(sentMessages[0].subject, "You're invited to organise League One on 3FC");
+  assert.match(sentMessages[0].body, /You have been invited to help organise League One on 3FC\./);
+  assert.match(
+    sentMessages[0].body,
+    /http:\/\/localhost:3000\/auth\/callback\?token=token-1\.secret-1&returnTo=%2Finvites%3Fcode%3DABCD2345/,
+  );
+});
+
 test("magic complete consumes token once and creates a session", async () => {
   const { client, service, sentMessages } = createHarness();
 

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -24,6 +24,7 @@ import {
   GameJoinRegistrationError,
   GameMutationStateError,
   GameTimerTransitionError,
+  LeagueInviteError,
   PlayerClaimError,
   ThreeFcRepository,
 } from "../data/repository.js";
@@ -144,7 +145,22 @@ class InMemoryDynamoClient {
 
       const pk = this.readString(key.pk, "pk");
       const sk = this.readString(key.sk, "sk");
-      this.items.delete(`${pk}|${sk}`);
+      const id = `${pk}|${sk}`;
+      if (
+        command.input.ConditionExpression &&
+        !this.conditionMatches(
+          command.input.ConditionExpression,
+          this.items.get(id),
+          command.input.ExpressionAttributeNames ?? {},
+          command.input.ExpressionAttributeValues ?? {},
+        )
+      ) {
+        const error = new Error("Conditional request failed.");
+        (error as Error & { name: string }).name = "ConditionalCheckFailedException";
+        throw error;
+      }
+
+      this.items.delete(id);
       return {};
     }
 
@@ -302,6 +318,12 @@ class InMemoryDynamoClient {
       if (attributeNotExists) {
         const attributeName = this.resolveAttributeName(attributeNotExists[1], attributeNames);
         return !existing || existing[attributeName] === undefined;
+      }
+
+      const attributeExists = clause.match(/^attribute_exists\(([^)]+)\)$/);
+      if (attributeExists) {
+        const attributeName = this.resolveAttributeName(attributeExists[1], attributeNames);
+        return Boolean(existing && existing[attributeName] !== undefined);
       }
 
       const equality = clause.match(/^(.+?)\s*=\s*(.+)$/);
@@ -622,6 +644,185 @@ test("repository grants league access monotonically without downgrading admins",
 
   const storedAccess = await repository.getLeagueAccess("league-1", "delegate-subject");
   assert.equal(storedAccess?.role, "admin");
+});
+
+test("repository ensures reusable league organiser share invites", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  await repository.createLeague({
+    leagueId: "league-invite",
+    name: "League Invite",
+    createdByUserId: "owner-subject",
+  });
+
+  const invite = await repository.createLeagueOrganiserInvite({
+    leagueId: "league-invite",
+    createdByUserId: "owner-subject",
+    kind: "share",
+  });
+  const repeatedInvite = await repository.createLeagueOrganiserInvite({
+    leagueId: "league-invite",
+    createdByUserId: "owner-subject",
+    kind: "share",
+  });
+
+  assert.match(invite.inviteCode, /^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{8}$/);
+  assert.equal(repeatedInvite.inviteCode, invite.inviteCode);
+  assert.equal(invite.kind, "share");
+  assert.equal(invite.role, "admin");
+  assert.equal(invite.email, null);
+  assert.equal(invite.acceptedByUserId, null);
+  assert.equal(client.readItem(`LEAGUE_INVITE#${invite.inviteCode}`, "METADATA")?.entityType?.S, "leagueInvite");
+  assert.equal(client.readItem("LEAGUE#league-invite", "INVITE#ORGANISER_SHARE")?.entityType?.S, "leagueInvitePointer");
+
+  const accepted = await repository.acceptLeagueOrganiserInvite({
+    inviteCode: invite.inviteCode.toLowerCase(),
+    userId: "co-organiser-subject",
+    email: "Co@Example.COM",
+  });
+  assert(accepted);
+  assert.equal(accepted.invite.kind, "share");
+  assert.equal(accepted.invite.acceptedByUserId, null);
+  assert.equal(accepted.access.leagueId, "league-invite");
+  assert.equal(accepted.access.userId, "co-organiser-subject");
+  assert.equal(accepted.access.role, "admin");
+  assert.deepEqual(
+    await repository.getLeagueAccess("league-invite", "co-organiser-subject"),
+    accepted.access,
+  );
+
+  const replayed = await repository.acceptLeagueOrganiserInvite({
+    inviteCode: invite.inviteCode,
+    userId: "co-organiser-subject",
+    email: "co@example.com",
+  });
+  assert.deepEqual(replayed, accepted);
+
+  const otherAccepted = await repository.acceptLeagueOrganiserInvite({
+    inviteCode: invite.inviteCode,
+    userId: "other-subject",
+    email: "other@example.com",
+  });
+  assert(otherAccepted);
+  assert.equal(otherAccepted.invite.acceptedByUserId, null);
+  assert.equal(otherAccepted.access.userId, "other-subject");
+  assert.equal(otherAccepted.access.role, "admin");
+});
+
+test("repository restricts email organiser invites to the invited email", async () => {
+  const { repository } = createRepositoryHarness();
+
+  await repository.createLeague({
+    leagueId: "league-email-invite",
+    name: "League Email Invite",
+    createdByUserId: "owner-subject",
+  });
+
+  const invite = await repository.createLeagueOrganiserInvite({
+    leagueId: "league-email-invite",
+    email: "Coach@Example.COM",
+    createdByUserId: "owner-subject",
+    kind: "email",
+  });
+  assert.equal(invite.kind, "email");
+  assert.equal(invite.email, "coach@example.com");
+
+  await assert.rejects(
+    repository.acceptLeagueOrganiserInvite({
+      inviteCode: invite.inviteCode,
+      userId: "other-subject",
+      email: "other@example.com",
+    }),
+    (error: unknown) =>
+      error instanceof LeagueInviteError &&
+      error.code === "invite_email_mismatch" &&
+      error.statusCode === 403,
+  );
+  assert.equal(await repository.getLeagueAccess("league-email-invite", "other-subject"), null);
+
+  const accepted = await repository.acceptLeagueOrganiserInvite({
+    inviteCode: invite.inviteCode,
+    userId: "coach-subject",
+    email: "coach@example.com",
+  });
+  assert(accepted);
+  assert.equal(accepted.invite.acceptedByUserId, "coach-subject");
+  assert.equal(accepted.access.role, "admin");
+
+  await assert.rejects(
+    repository.acceptLeagueOrganiserInvite({
+      inviteCode: invite.inviteCode,
+      userId: "other-coach-subject",
+      email: "coach@example.com",
+    }),
+    (error: unknown) =>
+      error instanceof LeagueInviteError &&
+      error.code === "invite_already_accepted" &&
+      error.statusCode === 409,
+  );
+});
+
+test("repository revokes organiser invites when deleting a league", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  await repository.createLeague({
+    leagueId: "league-delete-invites",
+    name: "Delete Invite League",
+    createdByUserId: "owner-subject",
+  });
+
+  const shareInvite = await repository.createLeagueOrganiserInvite({
+    leagueId: "league-delete-invites",
+    createdByUserId: "owner-subject",
+    kind: "share",
+  });
+  const emailInvite = await repository.createLeagueOrganiserInvite({
+    leagueId: "league-delete-invites",
+    email: "Coach@Example.COM",
+    createdByUserId: "owner-subject",
+    kind: "email",
+  });
+
+  assert.equal(
+    client.readItem("LEAGUE#league-delete-invites", "INVITE#ORGANISER_SHARE")?.entityType?.S,
+    "leagueInvitePointer",
+  );
+
+  assert.equal(await repository.deleteLeague("league-delete-invites"), true);
+  assert.equal(await repository.getLeagueOrganiserInvite(shareInvite.inviteCode), null);
+  assert.equal(await repository.getLeagueOrganiserInvite(emailInvite.inviteCode), null);
+  assert.equal(client.readItem("LEAGUE#league-delete-invites", "INVITE#ORGANISER_SHARE"), undefined);
+
+  await repository.createLeague({
+    leagueId: "league-delete-invites",
+    name: "Replacement League",
+    createdByUserId: "replacement-owner-subject",
+  });
+
+  assert.equal(
+    await repository.acceptLeagueOrganiserInvite({
+      inviteCode: shareInvite.inviteCode,
+      userId: "old-share-holder-subject",
+      email: "share@example.com",
+    }),
+    null,
+  );
+  assert.equal(
+    await repository.acceptLeagueOrganiserInvite({
+      inviteCode: emailInvite.inviteCode,
+      userId: "old-email-holder-subject",
+      email: "coach@example.com",
+    }),
+    null,
+  );
+  assert.equal(
+    await repository.getLeagueAccess("league-delete-invites", "old-share-holder-subject"),
+    null,
+  );
+  assert.equal(
+    await repository.getLeagueAccess("league-delete-invites", "old-email-holder-subject"),
+    null,
+  );
 });
 
 test("repository rejects creating games directly as finished", async () => {
@@ -1732,7 +1933,7 @@ test("repository leaves game and join-code lookup intact if delete sees a join-c
   );
 });
 
-test("repository rejects join registration for finished games without creating a player", async () => {
+test("repository allows join registration for finished games so players can claim profiles", async () => {
   const { repository, client } = createRepositoryHarness();
   const game = await repository.createGame({
     gameId: "game-finished-join",
@@ -1743,19 +1944,30 @@ test("repository rejects join registration for finished games without creating a
   });
   markStoredGameFinished(client, "game-finished-join");
 
-  await assert.rejects(
-    repository.joinGameByCode({
-      joinCode: game.joinCode,
+  const joinResult = await repository.joinGameByCode({
+    joinCode: game.joinCode,
+    playerId: "player-late",
+    nickname: "Late",
+  });
+
+  assert(joinResult);
+  assert.equal(joinResult.game.status, "finished");
+  assert.equal(joinResult.player.playerId, "player-late");
+  assert.equal(joinResult.player.claimedByUserId, null);
+  assert.deepEqual(await repository.listGamePlayers(game.gameId), [
+    {
+      gameId: game.gameId,
       playerId: "player-late",
-      nickname: "Late",
-    }),
-    (error) =>
-      error instanceof GameJoinRegistrationError &&
-      error.code === "game_finished" &&
-      error.statusCode === 409,
-  );
-  assert.equal(await repository.getPlayer("player-late"), null);
-  assert.deepEqual(await repository.listGamePlayers(game.gameId), []);
+      createdAt: joinResult.link.createdAt,
+      updatedAt: joinResult.link.updatedAt,
+    },
+  ]);
+
+  const claimed = await repository.claimPlayer({
+    playerId: "player-late",
+    userId: "late-subject",
+  });
+  assert.equal(claimed?.claimedByUserId, "late-subject");
 });
 
 test("repository rejects join registration if join code lookup changes before write", async () => {
@@ -2141,6 +2353,194 @@ test("repository supports idempotency record create/get semantics", async () => 
     client.getItemRequests.map((request) => request.consistentRead),
     [true],
   );
+});
+
+test("repository completes an existing idempotency reservation", async () => {
+  const { repository } = createRepositoryHarness();
+  const pendingBody = JSON.stringify({ idempotencyState: "pending" });
+
+  const reserved = await repository.createIdempotencyRecord({
+    scope: "admin@example.com:POST:/v1/leagues/league-1/organiser-invites",
+    key: "invite-email-1",
+    requestHash: "hash-1",
+    responseStatusCode: 202,
+    responseBody: pendingBody,
+  });
+
+  const completed = await repository.completeIdempotencyRecord({
+    scope: "admin@example.com:POST:/v1/leagues/league-1/organiser-invites",
+    key: "invite-email-1",
+    requestHash: "hash-1",
+    responseStatusCode: 201,
+    responseBody: JSON.stringify({ inviteCode: "ABCD2345" }),
+    expectedResponseStatusCode: 202,
+    expectedResponseBody: pendingBody,
+  });
+
+  const mismatched = await repository.completeIdempotencyRecord({
+    scope: "admin@example.com:POST:/v1/leagues/league-1/organiser-invites",
+    key: "invite-email-1",
+    requestHash: "different-hash",
+    responseStatusCode: 201,
+    responseBody: JSON.stringify({ inviteCode: "EFGH2345" }),
+    expectedResponseStatusCode: 202,
+    expectedResponseBody: pendingBody,
+  });
+
+  const record = await repository.getIdempotencyRecord(
+    "admin@example.com:POST:/v1/leagues/league-1/organiser-invites",
+    "invite-email-1",
+  );
+
+  assert.equal(reserved, true);
+  assert.equal(completed, true);
+  assert.equal(mismatched, false);
+  assert.equal(record?.requestHash, "hash-1");
+  assert.equal(record?.responseStatusCode, 201);
+  assert.equal(record?.responseBody, JSON.stringify({ inviteCode: "ABCD2345" }));
+});
+
+test("repository deletes an existing idempotency reservation by matching request hash", async () => {
+  const { repository } = createRepositoryHarness();
+  const pendingBody = JSON.stringify({ idempotencyState: "pending" });
+
+  const reserved = await repository.createIdempotencyRecord({
+    scope: "admin@example.com:POST:/v1/leagues/league-1/organiser-invites",
+    key: "invite-email-1",
+    requestHash: "hash-1",
+    responseStatusCode: 202,
+    responseBody: pendingBody,
+  });
+
+  const mismatched = await repository.deleteIdempotencyRecord({
+    scope: "admin@example.com:POST:/v1/leagues/league-1/organiser-invites",
+    key: "invite-email-1",
+    requestHash: "different-hash",
+    responseStatusCode: 202,
+    responseBody: pendingBody,
+  });
+
+  const deleted = await repository.deleteIdempotencyRecord({
+    scope: "admin@example.com:POST:/v1/leagues/league-1/organiser-invites",
+    key: "invite-email-1",
+    requestHash: "hash-1",
+    responseStatusCode: 202,
+    responseBody: pendingBody,
+  });
+
+  const missing = await repository.deleteIdempotencyRecord({
+    scope: "admin@example.com:POST:/v1/leagues/league-1/organiser-invites",
+    key: "invite-email-1",
+    requestHash: "hash-1",
+    responseStatusCode: 202,
+    responseBody: pendingBody,
+  });
+
+  const record = await repository.getIdempotencyRecord(
+    "admin@example.com:POST:/v1/leagues/league-1/organiser-invites",
+    "invite-email-1",
+  );
+
+  assert.equal(reserved, true);
+  assert.equal(mismatched, false);
+  assert.equal(deleted, true);
+  assert.equal(missing, false);
+  assert.equal(record, null);
+});
+
+test("repository does not delete an idempotency record that changed after it was read", async () => {
+  const { repository } = createRepositoryHarness();
+  const scope = "admin@example.com:POST:/v1/leagues/league-1/organiser-invites";
+  const pendingBody = JSON.stringify({ idempotencyState: "pending" });
+  const completedBody = JSON.stringify({ inviteCode: "ABCD2345" });
+
+  const reserved = await repository.createIdempotencyRecord({
+    scope,
+    key: "invite-email-1",
+    requestHash: "hash-1",
+    responseStatusCode: 202,
+    responseBody: pendingBody,
+  });
+  const pendingRecord = await repository.getIdempotencyRecord(scope, "invite-email-1");
+  const completed = await repository.completeIdempotencyRecord({
+    scope,
+    key: "invite-email-1",
+    requestHash: "hash-1",
+    responseStatusCode: 201,
+    responseBody: completedBody,
+    expectedResponseStatusCode: 202,
+    expectedResponseBody: pendingBody,
+  });
+
+  const deleted = await repository.deleteIdempotencyRecord({
+    scope,
+    key: "invite-email-1",
+    requestHash: "hash-1",
+    responseStatusCode: 202,
+    responseBody: pendingBody,
+    updatedAt: pendingRecord?.updatedAt,
+  });
+  const record = await repository.getIdempotencyRecord(scope, "invite-email-1");
+
+  assert.equal(reserved, true);
+  assert(pendingRecord);
+  assert.equal(completed, true);
+  assert.equal(deleted, false);
+  assert.equal(record?.responseStatusCode, 201);
+  assert.equal(record?.responseBody, completedBody);
+});
+
+test("repository does not complete an idempotency reservation that changed after it was read", async () => {
+  const { repository } = createRepositoryHarness();
+  const scope = "admin@example.com:POST:/v1/leagues/league-1/organiser-invites";
+  const firstPendingBody = JSON.stringify({
+    idempotencyState: "pending",
+    reservationId: "reservation-a",
+  });
+  const replacementPendingBody = JSON.stringify({
+    idempotencyState: "pending",
+    reservationId: "reservation-b",
+  });
+
+  const firstReserved = await repository.createIdempotencyRecord({
+    scope,
+    key: "invite-email-1",
+    requestHash: "hash-1",
+    responseStatusCode: 202,
+    responseBody: firstPendingBody,
+  });
+  const firstDeleted = await repository.deleteIdempotencyRecord({
+    scope,
+    key: "invite-email-1",
+    requestHash: "hash-1",
+    responseStatusCode: 202,
+    responseBody: firstPendingBody,
+  });
+  const replacementReserved = await repository.createIdempotencyRecord({
+    scope,
+    key: "invite-email-1",
+    requestHash: "hash-1",
+    responseStatusCode: 202,
+    responseBody: replacementPendingBody,
+  });
+
+  const staleCompleted = await repository.completeIdempotencyRecord({
+    scope,
+    key: "invite-email-1",
+    requestHash: "hash-1",
+    responseStatusCode: 201,
+    responseBody: JSON.stringify({ inviteCode: "ABCD2345" }),
+    expectedResponseStatusCode: 202,
+    expectedResponseBody: firstPendingBody,
+  });
+  const record = await repository.getIdempotencyRecord(scope, "invite-email-1");
+
+  assert.equal(firstReserved, true);
+  assert.equal(firstDeleted, true);
+  assert.equal(replacementReserved, true);
+  assert.equal(staleCompleted, false);
+  assert.equal(record?.responseStatusCode, 202);
+  assert.equal(record?.responseBody, replacementPendingBody);
 });
 
 async function setupScoringGame(repository: ThreeFcRepository): Promise<void> {

--- a/api/src/tests/session.test.ts
+++ b/api/src/tests/session.test.ts
@@ -54,6 +54,8 @@ test("isAuthenticatedApiRoute marks protected routes only", () => {
   assert.equal(isAuthenticatedApiRoute("POST", "/v1/games/game-1/goals/undo-last"), true);
   assert.equal(isAuthenticatedApiRoute("POST", "/v1/players/player-1/claim"), true);
   assert.equal(isAuthenticatedApiRoute("POST", "/v1/leagues/league-1/access"), true);
+  assert.equal(isAuthenticatedApiRoute("POST", "/v1/leagues/league-1/organiser-invites"), true);
+  assert.equal(isAuthenticatedApiRoute("POST", "/v1/invites/ABCD2345/accept"), true);
   assert.equal(isAuthenticatedApiRoute("GET", "/v1/auth/session"), true);
   assert.equal(isAuthenticatedApiRoute("POST", "/v1/leagues"), true);
   assert.equal(isAuthenticatedApiRoute("POST", "/v1/leagues/league-1/seasons"), true);

--- a/app/src/server.ts
+++ b/app/src/server.ts
@@ -7,6 +7,7 @@ import { buildSecurityHeaders } from "./security.js";
 import {
   renderComponentShowcasePage,
   renderGamePage,
+  renderInvitePage,
   renderJoinPage,
   renderLeaguePage,
   renderMagicLinkCallbackPage,
@@ -232,6 +233,18 @@ export function createAppRequestHandler(apiBaseUrl: string) {
     if (method === "GET" && joinPageMatch) {
       const joinCode = decodeURIComponent(joinPageMatch[1]);
       sendHtml(response, securityHeaders, 200, renderJoinPage(apiBaseUrl, joinCode));
+      return;
+    }
+
+    if (method === "GET" && route === "/invites") {
+      sendHtml(response, securityHeaders, 200, renderInvitePage(apiBaseUrl, ""));
+      return;
+    }
+
+    const invitePageMatch = route.match(/^\/invites\/([^/]+)$/);
+    if (method === "GET" && invitePageMatch) {
+      const inviteCode = decodeURIComponent(invitePageMatch[1]);
+      sendHtml(response, securityHeaders, 200, renderInvitePage(apiBaseUrl, inviteCode));
       return;
     }
 

--- a/app/src/static-export.ts
+++ b/app/src/static-export.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import {
   renderComponentShowcasePage,
   renderGamePage,
+  renderInvitePage,
   renderJoinPage,
   renderLeaguePage,
   renderMagicLinkCallbackPage,
@@ -94,6 +95,7 @@ export function buildStaticSite(options: StaticSiteBuildOptions): string {
     { path: "/seasons", html: renderSeasonPage(options.apiBaseUrl, "") },
     { path: "/games", html: renderGamePage(options.apiBaseUrl, { gameId: "" }) },
     { path: "/join", html: renderJoinPage(options.apiBaseUrl, "") },
+    { path: "/invites", html: renderInvitePage(options.apiBaseUrl, "") },
   ];
 
   rmSync(outputDir, { recursive: true, force: true });

--- a/app/src/tests/server.test.ts
+++ b/app/src/tests/server.test.ts
@@ -127,7 +127,7 @@ test("setup and auth flow script routes serve external javascript", () => {
   assert.match(authFlowResponse.body, /auth\/callback/);
 });
 
-test("league, season, game, and join routes render their shells", () => {
+test("league, season, game, join, and invite routes render their shells", () => {
   const leagueResponse = executeRoute("GET", "/leagues/league-1");
   assert.equal(leagueResponse.statusCode, 200);
   assert.match(leagueResponse.body, /data-testid="league-shell"/);
@@ -157,6 +157,14 @@ test("league, season, game, and join routes render their shells", () => {
   assert.match(joinResponse.body, /data-testid="join-shell"/);
   assert.match(joinResponse.body, /data-page="join"/);
   assert.match(joinResponse.body, /data-join-code="join0001"/);
+
+  const inviteResponse = executeRoute("GET", "/invites?code=ABCD2345");
+  assert.equal(inviteResponse.statusCode, 200);
+  assertSecurityHeaders(inviteResponse.headers);
+  assert.equal(inviteResponse.headers["Content-Type"], "text/html; charset=utf-8");
+  assert.match(inviteResponse.body, /data-testid="invite-shell"/);
+  assert.match(inviteResponse.body, /data-page="invite"/);
+  assert.match(inviteResponse.body, /data-invite-code=""/);
 });
 
 test("auth callback error and success responses include security headers", () => {
@@ -167,7 +175,8 @@ test("auth callback error and success responses include security headers", () =>
   const tokenResponse = executeRoute("GET", "/auth/callback?token=abc123");
   assert.equal(tokenResponse.statusCode, 200);
   assertSecurityHeaders(tokenResponse.headers);
-  assert.match(tokenResponse.body, /Completing sign-in/);
+  assert.match(tokenResponse.body, /Complete sign-in/);
+  assert.match(tokenResponse.body, /data-testid="complete-magic-link"/);
 
   const successResponse = executeRoute("GET", "/auth/callback?code=abc123");
   assert.equal(successResponse.statusCode, 200);

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -16,6 +16,7 @@ import {
 
 import {
   renderGamePage,
+  renderInvitePage,
   renderJoinPage,
   renderLeaguePage,
   renderMagicLinkCallbackPage,
@@ -36,6 +37,19 @@ interface MockLeague {
   name: string;
   slug: string | null;
   createdByUserId: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface MockLeagueInvite {
+  leagueId: string;
+  inviteCode: string;
+  kind: "share" | "email";
+  role: "admin";
+  email: string | null;
+  createdByUserId: string;
+  acceptedByUserId: string | null;
+  acceptedAt: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -138,6 +152,7 @@ interface MockApiState {
   session: MockSession | null;
   leagues: Map<string, MockLeague>;
   leagueAccess: Map<string, MockLeagueRole>;
+  leagueInvites: Map<string, MockLeagueInvite>;
   seasons: Map<string, MockSeason>;
   sessions: Map<string, MockSessionEntity>;
   games: Map<string, MockGame>;
@@ -150,6 +165,11 @@ interface MockApiState {
   goalSequence: number;
   lastPublicJoinRequest: { body: Record<string, unknown>; idempotencyKey: string | null } | null;
   lastGrantAccessRequest: { leagueId: string; body: Record<string, unknown> } | null;
+  lastOrganiserInviteRequest: {
+    leagueId: string;
+    body: Record<string, unknown>;
+    idempotencyKey: string | null;
+  } | null;
 }
 
 function readUiScript(fileName: string): string {
@@ -165,6 +185,7 @@ function createMockApiState(): MockApiState {
     session: null,
     leagues: new Map<string, MockLeague>(),
     leagueAccess: new Map<string, MockLeagueRole>(),
+    leagueInvites: new Map<string, MockLeagueInvite>(),
     seasons: new Map<string, MockSeason>(),
     sessions: new Map<string, MockSessionEntity>(),
     games: new Map<string, MockGame>(),
@@ -177,6 +198,7 @@ function createMockApiState(): MockApiState {
     goalSequence: 0,
     lastPublicJoinRequest: null,
     lastGrantAccessRequest: null,
+    lastOrganiserInviteRequest: null,
   };
 }
 
@@ -687,12 +709,6 @@ function createMockFetch(state: MockApiState) {
           message: "Join code was not found.",
         });
       }
-      if (game.status === "finished") {
-        return createJsonResponse(409, {
-          error: "conflict",
-          message: "Finished games cannot accept new joins.",
-        });
-      }
       if (!idempotencyKey?.trim()) {
         return createJsonResponse(400, {
           error: "bad_request",
@@ -862,6 +878,142 @@ function createMockFetch(state: MockApiState) {
       });
     }
 
+    const organiserInviteMatch = path.match(/^\/v1\/leagues\/([^/]+)\/organiser-invites$/);
+    if (method === "POST" && organiserInviteMatch) {
+      const leagueId = decodeURIComponent(organiserInviteMatch[1]);
+      const league = state.leagues.get(leagueId);
+      if (!league) {
+        return createJsonResponse(404, { error: "not_found", message: "League not found." });
+      }
+
+      const callerRole = mockLeagueRoleForSession(state, league);
+      if (callerRole !== "admin") {
+        return createJsonResponse(403, {
+          error: "forbidden",
+          code: "admin_required",
+          message: `Admin role is required for league ${leagueId}.`,
+        });
+      }
+
+      const email = typeof body.email === "string" && body.email.trim().length > 0
+        ? body.email.trim().toLowerCase()
+        : null;
+      if (email && !isValidEmail(email)) {
+        return createJsonResponse(400, {
+          error: "invalid_email",
+          message: "Email must be a valid email address.",
+        });
+      }
+
+      if (!email) {
+        const existingShareInvite = [...state.leagueInvites.values()].find(
+          (candidate) =>
+            candidate.leagueId === leagueId &&
+            candidate.kind === "share" &&
+            candidate.email === null,
+        );
+        state.lastOrganiserInviteRequest = {
+          leagueId,
+          body,
+          idempotencyKey: readInitHeader(init, "idempotency-key"),
+        };
+        if (existingShareInvite) {
+          return createJsonResponse(201, {
+            invite: existingShareInvite,
+            inviteCode: existingShareInvite.inviteCode,
+            inviteLink: `http://localhost:3000/invites?code=${existingShareInvite.inviteCode}`,
+            emailDelivery: null,
+          });
+        }
+      }
+
+      const inviteCode = ["ABCD2345", "EFGH2345", "JKLM2345"][state.leagueInvites.size] ?? "NPQR2345";
+      const invite: MockLeagueInvite = {
+        leagueId,
+        inviteCode,
+        kind: email ? "email" : "share",
+        role: "admin",
+        email,
+        createdByUserId: state.session.email,
+        acceptedByUserId: null,
+        acceptedAt: null,
+        createdAt: "2026-03-28T11:00:15.000Z",
+        updatedAt: "2026-03-28T11:00:15.000Z",
+      };
+      state.lastOrganiserInviteRequest = {
+        leagueId,
+        body,
+        idempotencyKey: readInitHeader(init, "idempotency-key"),
+      };
+      state.leagueInvites.set(inviteCode, invite);
+      return createJsonResponse(201, {
+        invite,
+        inviteCode,
+        inviteLink: `http://localhost:3000/invites?code=${inviteCode}`,
+        emailDelivery: email
+          ? {
+              status: "sent",
+              email,
+              expiresAt: "2026-03-28T11:15:00.000Z",
+              messageId: "msg-1",
+            }
+          : null,
+      });
+    }
+
+    const acceptOrganiserInviteMatch = path.match(/^\/v1\/invites\/([^/]+)\/accept$/);
+    if (method === "POST" && acceptOrganiserInviteMatch) {
+      const inviteCode = decodeURIComponent(acceptOrganiserInviteMatch[1]).trim().toUpperCase();
+      const invite = state.leagueInvites.get(inviteCode);
+      if (!invite) {
+        return createJsonResponse(404, {
+          error: "not_found",
+          message: "Organiser invite was not found.",
+        });
+      }
+
+      const sessionEmail = state.session.email.trim().toLowerCase();
+      if (invite.email && invite.email !== sessionEmail) {
+        return createJsonResponse(403, {
+          error: "forbidden",
+          code: "invite_email_mismatch",
+          message: "This organiser invite was issued for a different email address.",
+        });
+      }
+
+      if (invite.kind !== "share" && invite.acceptedByUserId && invite.acceptedByUserId !== state.session.email) {
+        return createJsonResponse(409, {
+          error: "conflict",
+          code: "invite_already_accepted",
+          message: "This organiser invite has already been accepted.",
+        });
+      }
+
+      const acceptedInvite: MockLeagueInvite = {
+        ...invite,
+        acceptedByUserId: invite.kind === "share" ? null : invite.acceptedByUserId ?? state.session.email,
+        acceptedAt: invite.kind === "share" ? null : invite.acceptedAt ?? "2026-03-28T11:00:16.000Z",
+        updatedAt:
+          invite.kind === "share" || invite.acceptedByUserId
+            ? invite.updatedAt
+            : "2026-03-28T11:00:16.000Z",
+      };
+      state.leagueInvites.set(inviteCode, acceptedInvite);
+      grantMockLeagueAccess(state, invite.leagueId, state.session.email, "admin");
+      return createJsonResponse(200, {
+        invite: acceptedInvite,
+        access: {
+          leagueId: invite.leagueId,
+          userId: state.session.email,
+          role: "admin",
+          grantedByUserId: invite.createdByUserId,
+          createdAt: "2026-03-28T11:00:16.000Z",
+          updatedAt: "2026-03-28T11:00:16.000Z",
+        },
+        inviteLink: `http://localhost:3000/invites?code=${inviteCode}`,
+      });
+    }
+
     if (method === "DELETE" && leagueMatch) {
       const leagueId = decodeURIComponent(leagueMatch[1]);
       if (![...state.leagues.keys()].includes(leagueId)) {
@@ -876,6 +1028,16 @@ function createMockFetch(state: MockApiState) {
       }
 
       state.leagues.delete(leagueId);
+      for (const [inviteCode, invite] of state.leagueInvites) {
+        if (invite.leagueId === leagueId) {
+          state.leagueInvites.delete(inviteCode);
+        }
+      }
+      for (const accessKey of state.leagueAccess.keys()) {
+        if (accessKey.startsWith(`${leagueId}:`)) {
+          state.leagueAccess.delete(accessKey);
+        }
+      }
       return new Response(null, { status: 204 });
     }
 
@@ -1685,6 +1847,37 @@ test("sign-in page shows inline validation for invalid email", async () => {
   assert.equal(notice.textContent, "Enter a valid email address.");
 });
 
+test("auth callback rejects backslash return targets", async () => {
+  const apiState = createMockApiState();
+  apiState.pendingEmail = "organizer@3fc.football";
+  apiState.pendingToken = "token-1";
+
+  const callbackPage = await bootPage({
+    html: renderMagicLinkCallbackPage("http://localhost:3001"),
+    url: "http://localhost:3000/auth/callback?token=token-1&returnTo=/%5Cevil.example",
+    scriptFile: "auth-flow.js",
+    apiState,
+  });
+  await flushAsync();
+
+  assert.equal(callbackPage.navigations.length, 0);
+  assert.equal(apiState.cookieJar, "");
+  assert.equal(
+    callbackPage.document.getElementById("auth-callback-status")?.textContent,
+    "Magic link ready. Complete sign-in to continue.",
+  );
+
+  const completeButton = callbackPage.document.querySelector('[data-testid="complete-magic-link"]');
+  assert(completeButton instanceof callbackPage.window.HTMLButtonElement);
+  dispatchClick(completeButton);
+  await flushAsync();
+
+  const callbackNavigation = callbackPage.navigations.at(-1);
+  assert(callbackNavigation);
+  assert.equal(callbackNavigation.url, "/setup");
+  assert.equal(apiState.cookieJar, "threefc_session=session-1");
+});
+
 test("setup flow shows inline validation for blank required fields", async () => {
   const apiState = createMockApiState();
   apiState.session = {
@@ -1779,6 +1972,322 @@ test("setup flow shows inline validation for blank required fields", async () =>
   assert.equal(gameKickoffNotice.textContent, "Kickoff time must be valid.");
 });
 
+test("league page loads reusable organiser share invites and sends direct email invites", async () => {
+  const apiState = createMockApiState();
+  apiState.session = {
+    sessionId: "session-admin",
+    email: "organizer@3fc.football",
+    createdAt: "2026-03-28T11:00:00.000Z",
+    expiresAt: "2026-03-29T11:00:00.000Z",
+  };
+  apiState.cookieJar = "threefc_session=session-admin";
+  apiState.leagues.set("autumn-league", {
+    leagueId: "autumn-league",
+    name: "Autumn League",
+    slug: "autumn-league",
+    createdByUserId: "organizer@3fc.football",
+    createdAt: "2026-03-28T11:00:00.000Z",
+    updatedAt: "2026-03-28T11:00:00.000Z",
+  });
+  grantMockLeagueAccess(apiState, "autumn-league", "organizer@3fc.football", "admin");
+
+  const leaguePage = await bootPage({
+    html: renderLeaguePage("http://localhost:3001", "autumn-league"),
+    url: "http://localhost:3000/leagues/autumn-league",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+
+  const createInviteButton = leaguePage.document.querySelector('[data-testid="create-organiser-invite"]');
+  const inviteEmailInput = leaguePage.document.getElementById("organiser-invite-email");
+  assert(createInviteButton instanceof leaguePage.window.HTMLButtonElement);
+  assert(inviteEmailInput instanceof leaguePage.window.HTMLInputElement);
+
+  assert.equal(apiState.lastOrganiserInviteRequest?.leagueId, "autumn-league");
+  assert.deepEqual(apiState.lastOrganiserInviteRequest?.body, { email: null });
+  assert.equal(
+    apiState.lastOrganiserInviteRequest?.idempotencyKey,
+    "organiser-share-invite-autumn-league",
+  );
+  assert.equal(
+    apiState.storage.has("threefc-idempotency:organiser-invite:autumn-league-link"),
+    false,
+  );
+  assert.equal(
+    leaguePage.document.getElementById("organiser-share-invite-status")?.textContent,
+    "Share invite ready.",
+  );
+  assert.equal(leaguePage.document.getElementById("organiser-share-invite-code")?.textContent, "ABCD2345");
+  const inviteLink = leaguePage.document.getElementById("organiser-share-invite-link");
+  assert(inviteLink instanceof leaguePage.window.HTMLAnchorElement);
+  assert.equal(inviteLink.href, "http://localhost:3000/invites?code=ABCD2345");
+  assert.equal(leaguePage.document.getElementById("organiser-email-invite-result")?.hidden, true);
+  assert.equal(leaguePage.document.getElementById("organiser-invite-email-status")?.textContent, "");
+
+  inviteEmailInput.value = "Coach@Example.COM";
+  inviteEmailInput.dispatchEvent(new leaguePage.window.Event("input", { bubbles: true }));
+  dispatchClick(createInviteButton);
+  await flushAsync();
+
+  assert.deepEqual(apiState.lastOrganiserInviteRequest?.body, { email: "Coach@Example.COM" });
+  assert.equal(leaguePage.document.getElementById("organiser-share-invite-code")?.textContent, "ABCD2345");
+  assert.equal(leaguePage.document.getElementById("organiser-email-invite-result")?.hidden, false);
+  assert.equal(leaguePage.document.getElementById("organiser-email-invite-code")?.textContent, "EFGH2345");
+  const emailInviteLink = leaguePage.document.getElementById("organiser-email-invite-link");
+  assert(emailInviteLink instanceof leaguePage.window.HTMLAnchorElement);
+  assert.equal(emailInviteLink.href, "http://localhost:3000/invites?code=EFGH2345");
+  assert.equal(
+    leaguePage.document.getElementById("organiser-invite-email-status")?.textContent,
+    "Sent to coach@example.com.",
+  );
+});
+
+test("league page reuses organiser invite idempotency key until a retry succeeds", async () => {
+  const apiState = createMockApiState();
+  apiState.session = {
+    sessionId: "session-admin",
+    email: "organizer@3fc.football",
+    createdAt: "2026-03-28T11:00:00.000Z",
+    expiresAt: "2026-03-29T11:00:00.000Z",
+  };
+  apiState.cookieJar = "threefc_session=session-admin";
+  apiState.leagues.set("autumn-league", {
+    leagueId: "autumn-league",
+    name: "Autumn League",
+    slug: "autumn-league",
+    createdByUserId: "organizer@3fc.football",
+    createdAt: "2026-03-28T11:00:00.000Z",
+    updatedAt: "2026-03-28T11:00:00.000Z",
+  });
+  grantMockLeagueAccess(apiState, "autumn-league", "organizer@3fc.football", "admin");
+
+  const defaultFetch = createMockFetch(apiState);
+  const requestedKeys: string[] = [];
+  let failNextInvite = true;
+  const retryFetch: ReturnType<typeof createMockFetch> = async (input, init = {}) => {
+    const target =
+      typeof input === "string" || input instanceof URL
+        ? new URL(String(input))
+        : new URL(input.url);
+    const method = (init.method ?? "GET").toUpperCase();
+
+    if (method === "POST" && target.pathname === "/v1/leagues/autumn-league/organiser-invites") {
+      const body =
+        typeof init.body === "string" && init.body.length > 0
+          ? (JSON.parse(init.body) as Record<string, unknown>)
+          : {};
+      if (typeof body.email === "string" && body.email.trim().length > 0) {
+        const idempotencyKey = readInitHeader(init, "idempotency-key");
+        if (idempotencyKey) {
+          requestedKeys.push(idempotencyKey);
+        }
+        if (failNextInvite) {
+          failNextInvite = false;
+          return createJsonResponse(503, {
+            error: "temporary_failure",
+            message: "Temporary failure.",
+          });
+        }
+      }
+    }
+
+    return defaultFetch(input, init);
+  };
+
+  const leaguePage = await bootPage({
+    html: renderLeaguePage("http://localhost:3001", "autumn-league"),
+    url: "http://localhost:3000/leagues/autumn-league",
+    scriptFile: "setup-flow.js",
+    apiState,
+    fetch: retryFetch,
+  });
+
+  const createInviteButton = leaguePage.document.querySelector('[data-testid="create-organiser-invite"]');
+  const inviteEmailInput = leaguePage.document.getElementById("organiser-invite-email");
+  assert(createInviteButton instanceof leaguePage.window.HTMLButtonElement);
+  assert(inviteEmailInput instanceof leaguePage.window.HTMLInputElement);
+
+  inviteEmailInput.value = "Coach@Example.COM";
+  inviteEmailInput.dispatchEvent(new leaguePage.window.Event("input", { bubbles: true }));
+  dispatchClick(createInviteButton);
+  await flushAsync();
+
+  assert.equal(leaguePage.document.getElementById("setup-status")?.textContent, "Organiser invite failed.");
+  assert.equal(
+    apiState.storage.get("threefc-idempotency:organiser-invite:autumn-league-coach%40example.com"),
+    requestedKeys[0],
+  );
+
+  dispatchClick(createInviteButton);
+  await flushAsync();
+
+  assert.equal(requestedKeys.length, 2);
+  assert.equal(requestedKeys[1], requestedKeys[0]);
+  assert.equal(
+    apiState.storage.has("threefc-idempotency:organiser-invite:autumn-league-coach%40example.com"),
+    false,
+  );
+  assert.equal(leaguePage.document.getElementById("setup-status")?.textContent, "Organiser invite sent.");
+});
+
+test("league page shows manual invite link when organiser email delivery is unconfirmed", async () => {
+  const apiState = createMockApiState();
+  apiState.session = {
+    sessionId: "session-admin",
+    email: "organizer@3fc.football",
+    createdAt: "2026-03-28T11:00:00.000Z",
+    expiresAt: "2026-03-29T11:00:00.000Z",
+  };
+  apiState.cookieJar = "threefc_session=session-admin";
+  apiState.leagues.set("autumn-league", {
+    leagueId: "autumn-league",
+    name: "Autumn League",
+    slug: "autumn-league",
+    createdByUserId: "organizer@3fc.football",
+    createdAt: "2026-03-28T11:00:00.000Z",
+    updatedAt: "2026-03-28T11:00:00.000Z",
+  });
+  grantMockLeagueAccess(apiState, "autumn-league", "organizer@3fc.football", "admin");
+
+  const defaultFetch = createMockFetch(apiState);
+  const uncertainFetch: ReturnType<typeof createMockFetch> = async (input, init = {}) => {
+    const target =
+      typeof input === "string" || input instanceof URL
+        ? new URL(String(input))
+        : new URL(input.url);
+    const method = (init.method ?? "GET").toUpperCase();
+
+    if (method === "POST" && target.pathname === "/v1/leagues/autumn-league/organiser-invites") {
+      const body =
+        typeof init.body === "string" && init.body.length > 0
+          ? (JSON.parse(init.body) as Record<string, unknown>)
+          : {};
+      if (typeof body.email !== "string" || body.email.trim().length === 0) {
+        return defaultFetch(input, init);
+      }
+
+      return createJsonResponse(202, {
+        invite: {
+          leagueId: "autumn-league",
+          inviteCode: "UNKN2345",
+          kind: "email",
+          role: "admin",
+          email: "coach@example.com",
+          createdByUserId: "organizer@3fc.football",
+          acceptedByUserId: null,
+          acceptedAt: null,
+          createdAt: "2026-03-28T11:00:15.000Z",
+          updatedAt: "2026-03-28T11:00:15.000Z",
+        },
+        inviteCode: "UNKN2345",
+        inviteLink: "http://localhost:3000/invites?code=UNKN2345",
+        emailDelivery: {
+          status: "unknown",
+          email: "coach@example.com",
+          expiresAt: null,
+          messageId: null,
+          message: "Email delivery could not be confirmed. Share the invite link manually.",
+        },
+      });
+    }
+
+    return defaultFetch(input, init);
+  };
+
+  const leaguePage = await bootPage({
+    html: renderLeaguePage("http://localhost:3001", "autumn-league"),
+    url: "http://localhost:3000/leagues/autumn-league",
+    scriptFile: "setup-flow.js",
+    apiState,
+    fetch: uncertainFetch,
+  });
+
+  const createInviteButton = leaguePage.document.querySelector('[data-testid="create-organiser-invite"]');
+  const inviteEmailInput = leaguePage.document.getElementById("organiser-invite-email");
+  assert(createInviteButton instanceof leaguePage.window.HTMLButtonElement);
+  assert(inviteEmailInput instanceof leaguePage.window.HTMLInputElement);
+
+  inviteEmailInput.value = "Coach@Example.COM";
+  inviteEmailInput.dispatchEvent(new leaguePage.window.Event("input", { bubbles: true }));
+  dispatchClick(createInviteButton);
+  await flushAsync();
+
+  assert.equal(
+    leaguePage.document.getElementById("setup-status")?.textContent,
+    "Organiser invite created; email delivery unconfirmed.",
+  );
+  assert.equal(
+    leaguePage.document.getElementById("organiser-invite-email-status")?.textContent,
+    "Delivery unconfirmed. Share the invite link manually.",
+  );
+  assert.equal(leaguePage.document.getElementById("organiser-email-invite-code")?.textContent, "UNKN2345");
+});
+
+test("invite page accepts organiser codes after confirmation and grants league admin access", async () => {
+  const apiState = createMockApiState();
+  apiState.session = {
+    sessionId: "session-invitee",
+    email: "coach@example.com",
+    createdAt: "2026-03-28T11:00:00.000Z",
+    expiresAt: "2026-03-29T11:00:00.000Z",
+  };
+  apiState.cookieJar = "threefc_session=session-invitee";
+  apiState.leagues.set("autumn-league", {
+    leagueId: "autumn-league",
+    name: "Autumn League",
+    slug: "autumn-league",
+    createdByUserId: "organizer@3fc.football",
+    createdAt: "2026-03-28T11:00:00.000Z",
+    updatedAt: "2026-03-28T11:00:00.000Z",
+  });
+  apiState.leagueInvites.set("ABCD2345", {
+    leagueId: "autumn-league",
+    inviteCode: "ABCD2345",
+    kind: "email",
+    role: "admin",
+    email: "coach@example.com",
+    createdByUserId: "organizer@3fc.football",
+    acceptedByUserId: null,
+    acceptedAt: null,
+    createdAt: "2026-03-28T11:00:15.000Z",
+    updatedAt: "2026-03-28T11:00:15.000Z",
+  });
+
+  const invitePage = await bootPage({
+    html: renderInvitePage("http://localhost:3001", ""),
+    url: "http://localhost:3000/invites?code=abcd2345",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+  await flushAsync();
+
+  assert.equal(apiState.leagueAccess.get(leagueAccessKey("autumn-league", "coach@example.com")), undefined);
+  assert.equal(apiState.leagueInvites.get("ABCD2345")?.acceptedByUserId, null);
+  assert.equal(
+    invitePage.document.getElementById("setup-status")?.textContent,
+    "Invite page ready.",
+  );
+  assert.equal(invitePage.document.getElementById("organiser-invite-code-form")?.hidden, true);
+  assert.equal(invitePage.document.getElementById("organiser-invite-accept-code")?.textContent, "ABCD2345");
+
+  const acceptButton = invitePage.document.querySelector('[data-action="accept-organiser-invite"]');
+  assert(acceptButton instanceof invitePage.window.HTMLButtonElement);
+  dispatchClick(acceptButton);
+  await flushAsync();
+
+  assert.equal(apiState.leagueAccess.get(leagueAccessKey("autumn-league", "coach@example.com")), "admin");
+  assert.equal(
+    invitePage.document.getElementById("setup-status")?.textContent,
+    "Organiser invite accepted.",
+  );
+  assert.equal(invitePage.document.getElementById("organiser-invite-league")?.textContent, "autumn-league");
+  assert.equal(invitePage.document.getElementById("organiser-invite-code-form")?.hidden, true);
+  const leagueLink = invitePage.document.getElementById("organiser-invite-league-link");
+  assert(leagueLink instanceof invitePage.window.HTMLAnchorElement);
+  assert.equal(leagueLink.hidden, false);
+  assert.equal(leagueLink.getAttribute("href"), "/leagues/autumn-league");
+});
+
 test("season page renders game kickoff times in the user local timezone", async () => {
   const apiState = createMockApiState();
   seedGoalScoringGame(apiState, {
@@ -1830,6 +2339,13 @@ test("setup happy path runs from sign-in to created game context", async () => {
     scriptFile: "auth-flow.js",
     apiState,
   });
+
+  assert.equal(callbackPage.navigations.length, 0);
+  assert.equal(apiState.cookieJar, "");
+  const completeButton = callbackPage.document.querySelector('[data-testid="complete-magic-link"]');
+  assert(completeButton instanceof callbackPage.window.HTMLButtonElement);
+  dispatchClick(completeButton);
+  await flushAsync();
 
   const callbackNavigation = callbackPage.navigations.at(-1);
   assert(callbackNavigation);

--- a/app/src/tests/static-export.test.ts
+++ b/app/src/tests/static-export.test.ts
@@ -42,6 +42,7 @@ test("buildStaticSite exports static route shells and ui assets", () => {
     assert.equal(existsSync(resolve(outputDir, "seasons/index.html")), true);
     assert.equal(existsSync(resolve(outputDir, "games/index.html")), true);
     assert.equal(existsSync(resolve(outputDir, "join/index.html")), true);
+    assert.equal(existsSync(resolve(outputDir, "invites/index.html")), true);
     assert.equal(existsSync(resolve(outputDir, "ui/styles.css")), true);
     assert.equal(existsSync(resolve(outputDir, "ui/setup-flow.js")), true);
     assert.equal(existsSync(resolve(outputDir, "ui/auth-flow.js")), true);
@@ -59,13 +60,19 @@ test("buildStaticSite exports static route shells and ui assets", () => {
     const joinHtml = readFileSync(resolve(outputDir, "join/index.html"), "utf8");
     assert.match(joinHtml, /data-page="join"/);
     assert.match(joinHtml, /data-join-code=""/);
+
+    const inviteHtml = readFileSync(resolve(outputDir, "invites/index.html"), "utf8");
+    assert.match(inviteHtml, /data-page="invite"/);
+    assert.match(inviteHtml, /data-invite-code=""/);
   } finally {
     rmSync(outputDir, { recursive: true, force: true });
   }
 });
 
-test("CloudFront router maps deployed join deep links to the exported shell", () => {
+test("CloudFront router maps deployed join deep links to exported shells", () => {
   assert.equal(runCloudFrontRouter("/join"), "/join/index.html");
   assert.equal(runCloudFrontRouter("/join/ABCD2345"), "/join/index.html");
+  assert.equal(runCloudFrontRouter("/invites"), "/invites/index.html");
+  assert.equal(runCloudFrontRouter("/invites/ABCD2345"), "/invites/index.html");
   assert.equal(runCloudFrontRouter("/ui/setup-flow.js"), "/ui/setup-flow.js");
 });

--- a/app/src/tests/ui-layout.test.ts
+++ b/app/src/tests/ui-layout.test.ts
@@ -169,7 +169,8 @@ test("magic-link callback page includes auth flow script and callback messaging"
   const html = renderMagicLinkCallbackPage("https://qa-api.3fc.football");
 
   assert.match(html, /data-testid="auth-callback-shell"/);
-  assert.match(html, /Completing sign-in/);
+  assert.match(html, /Complete sign-in/);
+  assert.match(html, /data-testid="complete-magic-link"/);
   assert.match(html, /id="auth-callback-status"/);
   assert.match(html, /<script src="\/ui\/auth-flow\.js" defer><\/script>/);
 });

--- a/app/src/ui/auth-flow.js
+++ b/app/src/ui/auth-flow.js
@@ -176,6 +176,23 @@
     return fallback;
   }
 
+  function isSafeReturnTo(value) {
+    if (typeof value !== "string" || !value.startsWith("/") || value.startsWith("//")) {
+      return false;
+    }
+
+    if (value.includes("\\")) {
+      return false;
+    }
+
+    try {
+      const target = new URL(value, window.location.origin);
+      return target.origin === window.location.origin && target.pathname.startsWith("/");
+    } catch {
+      return false;
+    }
+  }
+
   async function initSignInPage() {
     const form = document.getElementById("auth-magic-form");
     if (!(form instanceof HTMLFormElement)) {
@@ -322,6 +339,7 @@
 
     const statusElement = document.getElementById("auth-callback-status");
     const errorElement = document.getElementById("auth-callback-error");
+    const completeButton = document.querySelector('[data-action="complete-magic-link"]');
     const params = new URLSearchParams(window.location.search);
     const token = params.get("token");
     const oauthError = params.get("error");
@@ -334,9 +352,22 @@
       }
 
       setStatus(statusElement, "Sign-in callback failed.", "error");
+      if (completeButton instanceof HTMLButtonElement) {
+        completeButton.disabled = false;
+      }
     }
 
-    const returnTo = consumeReturnTo("/setup");
+    function clearCallbackError() {
+      if (!errorElement) {
+        return;
+      }
+
+      errorElement.hidden = true;
+      errorElement.textContent = "";
+    }
+
+    const callbackReturnTo = params.get("returnTo");
+    const returnTo = isSafeReturnTo(callbackReturnTo) ? callbackReturnTo : consumeReturnTo("/setup");
 
     if (oauthError) {
       showCallbackError(`OAuth provider returned: ${oauthError}.`);
@@ -344,26 +375,38 @@
     }
 
     if (token) {
-      setStatus(statusElement, "Completing magic-link sign-in…", "default");
-      const result = await requestJson("/v1/auth/magic/complete", {
-        method: "POST",
-        credentials: "include",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ token }),
-      });
-
-      if (!result.ok) {
-        const message = result.body?.message || result.body?.error || "Magic-link completion failed.";
-        showCallbackError(message);
+      setStatus(statusElement, "Magic link ready. Complete sign-in to continue.", "default");
+      if (!(completeButton instanceof HTMLButtonElement)) {
+        showCallbackError("Sign-in confirmation control was not available.");
         return;
       }
 
-      setStatus(statusElement, "Sign-in complete. Redirecting…", "success");
-      setTimeout(() => {
-        navigateTo(returnTo, "replace");
-      }, 700);
+      completeButton.hidden = false;
+      completeButton.disabled = false;
+      completeButton.addEventListener("click", async () => {
+        clearCallbackError();
+        completeButton.disabled = true;
+        setStatus(statusElement, "Completing magic-link sign-in…", "default");
+        const result = await requestJson("/v1/auth/magic/complete", {
+          method: "POST",
+          credentials: "include",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ token }),
+        });
+
+        if (!result.ok) {
+          const message = result.body?.message || result.body?.error || "Magic-link completion failed.";
+          showCallbackError(message);
+          return;
+        }
+
+        setStatus(statusElement, "Sign-in complete. Redirecting…", "success");
+        setTimeout(() => {
+          navigateTo(returnTo, "replace");
+        }, 700);
+      });
       return;
     }
 

--- a/app/src/ui/layout.ts
+++ b/app/src/ui/layout.ts
@@ -271,6 +271,41 @@ export function renderLeaguePage(apiBaseUrl: string, leagueId: string): string {
     "panel-league-seasons",
   );
 
+  const organiserInvitePanel = renderPanel(
+    "Invite organiser",
+    "Share a reusable league code or send a direct email invite.",
+    `<section data-ui="section-stack" aria-labelledby="organiser-share-invite-heading">
+      <h3 id="organiser-share-invite-heading">Share code/link</h3>
+      <p data-ui="status-note" id="organiser-share-invite-status">Loading share invite…</p>
+      <p data-ui="field-hint">Reusable league organiser code. Anyone signed in with this code or link can join as organiser.</p>
+      <dl data-ui="id-preview" data-testid="organiser-share-invite-result" id="organiser-share-invite-result">
+        <div><dt>Invite code</dt><dd id="organiser-share-invite-code">Loading…</dd></div>
+        <div><dt>Invite link</dt><dd><a id="organiser-share-invite-link">Loading…</a></dd></div>
+      </dl>
+    </section>
+    <section data-ui="section-stack" aria-labelledby="organiser-email-invite-heading">
+      <h3 id="organiser-email-invite-heading">Email invite</h3>
+      ${renderValidatedField({
+        id: "organiser-invite-email",
+        label: "Organiser email",
+        type: "email",
+        placeholder: "coach@example.com",
+        hint: "Sends a one-time invite restricted to this email.",
+      })}
+      <dl data-ui="id-preview" data-testid="organiser-email-invite-result" id="organiser-email-invite-result" hidden>
+        <div><dt>Invite code</dt><dd id="organiser-email-invite-code"></dd></div>
+        <div><dt>Invite link</dt><dd><a id="organiser-email-invite-link"></a></dd></div>
+        <div><dt>Email</dt><dd id="organiser-invite-email-status"></dd></div>
+      </dl>
+    </section>`,
+    `<div data-ui="button-row">${renderButton("Send email invite", "primary", {
+      type: "button",
+      "data-action": "create-organiser-invite",
+      "data-testid": "create-organiser-invite",
+    })}</div>`,
+    "panel-league-organiser-invite",
+  );
+
   return `<!doctype html>
 <html lang="en">
   <head>
@@ -296,7 +331,73 @@ export function renderLeaguePage(apiBaseUrl: string, leagueId: string): string {
         <p data-ui="status-note" data-state="error" id="setup-error" hidden></p>
         <section data-ui="panel-grid" data-testid="league-grid">
           ${createSeasonPanel}
+          ${organiserInvitePanel}
           ${seasonsPanel}
+        </section>
+      </section>
+    </main>
+    ${renderSetupScriptTag()}
+  </body>
+</html>`;
+}
+
+export function renderInvitePage(apiBaseUrl: string, inviteCode: string): string {
+  const safeInviteCode = escapeHtml(inviteCode.trim().toUpperCase());
+  const inviteHeading = safeInviteCode.length > 0 ? safeInviteCode : "Organiser invite";
+  const hasCode = safeInviteCode.length > 0;
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>3FC Organiser Invite</title>
+    ${renderStylesheetLink()}
+  </head>
+  <body data-api-base-url="${escapeHtml(apiBaseUrl)}">
+    <main data-ui="app-shell" data-testid="invite-shell" data-api-base-url="${escapeHtml(apiBaseUrl)}">
+      <section data-ui="hero">
+        <span data-ui="hero-kicker">3FC Invite</span>
+        <h1>Organiser invite</h1>
+        <p data-ui="hero-copy">Code <code>${inviteHeading}</code></p>
+      </section>
+      <section data-ui="setup-flow" id="setup-flow-root" data-testid="setup-flow-root" data-page="invite" data-api-base-url="${escapeHtml(apiBaseUrl)}" data-invite-code="${safeInviteCode}">
+        <p data-ui="status-note" id="setup-status">Checking sign-in state…</p>
+        <p data-ui="status-note" data-state="error" id="setup-error" hidden></p>
+        <section data-ui="panel-grid" data-testid="invite-grid">
+          ${renderPanel(
+            "Accept invite",
+            "Join the league setup team.",
+            `<form data-ui="auth-form" id="organiser-invite-code-form" ${hasCode ? "hidden" : ""} novalidate>
+              ${renderValidatedField({
+                id: "organiser-invite-code-input",
+                label: "Invite code",
+                placeholder: "ABCD2345",
+                required: true,
+              })}
+              <div data-ui="button-row">${renderButton("Continue", "primary", {
+                type: "submit",
+                "data-action": "continue-organiser-invite",
+                "data-testid": "continue-organiser-invite",
+              })}</div>
+            </form>
+            <section data-ui="claim-panel" id="organiser-invite-acceptance" data-testid="organiser-invite-acceptance" ${hasCode ? "" : "hidden"}>
+              <dl data-ui="id-preview">
+                <div><dt>Invite code</dt><dd id="organiser-invite-accept-code">${inviteHeading}</dd></div>
+                <div><dt>League</dt><dd id="organiser-invite-league">Pending</dd></div>
+              </dl>
+              <div data-ui="button-row">
+                ${renderButton("Accept invite", "primary", {
+                  type: "button",
+                  "data-action": "accept-organiser-invite",
+                  "data-testid": "accept-organiser-invite",
+                })}
+                <a data-ui="button-secondary" id="organiser-invite-league-link" data-testid="organiser-invite-league-link" href="/setup" hidden>Open league</a>
+              </div>
+            </section>`,
+            "",
+            "panel-organiser-invite",
+          )}
         </section>
       </section>
     </main>
@@ -630,11 +731,19 @@ export function renderMagicLinkCallbackPage(apiBaseUrl: string): string {
     <main data-ui="app-shell" data-testid="auth-callback-shell" data-api-base-url="${escapeHtml(apiBaseUrl)}">
       <section data-ui="hero">
         <span data-ui="hero-kicker">3FC Auth</span>
-        <h1>Completing sign-in</h1>
-        <p data-ui="hero-copy">Please wait while we complete your sign-in and return you to setup.</p>
+        <h1>Complete sign-in</h1>
+        <p data-ui="hero-copy">Confirm this browser should finish sign-in and continue.</p>
       </section>
       <section data-ui="section-stack">
         <p data-ui="status-note" id="auth-callback-status">Verifying callback parameters…</p>
+        <div data-ui="button-row">
+          ${renderButton("Complete sign-in", "primary", {
+            type: "button",
+            "data-action": "complete-magic-link",
+            "data-testid": "complete-magic-link",
+            hidden: "hidden",
+          })}
+        </div>
         <p data-ui="status-note" data-state="error" id="auth-callback-error" hidden></p>
       </section>
     </main>

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -512,6 +512,30 @@
     clearCachedIdempotencyKey("join-player", publicJoinIdempotencyStablePart(joinCode, nickname));
   }
 
+  function organiserInviteIdempotencyStablePart(leagueId, email) {
+    const normalizedEmail = email.trim().toLowerCase();
+    return `${leagueId.trim()}-${normalizedEmail || "link"}`;
+  }
+
+  function idempotencyKeyForOrganiserInvite(leagueId, email) {
+    return cachedIdempotencyKey(
+      "organiser-invite",
+      organiserInviteIdempotencyStablePart(leagueId, email),
+    );
+  }
+
+  function stableOrganiserShareInviteIdempotencyKey(leagueId) {
+    const safeLeagueId = leagueId.trim().replace(/[^A-Za-z0-9-]+/g, "-").replace(/-+/g, "-");
+    return `organiser-share-invite-${(safeLeagueId || "league").slice(0, 80)}`;
+  }
+
+  function clearIdempotencyKeyForOrganiserInvite(leagueId, email) {
+    clearCachedIdempotencyKey(
+      "organiser-invite",
+      organiserInviteIdempotencyStablePart(leagueId, email),
+    );
+  }
+
   async function requestJson(path, init = {}) {
     const response = await fetch(buildApiUrl(path), {
       credentials: "include",
@@ -944,6 +968,16 @@
     const seasonFriendlyUrlInput = document.getElementById("season-friendly-url");
     const seasonIdDisplay = document.getElementById("season-id-display");
     const createSeasonButton = root.querySelector('[data-action="create-season"]');
+    const organiserInviteEmailInput = document.getElementById("organiser-invite-email");
+    const createOrganiserInviteButton = root.querySelector('[data-action="create-organiser-invite"]');
+    const organiserShareInviteStatus = document.getElementById("organiser-share-invite-status");
+    const organiserShareInviteResult = document.getElementById("organiser-share-invite-result");
+    const organiserShareInviteCode = document.getElementById("organiser-share-invite-code");
+    const organiserShareInviteLink = document.getElementById("organiser-share-invite-link");
+    const organiserEmailInviteResult = document.getElementById("organiser-email-invite-result");
+    const organiserEmailInviteCode = document.getElementById("organiser-email-invite-code");
+    const organiserEmailInviteLink = document.getElementById("organiser-email-invite-link");
+    const organiserInviteEmailStatus = document.getElementById("organiser-invite-email-status");
 
     const seasonsBody = document.getElementById("league-seasons-body");
     const seasonsTableWrap = document.querySelector('[data-testid="league-seasons-table"]');
@@ -953,6 +987,8 @@
       !(seasonNameInput instanceof HTMLInputElement) ||
       !(seasonFriendlyUrlInput instanceof HTMLInputElement) ||
       !(createSeasonButton instanceof HTMLButtonElement) ||
+      !(organiserInviteEmailInput instanceof HTMLInputElement) ||
+      !(createOrganiserInviteButton instanceof HTMLButtonElement) ||
       !(seasonsBody instanceof HTMLElement)
     ) {
       return;
@@ -965,6 +1001,92 @@
     seasonFriendlyUrlInput.addEventListener("input", () => {
       setFieldMessage("season-friendly-url");
     });
+    organiserInviteEmailInput.addEventListener("input", () => {
+      setFieldMessage("organiser-invite-email");
+    });
+
+    function setLocalStatus(element, text, state = "default") {
+      if (!(element instanceof HTMLElement)) {
+        return;
+      }
+
+      element.textContent = text;
+      if (state === "default") {
+        element.removeAttribute("data-state");
+        return;
+      }
+
+      element.setAttribute("data-state", state);
+    }
+
+    function renderInviteCodeLink(resultElement, codeElement, linkElement, payload) {
+      const inviteCode = typeof payload?.inviteCode === "string"
+        ? payload.inviteCode
+        : typeof payload?.invite?.inviteCode === "string" ? payload.invite.inviteCode : "";
+      const inviteLink = typeof payload?.inviteLink === "string" ? payload.inviteLink : "";
+
+      if (resultElement instanceof HTMLElement) {
+        resultElement.hidden = false;
+      }
+      if (codeElement instanceof HTMLElement) {
+        codeElement.textContent = inviteCode || "Unavailable";
+      }
+      if (linkElement instanceof HTMLAnchorElement) {
+        if (inviteLink) {
+          linkElement.href = inviteLink;
+          linkElement.textContent = inviteLink;
+        } else {
+          linkElement.removeAttribute("href");
+          linkElement.textContent = "Unavailable";
+        }
+      }
+    }
+
+    async function ensureShareInvite() {
+      setLocalStatus(organiserShareInviteStatus, "Loading share invite…", "default");
+      if (organiserShareInviteCode instanceof HTMLElement) {
+        organiserShareInviteCode.textContent = "Loading…";
+      }
+      if (organiserShareInviteLink instanceof HTMLAnchorElement) {
+        organiserShareInviteLink.removeAttribute("href");
+        organiserShareInviteLink.textContent = "Loading…";
+      }
+
+      const idempotencyKey = stableOrganiserShareInviteIdempotencyKey(leagueId);
+
+      try {
+        const payload = await requestJsonOrThrow(
+          `/v1/leagues/${encodeURIComponent(leagueId)}/organiser-invites`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "Idempotency-Key": idempotencyKey,
+            },
+            body: JSON.stringify({
+              email: null,
+            }),
+          },
+        );
+
+        renderInviteCodeLink(
+          organiserShareInviteResult,
+          organiserShareInviteCode,
+          organiserShareInviteLink,
+          payload,
+        );
+        setLocalStatus(organiserShareInviteStatus, "Share invite ready.", "success");
+      } catch {
+        if (organiserShareInviteCode instanceof HTMLElement) {
+          organiserShareInviteCode.textContent = "Unavailable";
+        }
+        if (organiserShareInviteLink instanceof HTMLAnchorElement) {
+          organiserShareInviteLink.removeAttribute("href");
+          organiserShareInviteLink.textContent = "Unavailable";
+        }
+        setLocalStatus(organiserShareInviteStatus, "Share invite unavailable. Reload to try again.", "error");
+      }
+    }
 
     async function loadLeague() {
       const league = await requestJsonOrThrow(`/v1/leagues/${encodeURIComponent(leagueId)}`, {
@@ -1069,6 +1191,74 @@
       }
     });
 
+    createOrganiserInviteButton.addEventListener("click", async () => {
+      clearError();
+
+      const rawEmail = organiserInviteEmailInput.value.trim();
+      if (!rawEmail) {
+        setFieldMessage("organiser-invite-email", "invalid", "Email is required.");
+        organiserInviteEmailInput.focus();
+        return;
+      }
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(rawEmail)) {
+        setFieldMessage("organiser-invite-email", "invalid", "Enter a valid email address.");
+        organiserInviteEmailInput.focus();
+        return;
+      }
+
+      setFieldMessage("organiser-invite-email");
+      createOrganiserInviteButton.disabled = true;
+      setStatus("Sending organiser invite…", "default");
+      const idempotencyKey = idempotencyKeyForOrganiserInvite(leagueId, rawEmail);
+
+      try {
+        const payload = await requestJsonOrThrow(
+          `/v1/leagues/${encodeURIComponent(leagueId)}/organiser-invites`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "Idempotency-Key": idempotencyKey,
+            },
+            body: JSON.stringify({
+              email: rawEmail,
+            }),
+          },
+        );
+
+        renderInviteCodeLink(
+          organiserEmailInviteResult,
+          organiserEmailInviteCode,
+          organiserEmailInviteLink,
+          payload,
+        );
+        if (organiserInviteEmailStatus instanceof HTMLElement) {
+          if (payload.emailDelivery?.status === "sent") {
+            organiserInviteEmailStatus.textContent = `Sent to ${payload.emailDelivery.email}.`;
+          } else if (payload.emailDelivery?.status === "unknown") {
+            organiserInviteEmailStatus.textContent = "Delivery unconfirmed. Share the invite link manually.";
+          } else {
+            organiserInviteEmailStatus.textContent = "";
+          }
+        }
+
+        organiserInviteEmailInput.value = "";
+        clearIdempotencyKeyForOrganiserInvite(leagueId, rawEmail);
+        setStatus(
+          payload.emailDelivery?.status === "unknown"
+            ? "Organiser invite created; email delivery unconfirmed."
+            : "Organiser invite sent.",
+          "success",
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Could not create organiser invite.";
+        showError(message);
+        setStatus("Organiser invite failed.", "error");
+      } finally {
+        createOrganiserInviteButton.disabled = false;
+      }
+    });
+
     seasonsBody.addEventListener("click", async (event) => {
       const target = event.target;
       if (!(target instanceof HTMLElement)) {
@@ -1133,7 +1323,7 @@
     }
 
     await loadLeague();
-    await renderSeasons();
+    await Promise.all([renderSeasons(), ensureShareInvite()]);
     setStatus("League page ready.", "success");
   }
 
@@ -3898,6 +4088,135 @@
     setStatus("Join page ready.", "success");
   }
 
+  async function initInvitePage() {
+    const queryInviteCode = new URLSearchParams(window.location.search).get("code") ?? "";
+    const initialInviteCode =
+      resolveRouteEntityId("data-invite-code", "invites") || queryInviteCode;
+    const codeForm = document.getElementById("organiser-invite-code-form");
+    const codeInput = document.getElementById("organiser-invite-code-input");
+    const acceptance = document.getElementById("organiser-invite-acceptance");
+    const acceptCode = document.getElementById("organiser-invite-accept-code");
+    const acceptLeague = document.getElementById("organiser-invite-league");
+    const acceptButton = document.querySelector('[data-action="accept-organiser-invite"]');
+    const leagueLink = document.getElementById("organiser-invite-league-link");
+
+    function normalizeInviteCode(value) {
+      return value.trim().toUpperCase().replace(/\s+/g, "");
+    }
+
+    function isInviteCodeValid(value) {
+      return /^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{8}$/.test(value);
+    }
+
+    function showInviteAcceptance(inviteCode) {
+      if (codeForm instanceof HTMLFormElement) {
+        codeForm.hidden = true;
+      }
+      if (acceptance instanceof HTMLElement) {
+        acceptance.hidden = false;
+      }
+      if (acceptCode instanceof HTMLElement) {
+        acceptCode.textContent = inviteCode;
+      }
+    }
+
+    async function acceptInvite(inviteCode) {
+      if (!isInviteCodeValid(inviteCode)) {
+        setFieldMessage("organiser-invite-code-input", "invalid", "Invite code must be 8 characters.");
+        if (codeInput instanceof HTMLInputElement) {
+          codeInput.focus();
+        }
+        return;
+      }
+
+      showInviteAcceptance(inviteCode);
+      if (acceptButton instanceof HTMLButtonElement) {
+        acceptButton.disabled = true;
+      }
+      clearError();
+      setStatus("Accepting organiser invite…", "default");
+
+      try {
+        const payload = await requestJsonOrThrow(
+          `/v1/invites/${encodeURIComponent(inviteCode)}/accept`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({}),
+          },
+        );
+        const leagueId = payload.invite?.leagueId ?? payload.access?.leagueId ?? "";
+        if (acceptLeague instanceof HTMLElement) {
+          acceptLeague.textContent = leagueId || "Accepted";
+        }
+        if (leagueLink instanceof HTMLAnchorElement && leagueId) {
+          leagueLink.href = `/leagues/${encodeURIComponent(leagueId)}`;
+          leagueLink.hidden = false;
+        }
+        setStatus("Organiser invite accepted.", "success");
+      } catch (error) {
+        const message = error instanceof Error ? error.message : "Could not accept organiser invite.";
+        showError(message);
+        setStatus("Organiser invite failed.", "error");
+        if (acceptButton instanceof HTMLButtonElement) {
+          acceptButton.disabled = false;
+        }
+      }
+    }
+
+    if (codeForm instanceof HTMLFormElement) {
+      codeForm.addEventListener("submit", (event) => {
+        event.preventDefault();
+        if (!(codeInput instanceof HTMLInputElement)) {
+          return;
+        }
+
+        const inviteCode = normalizeInviteCode(codeInput.value);
+        if (!isInviteCodeValid(inviteCode)) {
+          setFieldMessage("organiser-invite-code-input", "invalid", "Invite code must be 8 characters.");
+          codeInput.focus();
+          return;
+        }
+
+        navigateTo(`/invites?code=${encodeURIComponent(inviteCode)}`);
+      });
+    }
+
+    if (codeInput instanceof HTMLInputElement) {
+      codeInput.addEventListener("input", () => {
+        setFieldMessage("organiser-invite-code-input");
+      });
+    }
+
+    if (acceptButton instanceof HTMLButtonElement) {
+      acceptButton.addEventListener("click", () => {
+        const inviteCode = normalizeInviteCode(
+          acceptCode instanceof HTMLElement ? acceptCode.textContent ?? "" : initialInviteCode ?? "",
+        );
+        void acceptInvite(inviteCode);
+      });
+    }
+
+    if (initialInviteCode) {
+      const normalizedInitialInviteCode = normalizeInviteCode(initialInviteCode);
+      if (isInviteCodeValid(normalizedInitialInviteCode)) {
+        showInviteAcceptance(normalizedInitialInviteCode);
+      } else {
+        setFieldMessage("organiser-invite-code-input", "invalid", "Invite code must be 8 characters.");
+        if (codeInput instanceof HTMLInputElement) {
+          codeInput.value = normalizedInitialInviteCode;
+          codeInput.focus();
+        }
+      }
+      setStatus("Invite page ready.", "success");
+      return;
+    }
+
+    setStatus("Invite page ready.", "success");
+  }
+
   async function initialize() {
     clearError();
 
@@ -3932,6 +4251,11 @@
 
       if (page === "league") {
         await initLeaguePage();
+        return;
+      }
+
+      if (page === "invite") {
+        await initInvitePage();
         return;
       }
 

--- a/docs/dynamodb-single-table.md
+++ b/docs/dynamodb-single-table.md
@@ -37,7 +37,19 @@ This document defines the baseline key structure and access patterns for the
 - Join code lookup:
   - `pk=JOIN_CODE#{joinCode}`
   - `sk=METADATA`
-  - maps an active QR/join code to its `gameId`
+  - maps a QR/join code to its `gameId`; finished games keep the lookup so late players can join and claim their profile
+- League organiser invite:
+  - `pk=LEAGUE_INVITE#{inviteCode}`
+  - `sk=METADATA`
+  - maps an organiser invite code to its league, `kind` (`share` or `email`), optional email restriction, creator, and acceptance state
+  - `kind=share` invites are reusable league share codes and are not consumed on accept
+  - `kind=email` invites are one-time, email-restricted, and are consumed on accept
+  - deleting a league invalidates organiser invite records for that league
+- League organiser share invite pointer:
+  - `pk=LEAGUE#{leagueId}`
+  - `sk=INVITE#ORGANISER_SHARE`
+  - points each league at its active reusable organiser share invite code
+  - deleted with the league so old share codes cannot target a replacement league id
 - Goal event timeline:
   - `pk=GAME#{gameId}`
   - `sk=GOAL#{third}#{gameMinuteSortable}#{elapsedSecondsSortable}#{eventId}`
@@ -95,6 +107,7 @@ without schema rewrites at this stage.
 - Create/list sessions for a season.
 - Create/read game metadata.
 - Resolve join code to game for player self-registration.
+- Create/accept reusable share organiser invites and one-time email organiser invites, then grant league admin ACL entries.
 - Finish game and store deterministic winner/draw result on game metadata.
 - Link/list games for a session (`SESSION#{sessionId}` query).
 - Create/read player profile.

--- a/docs/openapi/v1-core-write.yaml
+++ b/docs/openapi/v1-core-write.yaml
@@ -4,7 +4,7 @@ info:
   version: 0.1.0
   description: |
     Core routes for public join-code registration plus authenticated league/season/session/game creation,
-    M2 roster setup, third timer control, goal scoring reads and writes, and game finish.
+    organiser invites, M2 roster setup, third timer control, goal scoring reads and writes, and game finish.
 servers:
   - url: https://qa-api.3fc.football
     description: QA
@@ -110,6 +110,93 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "404":
           $ref: "#/components/responses/NotFound"
+  /v1/leagues/{leagueId}/organiser-invites:
+    post:
+      summary: Create or ensure a league organiser invite
+      description: >-
+        With no email, ensures and returns the league's reusable share invite.
+        With an email, creates a one-time, email-restricted invite and starts
+        direct magic-link delivery.
+      operationId: createLeagueOrganiserInvite
+      parameters:
+        - name: leagueId
+          in: path
+          required: true
+          schema:
+            type: string
+            minLength: 1
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateLeagueOrganiserInviteRequest"
+      responses:
+        "201":
+          description: Organiser invite created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateLeagueOrganiserInviteResponse"
+        "202":
+          description: Organiser invite created, but direct email delivery could not be confirmed
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateLeagueOrganiserInviteResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+  /v1/invites/{inviteCode}/accept:
+    post:
+      summary: Accept a league organiser invite
+      description: >-
+        Grants league admin access. Reusable share invites remain active after
+        acceptance; one-time email invites are consumed on first acceptance and
+        require the signed-in email to match the invite email.
+      operationId: acceptLeagueOrganiserInvite
+      parameters:
+        - name: inviteCode
+          in: path
+          required: true
+          schema:
+            type: string
+            minLength: 8
+            maxLength: 8
+            pattern: "^[ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjklmnpqrstuvwxyz23456789]{8}$"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AcceptLeagueOrganiserInviteRequest"
+      responses:
+        "200":
+          description: Organiser invite accepted and league admin access granted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AcceptLeagueOrganiserInviteResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
   /v1/leagues/{leagueId}/seasons:
     post:
       summary: Create season
@@ -801,7 +888,13 @@ components:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
     Conflict:
-      description: State transition rejected
+      description: State transition or idempotent write rejected
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ErrorResponse"
+    RateLimited:
+      description: Direct email invite delivery rate limit exceeded
       content:
         application/json:
           schema:
@@ -813,7 +906,7 @@ components:
           schema:
             $ref: "#/components/schemas/ErrorResponse"
     JoinGameConflict:
-      description: Idempotency key was reused with a different request payload, join registration is closed, or the join state changed while registering
+      description: Idempotency key was reused with a different request payload, or the join state changed while registering
       content:
         application/json:
           schema:
@@ -958,6 +1051,22 @@ components:
           enum:
             - admin
             - scorekeeper
+    CreateLeagueOrganiserInviteRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        email:
+          type:
+            - string
+            - "null"
+          format: email
+          description: >-
+            Optional email restriction. When omitted or null, the API ensures the
+            reusable league share invite. When present, the API creates a
+            one-time email invite and sends a magic-link invite to this email.
+    AcceptLeagueOrganiserInviteRequest:
+      type: object
+      additionalProperties: false
     AssignRosterPlayerRequest:
       type: object
       additionalProperties: false
@@ -1501,6 +1610,122 @@ components:
         updatedAt:
           type: string
           format: date-time
+    LeagueOrganiserInvite:
+      type: object
+      required:
+        - leagueId
+        - inviteCode
+        - kind
+        - role
+        - email
+        - createdByUserId
+        - acceptedByUserId
+        - acceptedAt
+        - createdAt
+        - updatedAt
+      properties:
+        leagueId:
+          type: string
+        inviteCode:
+          type: string
+          minLength: 8
+          maxLength: 8
+          pattern: "^[ABCDEFGHJKLMNPQRSTUVWXYZ23456789]{8}$"
+        kind:
+          type: string
+          enum:
+            - share
+            - email
+          description: >-
+            Share invites are reusable league-level codes and are not consumed
+            when accepted. Email invites are one-time and restricted to the
+            invited email.
+        role:
+          type: string
+          enum:
+            - admin
+        email:
+          type:
+            - string
+            - "null"
+          format: email
+        createdByUserId:
+          type: string
+        acceptedByUserId:
+          type:
+            - string
+            - "null"
+        acceptedAt:
+          type:
+            - string
+            - "null"
+          format: date-time
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    LeagueOrganiserInviteEmailDelivery:
+      type:
+        - object
+        - "null"
+      required:
+        - status
+        - email
+        - expiresAt
+        - messageId
+      properties:
+        status:
+          type: string
+          enum:
+            - sent
+            - unknown
+        email:
+          type: string
+          format: email
+        expiresAt:
+          type:
+            - string
+            - "null"
+          format: date-time
+        messageId:
+          type:
+            - string
+            - "null"
+        message:
+          type: string
+    CreateLeagueOrganiserInviteResponse:
+      type: object
+      required:
+        - invite
+        - inviteCode
+        - inviteLink
+        - emailDelivery
+      properties:
+        invite:
+          $ref: "#/components/schemas/LeagueOrganiserInvite"
+        inviteCode:
+          type: string
+        inviteLink:
+          type: string
+          format: uri
+        emailDelivery:
+          $ref: "#/components/schemas/LeagueOrganiserInviteEmailDelivery"
+    AcceptLeagueOrganiserInviteResponse:
+      type: object
+      required:
+        - invite
+        - access
+        - inviteLink
+      properties:
+        invite:
+          $ref: "#/components/schemas/LeagueOrganiserInvite"
+        access:
+          $ref: "#/components/schemas/LeagueAccessGrant"
+        inviteLink:
+          type: string
+          format: uri
     JoinGameResponse:
       type: object
       required:

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -64,6 +64,12 @@ gameId.
 - Session→Game index: PK=SESSION#{sessionId} SK=GAME#{gameStartTs}#{gameId}
 - Player: PK=PLAYER#{playerId} SK=PROFILE
 - Player claim: PK=USER#{cognitoSub} SK=PLAYER#{playerId}
+- League organiser invite: PK=LEAGUE_INVITE#{inviteCode} SK=METADATA
+  (leagueId, kind=`share|email`, role=admin, optional email restriction,
+  acceptedByUserId).
+- League organiser share invite pointer: PK=LEAGUE#{leagueId}
+  SK=INVITE#ORGANISER_SHARE (active reusable organiser share invite code).
+  Deleting a league invalidates organiser invite records and removes this pointer.
 - Admin grants: PK=ACL#{scopeType}#{scopeId} SK=ADMIN#{cognitoSub}
 
 ### 5.2 GoalEvent fields
@@ -78,29 +84,55 @@ gameId.
 - Emails visible only to self + admins.
 - Admin permissions scoped per League/Season/Game via ACL items.
 - Social sign-in: Cognito Hosted UI (Google + Facebook).
-- Magic-link: custom flow using SES + Dynamo TTL + Cognito CUSTOM_AUTH (click
-  link → signed in).
+- Magic-link: custom flow using SES + Dynamo TTL + Cognito CUSTOM_AUTH (open
+  link, then explicitly complete sign-in in the browser).
 
 ## 7. API design
 
 - JSON over HTTP, /v1, Zod validation.
-- Idempotency-Key for write endpoints (goals, finish).
+- Idempotency-Key for retry-sensitive write endpoints, including setup creation,
+  organiser invites, public joins, goals, and finish.
+- League organiser invites have two modes on the same endpoints:
+  no-email creation ensures the league's reusable share invite (`kind=share`),
+  while direct-email creation creates a one-time, email-restricted invite
+  (`kind=email`). Accepting share invites grants league admin access without
+  consuming the invite; accepting email invites marks that invite consumed.
+- Direct-email organiser invite creation reserves the idempotency key before
+  creating the invite or sending email, so concurrent retries replay the same
+  completed response instead of delivering duplicate valid invites. Pending
+  reservations are recoverable after a bounded stale window, and uncertain email
+  delivery returns the original invite link with `emailDelivery.status=unknown`
+  rather than reopening the mutation.
 
-``` Public: GET /v1/public/leagues GET
-/v1/public/leagues/{leagueIdOrSlug}/seasons GET /v1/public/games/{gameId} GET
-/v1/public/games/{gameId}/timeline
+```
+Public:
+GET   /v1/public/leagues
+GET   /v1/public/leagues/{leagueIdOrSlug}/seasons
+GET   /v1/public/games/{gameId}
+GET   /v1/public/games/{gameId}/timeline
 
-Auth: POST /v1/auth/magic/start POST /v1/auth/magic/complete
+Auth:
+POST  /v1/auth/magic/start
+POST  /v1/auth/magic/complete
 
-Core (authed): POST  /v1/leagues POST  /v1/leagues/{leagueId}/seasons POST
-/v1/seasons/{seasonId}/sessions POST  /v1/sessions/{sessionId}/games PATCH
-/v1/games/{gameId} POST  /v1/games/{gameId}/roster POST
-/v1/games/{gameId}/thirds/{third}/start POST
-/v1/games/{gameId}/thirds/{third}/finish POST  /v1/games/{gameId}/goals PATCH
-/v1/games/{gameId}/goals/{eventId} DELETE /v1/games/{gameId}/goals/{eventId}
-POST  /v1/games/{gameId}/finish POST  /v1/join/{joinCode} POST  /v1/players
+Core (authed):
+POST  /v1/leagues
+POST  /v1/leagues/{leagueId}/seasons
+POST  /v1/seasons/{seasonId}/sessions
+POST  /v1/sessions/{sessionId}/games
+PATCH /v1/games/{gameId}
+POST  /v1/games/{gameId}/roster
+POST  /v1/games/{gameId}/thirds/{third}/start
+POST  /v1/games/{gameId}/thirds/{third}/finish
+POST  /v1/games/{gameId}/goals
+PATCH /v1/games/{gameId}/goals/{eventId}
+DELETE /v1/games/{gameId}/goals/{eventId}
+POST  /v1/games/{gameId}/finish
+POST  /v1/join/{joinCode}
+POST  /v1/players
 POST  /v1/players/{playerId}/claim
-
+POST  /v1/leagues/{leagueId}/organiser-invites
+POST  /v1/invites/{inviteCode}/accept
 ```
 
 ## 8. Timer + thirds
@@ -162,7 +194,8 @@ POST  /v1/players/{playerId}/claim
 - The `production` environment application will be deployed to via github
   workflows and will reside in AWS. It will be automatically deployed to when a
   branch is merged to the `main` branch and will be fully automated.
-- Production app host/domain: `https://app.3fc.football`.
+- Production app host/domain: `https://3fc.football`.
+- Production public share-link host/domain: `https://3fc.football`.
 - QA app host/domain: `https://qa.3fc.football`.
 - Production API host/domain: `https://api.3fc.football`.
 - QA API host/domain: `https://qa-api.3fc.football`.

--- a/infra/application/cloudfront-site-router.js
+++ b/infra/application/cloudfront-site-router.js
@@ -39,6 +39,10 @@ function rewriteToShell(uri) {
     return "/join/index.html";
   }
 
+  if (uri === "/invites" || uri.indexOf("/invites/") === 0) {
+    return "/invites/index.html";
+  }
+
   return uri;
 }
 

--- a/infra/prod/main.tf
+++ b/infra/prod/main.tf
@@ -9,7 +9,7 @@ module "app" {
   manage_shared_ses_domain_identity = false
   github_repository                 = "ajfisher/3fc"
   github_environment_name           = "production"
-  site_domain                       = "app.3fc.football"
+  site_domain                       = "3fc.football"
   api_domain                        = "api.3fc.football"
   cognito_domain                    = "auth.app.3fc.football"
   google_oauth_client_id            = var.google_oauth_client_id

--- a/scripts/deploy/deploy-site.sh
+++ b/scripts/deploy/deploy-site.sh
@@ -37,7 +37,7 @@ case "$ENV" in
     API_BASE_URL="${API_BASE_URL:-https://qa-api.3fc.football}"
     ;;
   prod)
-    SITE_DOMAIN="${SITE_DOMAIN:-app.3fc.football}"
+    SITE_DOMAIN="${SITE_DOMAIN:-3fc.football}"
     API_BASE_URL="${API_BASE_URL:-https://api.3fc.football}"
     ;;
 esac
@@ -107,6 +107,7 @@ upload_html_alias "${STATIC_SITE_OUTPUT_DIR}/leagues/index.html" "leagues"
 upload_html_alias "${STATIC_SITE_OUTPUT_DIR}/seasons/index.html" "seasons"
 upload_html_alias "${STATIC_SITE_OUTPUT_DIR}/games/index.html" "games"
 upload_html_alias "${STATIC_SITE_OUTPUT_DIR}/join/index.html" "join"
+upload_html_alias "${STATIC_SITE_OUTPUT_DIR}/invites/index.html" "invites"
 upload_html_alias "${STATIC_SITE_OUTPUT_DIR}/ui/components/index.html" "ui/components"
 
 echo "[deploy] Creating CloudFront invalidation for ${SITE_DISTRIBUTION_ID}"

--- a/serverless.api-core.yml
+++ b/serverless.api-core.yml
@@ -22,6 +22,7 @@ provider:
   environment:
     DYNAMODB_TABLE: ${env:DYNAMODB_TABLE, '3fc-${sls:stage}-app'}
     APP_BASE_URL: ${self:custom.appBaseUrls.${sls:stage}, self:custom.appBaseUrls.default}
+    PUBLIC_APP_BASE_URL: ${self:custom.publicAppBaseUrls.${sls:stage}, self:custom.publicAppBaseUrls.default}
     SES_FROM_EMAIL: ${self:custom.sesFromEmail.${sls:stage}, self:custom.sesFromEmail.default}
     SESSION_COOKIE_NAME: threefc_session
     CORS_ALLOWED_ORIGINS: ${self:custom.corsAllowedOrigins.${sls:stage}, self:custom.corsAllowedOrigins.default}
@@ -39,16 +40,20 @@ provider:
 custom:
   appBaseUrls:
     qa: https://qa.3fc.football
-    prod: https://app.3fc.football
-    default: https://app.3fc.football
+    prod: https://3fc.football
+    default: https://3fc.football
+  publicAppBaseUrls:
+    qa: https://qa.3fc.football
+    prod: https://3fc.football
+    default: https://3fc.football
   sesFromEmail:
     qa: noreply@3fc.football
     prod: noreply@3fc.football
     default: noreply@3fc.football
   corsAllowedOrigins:
     qa: https://qa.3fc.football,https://app.3fc.football
-    prod: https://app.3fc.football,https://qa.3fc.football
-    default: https://app.3fc.football
+    prod: https://3fc.football,https://app.3fc.football,https://qa.3fc.football
+    default: https://3fc.football,https://app.3fc.football
   esbuild:
     bundle: true
     minify: false
@@ -124,6 +129,18 @@ functions:
       - httpApi:
           method: OPTIONS
           path: /v1/leagues/{leagueId}/access
+      - httpApi:
+          method: POST
+          path: /v1/leagues/{leagueId}/organiser-invites
+      - httpApi:
+          method: OPTIONS
+          path: /v1/leagues/{leagueId}/organiser-invites
+      - httpApi:
+          method: POST
+          path: /v1/invites/{inviteCode}/accept
+      - httpApi:
+          method: OPTIONS
+          path: /v1/invites/{inviteCode}/accept
       - httpApi:
           method: GET
           path: /v1/leagues/{leagueId}/seasons


### PR DESCRIPTION
<!-- review-packet-version:1 -->

## Behavioural claim

A signed-in league admin can create league-scoped organiser invitations through two clear paths: a reusable share code/link that any signed-in holder can accept, and a one-time direct email invite that is restricted to the invited email. Magic-link callback pages no longer consume one-time tokens on page load; the user must explicitly complete sign-in before returning to the invite confirmation page. Public join codes also remain usable after a game is finished so late players can self-register and claim their profile. Deleting a league invalidates organiser invites for that league so old codes cannot grant access to a replacement league id.

## Specification and acceptance evidence

| Acceptance criterion | Evidence | Result |
| --- | --- | --- |
| Finished game join codes allow public player registration and later player claim without reopening scoring mutations. | `npm test` covering finished-game join registration, claim, and public join replay. Earlier QA browser evidence on this PR joined finished game `game-20260802-1000-3ee7` with code `4RR6S57P` as `Late QA 1209` and reported `Player claimed.` | PASS |
| League pages load a real reusable organiser share code/link, never blank fields or a fake `/invites` link. | `npm test`; QA browser on `setup-flow.js?v=174c00f` loaded league `codex-invite-qa-20260802-1204`, showed share code `TWB895ZJ`, link `https://qa.3fc.football/invites?code=TWB895ZJ`, `Share invite ready.`, blank email status, hidden email result, and no legacy `#organiser-invite-link` fake `/invites` anchor. Final QA deploy run `31239292896` passed for commit `9d8619638aeac9e22a1b08daf93d72ba082f0078`, and a terminal fetch confirmed the deployed league shell serves `setup-flow.js?v=9d86196`. | PASS |
| Reusable share invites remain explicit-confirmation and reusable after acceptance. | `npm test` covering same-code share ensure and multi-user share acceptance. QA opened `/invites?code=TWB895ZJ` on `setup-flow.js?v=174c00f`; before clicking it showed `Invite page ready.` with Accept visible and no league link. After clicking Accept it showed `Organiser invite accepted.` and an `Open league` link for `codex-invite-qa-20260802-1204`. | PASS |
| Email invite UI is separate and neutral until a send attempt. | `npm test`; QA browser showed `organiser-email-invite-result.hidden=true` and blank email status on page load. After sending to `ajfisher@loypal.io`, it showed `Organiser invite sent.`, email invite code `77T5D6F7`, link `https://qa.3fc.football/invites?code=77T5D6F7`, and `Sent to ajfisher@loypal.io.` | PASS |
| Direct email invites remain one-time and email-restricted. | `npm test` covering email mismatch and one-time acceptance. QA opened `/invites?code=77T5D6F7` in the currently signed-in browser; it waited at `Invite page ready.` with Accept visible, then rejected acceptance with `This organiser invite was issued for a different email address.`, proving the invite is email-restricted. | PASS |
| Magic-link callback token completion is explicit rather than automatic. | `npm test` covering callback no-consume-before-click and safe return-target handling. QA browser opened `/auth/callback?token=synthetic-token-before-click&returnTo=/invites?code=77T5D6F7` on `auth-flow.js?v=174c00f`; before click it showed `Magic link ready. Complete sign-in to continue.`, an empty error, and a visible `Complete sign-in` button. With a synthetic invalid token, clicking the button produced `Sign-in callback failed.` and `Invalid or expired magic link.` | PASS |
| Direct email invite magic links preserve invite return targets. | `npm test` covering invite-specific magic-link copy and return target `/invites?code={inviteCode}`. Live QA email send returned `sent` for `ajfisher@loypal.io`; mailbox click could not be completed from this environment, but the deployed callback and invite confirmation pages were tested separately. | PASS |
| Invite creation idempotency remains retry-safe around email delivery uncertainty. | `npm test` covering reservation before email, transient cleanup, stale share recovery, stale direct-email recovery before delivery starts, stale direct-email recovery after delivery starts with a manual link and no resend, uncertain-delivery replay, and UI retry-key reuse. | PASS |
| Share invite page-load idempotency does not create a new completed idempotency row on every reload. | `npm test -w @3fc/app` covers the league-page share request using deterministic key `organiser-share-invite-autumn-league` and not writing the localStorage-backed random organiser-invite key. | PASS |
| Deleting a league invalidates organiser invite records and the share pointer. | `npm test -w @3fc/api` and `npm test` include `repository revokes organiser invites when deleting a league`, which creates share and email organiser invites, deletes the league, recreates the same league id, and verifies old invite codes cannot be accepted or grant ACL access to the replacement league. | PASS |
| Invite API routes, deployed shells, generated origins, OpenAPI, and storage docs match the new contract. | `git diff --check`; `make build`; `npm test`; `npm test -w @3fc/api`; `npm test -w @3fc/app`; docs updated in `docs/spec.md`, `docs/dynamodb-single-table.md`, and `docs/openapi/v1-core-write.yaml`. `make check` is unavailable in this repo (`No rule to make target 'check'`). | PASS |

## Scope boundaries

Included:

- Finished-game public join registration for late player profile claiming.
- League-scoped organiser invite records with `kind=share` or `kind=email`.
- A league share-invite pointer at `LEAGUE#{leagueId}` / `INVITE#ORGANISER_SHARE` so no-email create returns the same reusable invite.
- Admin-only invite creation API, signed-in invite acceptance API, and league admin ACL grant on acceptance.
- League deletion invalidates organiser invite records and removes the share pointer before removing league metadata.
- App UI split into Share code/link and Email invite sections.
- Explicit magic-link callback completion before token use.
- Safe auth diagnostic logs with request id, status, reason, hashed email/token identifier, and optional message correlation id only.
- Idempotency reservation/recovery for direct-email organiser invite creation, including stale started-delivery records that can be recovered to a manual invite link without re-sending.
- Stable share-invite idempotency key use on league page load.
- Static export, deploy script, OpenAPI, and storage docs for invite routes.

Excluded:

- Game-scoped organiser invites.
- Regenerate/disable controls for share invites.
- New league roles beyond existing `admin` grants.
- Data migrations or destructive backfills.
- Email template redesign beyond invite-specific copy.
- Reading the live recipient mailbox from this environment.
- CloudWatch QA log inspection until local AWS credentials are refreshed; `aws sts get-caller-identity` returns `InvalidClientTokenId` in this shell.

## Change classification

- Declared risk: `high`
- [ ] `documentation-only` - Documentation only
- [ ] `tests-only` - Tests only
- [x] `application-behaviour` - Application or API behaviour
- [ ] `backlog-maintenance` - Canonical backlog maintenance
- [ ] `dependency-tooling` - Dependency or tooling
- [x] `public-contract` - Public API or repository contract
- [ ] `data-migration` - Database schema or data migration
- [x] `permission-trust-boundary` - Permission or trust boundary
- [x] `durable-state-ownership` - Durable state or ownership
- [ ] `destructive-behaviour` - Destructive or difficult-to-reverse behaviour
- [ ] `new-production-dependency` - New production dependency
- [x] `authentication-authorisation` - Authentication or authorisation
- [x] `privacy-regulated-data` - Privacy or regulated data
- [x] `infrastructure-production-configuration` - Infrastructure or deployment control
- [ ] `review-policy` - Review policy, packet, or workflow

## Architecture and invariants

- [ ] `architecture:none`
- [x] `architecture:documented`
- [ ] `architecture:judgement-required`

### Affected invariants

| Invariant | How this PR affects it | Why it remains valid | Evidence |
| --- | --- | --- | --- |
| INV-001 | Invite records include optional invitee email and direct email responses include email delivery status. | Email data remains limited to authenticated organiser/invitee API contexts; public pages still do not expose private email. | `npm test`; app route tests; QA email section only displayed the sent recipient after the authenticated send action. |
| INV-002 | Adds signed-in invite acceptance that can grant league admin access, and keeps invite creation admin-only. League deletion now invalidates existing organiser invites. | Invite creation uses the existing league admin ACL gate; acceptance requires a valid session and enforces email restriction/one-time state before granting ACL. Deleted league invite codes are removed, so they cannot grant admin access to a recreated league id. | `npm test`; QA share accept succeeded; QA email accept by a different signed-in email was rejected; `repository revokes organiser invites when deleting a league`. |
| INV-003 | Adds reusable share invite recovery and hardens direct-email invite idempotency. | Share invites are not consumed; email invites are consumed once. Direct-email mutation reserves before email delivery, can recover existing invite links from stale started-delivery reservations, and does not re-send when delivery state is uncertain. | `npm test`; repository/lambda idempotency tests; QA share code `TWB895ZJ` remained active after acceptance. |
| INV-004 | Adds `LeagueInviteRecord.kind` and a league-scoped share invite pointer item. League deletion now removes invite records and the pointer for the league. | Invite state stays in dedicated invite/pointer items; acceptance writes existing league ACL items transactionally. Legacy missing-kind invite records normalise to `email` so old PR data does not become reusable. | `npm test`; `docs/spec.md`; `docs/dynamodb-single-table.md`; repository tests. |
| INV-009 | Magic-link callback now requires explicit completion and safe internal return targets for invite links. | Return targets must resolve to the current origin and cannot include backslashes; tokens are only posted from the callback page after the button click. | `npm test`; QA callback synthetic-token test on `auth-flow.js?v=174c00f`. |

### Architecture or decision record

Documented in `docs/spec.md`, `docs/dynamodb-single-table.md`, and `docs/openapi/v1-core-write.yaml`. No new ADR is proposed because this keeps organiser invitation inside the existing league ACL, magic-link, idempotency, and DynamoDB single-table architecture.

## Failure and rollback

### Failure behaviour

Invalid invite payloads return 400, missing invites return 404, email mismatches return 403, already-accepted one-time email invites return 409, and invite email sends use the existing magic-link rate limiter and delivery path. Share invite acceptance grants access without marking the invite consumed. Stale direct-email invite retries return the existing invite link with unknown email delivery state only when the deterministic invite matches the original request. League deletion removes organiser invite records and the share pointer before deleting league metadata. Magic-link callback pages show a failure only after explicit completion fails.

### Rollback approach

Revert this PR and redeploy API/site. Existing league, game, player, goal, ACL, and idempotency entities remain compatible; newly-created reusable share pointer and invite records become unused orphan records and can be cleaned operationally if needed.

### Rollback evidence

No data migration is introduced. `git diff --check`, `make build`, `npm test`, `npm test -w @3fc/api`, and `npm test -w @3fc/app` pass on commit `9d8619638aeac9e22a1b08daf93d72ba082f0078`. GitHub PR checks, merge-gate, review-gate, and Deploy QA passed for the same commit; Deploy QA run `31239292896` completed its site, API, and smoke-test steps successfully. QA browser verified deployed invite assets before the final repository-only delete fix, and a final terminal fetch verified the current deployed league shell uses `setup-flow.js?v=9d86196`.

## Automated and agent review disposition

### Unresolved blocking findings

None.

### Rejected findings and evidence

None.

### Resolved automated review findings

- Replaced blank/no-email one-time invite creation with a reusable league share invite and pointer; covered by `repository ensures reusable league organiser share invites` and `core lambda ensures reusable league organiser share invites`.
- Kept share invites unconsumed on accept while preserving email invite one-time consumption; covered by repository and lambda share/email invite acceptance tests.
- Split the league invite panel into Share code/link and Email invite sections; covered by `league page loads reusable organiser share invites and sends direct email invites`.
- Removed fake `/invites` rendering before a real invite URL exists; covered by app e2e and QA browser evidence.
- Required explicit magic-link callback completion before token POST; covered by app e2e and QA synthetic-token callback test.
- Added safe magic-link diagnostics with hashes/correlation ids only; covered by API build/tests and manual log-shape inspection in code review.
- Updated OpenAPI and storage/spec docs for `kind=share|email` invite semantics.
- Preserved direct-email idempotency reservation/recovery behaviour from prior review findings; covered by the existing idempotency test matrix.
- Addressed review thread `PRRT_kwDORVMqbs6XcExu` by recovering stale started direct-email invite reservations to the existing deterministic invite link with `emailDelivery.status=unknown`, completing the idempotency record, and avoiding rate-limit or magic-link resend calls.
- Addressed review thread `PRRT_kwDORVMqbs6XcExw` by switching league-page share-invite loading to stable deterministic key `organiser-share-invite-{leagueId}` and not clearing/recreating a localStorage-backed random key on success.
- Addressed review thread `PRRT_kwDORVMqbs6XcJYG` by deleting organiser invite records and the league share pointer during league deletion, with a regression that recreates the same league id and proves old codes cannot grant ACL access.

## Human judgement

- [x] `human-judgement:none`
- [ ] `human-judgement:required`

### Decision requiring judgement

None.

### Options considered

None.

### Reason selected

None.

### Reversal cost

None.

## Review focus

Focus review on reusable share invite ownership, legacy invite kind normalisation, email-restricted one-time invite acceptance, idempotency around direct email delivery, league deletion invite invalidation, the explicit magic-link callback action, safe diagnostic logging, and the league invite panel’s initial loading/empty states.
