### PR TITLE
fix: scope season game listings by league

### DIFF
--- a/api/src/auth/session.ts
+++ b/api/src/auth/session.ts
@@ -43,6 +43,18 @@ export function isAuthenticatedApiRoute(method: string, route: string): boolean 
     return true;
   }
 
+  if (method === "GET" && /^\/v1\/leagues\/[^/]+\/seasons\/[^/]+$/.test(route)) {
+    return true;
+  }
+
+  if (method === "DELETE" && /^\/v1\/leagues\/[^/]+\/seasons\/[^/]+$/.test(route)) {
+    return true;
+  }
+
+  if (method === "GET" && /^\/v1\/leagues\/[^/]+\/seasons\/[^/]+\/games$/.test(route)) {
+    return true;
+  }
+
   if (method === "DELETE" && /^\/v1\/leagues\/[^/]+$/.test(route)) {
     return true;
   }
@@ -160,6 +172,14 @@ export function isAuthenticatedApiRoute(method: string, route: string): boolean 
   }
 
   if (method === "POST" && /^\/v1\/leagues\/[^/]+\/seasons$/.test(route)) {
+    return true;
+  }
+
+  if (method === "POST" && /^\/v1\/leagues\/[^/]+\/seasons\/[^/]+\/sessions$/.test(route)) {
+    return true;
+  }
+
+  if (method === "POST" && /^\/v1\/leagues\/[^/]+\/seasons\/[^/]+\/sessions\/[^/]+\/games$/.test(route)) {
     return true;
   }
 

--- a/api/src/data/keys.ts
+++ b/api/src/data/keys.ts
@@ -30,6 +30,14 @@ export function sessionSk(sessionId: string): string {
   return `SESSION#${sessionId}`;
 }
 
+export function scopedSeasonSessionSk(seasonId: string, sessionId: string): string {
+  return `SEASON#${seasonId}#SESSION#${sessionId}`;
+}
+
+export function scopedSeasonTeamSk(seasonId: string, teamId: string): string {
+  return `SEASON#${seasonId}#TEAM#${teamId}`;
+}
+
 export function sessionPk(sessionId: string): string {
   return `${ENTITY_PK_PREFIX.session}${sessionId}`;
 }

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -7,6 +7,8 @@ import {
   type QueryCommandOutput,
   ScanCommand,
   type ScanCommandOutput,
+  TransactGetItemsCommand,
+  type TransactGetItemsCommandOutput,
   TransactWriteItemsCommand,
   type AttributeValue,
   type TransactWriteItem,
@@ -48,6 +50,8 @@ import {
   playerPk,
   profileSk,
   rosterSk,
+  scopedSeasonSessionSk,
+  scopedSeasonTeamSk,
   seasonPk,
   seasonSk,
   sessionPk,
@@ -375,6 +379,14 @@ function normalizeThirdTimerSegments(value: unknown): ThirdTimerSegment[] {
 
 function isValidTimestamp(value: unknown): value is string {
   return typeof value === "string" && !Number.isNaN(Date.parse(value));
+}
+
+function shouldUseTeamCandidate(existing: TeamRecord | undefined, candidate: TeamRecord): boolean {
+  if (!existing) {
+    return true;
+  }
+
+  return candidate.updatedAt >= existing.updatedAt;
 }
 
 const JOIN_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
@@ -1065,9 +1077,32 @@ export class ThreeFcRepository {
     );
   }
 
-  async listSeasonsForLeague(leagueId: string): Promise<SeasonRecord[]> {
+  async getSeasonForLeague(
+    leagueId: string,
+    seasonId: string,
+    options: { consistentRead?: boolean } = {},
+  ): Promise<SeasonRecord | null> {
     requireNonEmpty("leagueId", leagueId);
-    const items = await this.queryByPrefix(leaguePk(leagueId), "SEASON#");
+    requireNonEmpty("seasonId", seasonId);
+    const item = await this.getEntity(leaguePk(leagueId), seasonSk(seasonId), options);
+
+    if (!item || item.entityType !== ENTITY_TYPE.season) {
+      return null;
+    }
+
+    return withTimestamps(
+      item.data as Omit<SeasonRecord, "createdAt" | "updatedAt">,
+      item.createdAt,
+      item.updatedAt,
+    );
+  }
+
+  async listSeasonsForLeague(
+    leagueId: string,
+    options: { consistentRead?: boolean } = {},
+  ): Promise<SeasonRecord[]> {
+    requireNonEmpty("leagueId", leagueId);
+    const items = await this.queryByPrefix(leaguePk(leagueId), "SEASON#", options);
 
     return items
       .filter((item) => item.entityType === ENTITY_TYPE.season)
@@ -1081,11 +1116,18 @@ export class ThreeFcRepository {
   }
 
   async createTeam(input: CreateTeamInput): Promise<TeamRecord> {
+    if (input.leagueId !== undefined) {
+      requireNonEmpty("leagueId", input.leagueId);
+    }
     requireNonEmpty("seasonId", input.seasonId);
     requireNonEmpty("name", input.name);
 
     const now = this.clock.now();
-    const existing = await this.getEntity(seasonPk(input.seasonId), teamSk(input.teamId), {
+    const teamPartitionKey = input.leagueId ? leaguePk(input.leagueId) : seasonPk(input.seasonId);
+    const teamSortKey = input.leagueId
+      ? scopedSeasonTeamSk(input.seasonId, input.teamId)
+      : teamSk(input.teamId);
+    const existing = await this.getEntity(teamPartitionKey, teamSortKey, {
       consistentRead: input.createOnly,
     });
     const existingTeam = existing?.entityType === ENTITY_TYPE.team ? existing : null;
@@ -1095,13 +1137,91 @@ export class ThreeFcRepository {
     if (input.createOnly && existingTeam && existingPayload) {
       return withTimestamps(existingPayload, existingTeam.createdAt, existingTeam.updatedAt);
     }
+    const legacySeasonItem = input.leagueId
+      ? null
+      : await this.getEntity(seasonPk(input.seasonId), metadataSk(), { consistentRead: true });
+    const legacySeason =
+      legacySeasonItem?.entityType === ENTITY_TYPE.season
+        ? (legacySeasonItem.data as Partial<SeasonRecord>)
+        : null;
 
     const payload = {
+      ...(input.leagueId
+        ? { leagueId: input.leagueId }
+        : legacySeason?.leagueId
+          ? { leagueId: legacySeason.leagueId }
+          : {}),
       seasonId: input.seasonId,
       teamId: input.teamId,
       name: input.name,
       color: input.color ?? null,
     };
+
+    if (input.leagueId) {
+      const seasonItem = await this.getEntity(leaguePk(input.leagueId), seasonSk(input.seasonId), {
+        consistentRead: true,
+      });
+      if (!seasonItem || seasonItem.entityType !== ENTITY_TYPE.season) {
+        throw new GameMutationStateError(
+          "game_state_changed",
+          `Season ${input.seasonId} changed before the team could be created. Reload and try again.`,
+        );
+      }
+
+      const transactionItems: TransactWriteItem[] = [
+        {
+          Put: {
+            TableName: this.tableName,
+            Item: buildItemWithTimestamps(
+              teamPartitionKey,
+              teamSortKey,
+              ENTITY_TYPE.team,
+              payload,
+              now,
+              now,
+            ),
+            ...(input.createOnly
+              ? {
+                  ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
+                }
+              : {}),
+          },
+        },
+        this.buildConditionalPutFromStoredEntity(seasonItem, now),
+      ];
+
+      try {
+        await this.client.send(
+          new TransactWriteItemsCommand({
+            TransactItems: transactionItems,
+          }),
+        );
+      } catch (error) {
+        if (isConditionalWriteFailure(error)) {
+          if (input.createOnly) {
+            const concurrent = await this.getEntity(teamPartitionKey, teamSortKey, {
+              consistentRead: true,
+            });
+            if (concurrent?.entityType === ENTITY_TYPE.team) {
+              return withTimestamps(
+                concurrent.data as Omit<TeamRecord, "createdAt" | "updatedAt">,
+                concurrent.createdAt,
+                concurrent.updatedAt,
+              );
+            }
+          }
+
+          throw new GameMutationStateError(
+            "game_state_changed",
+            `Season ${input.seasonId} changed before the team could be created. Reload and try again.`,
+          );
+        }
+
+        throw error;
+      }
+
+      return withTimestamps(payload, now, now);
+    }
 
     if (input.createOnly) {
       try {
@@ -1109,8 +1229,8 @@ export class ThreeFcRepository {
           new PutItemCommand({
             TableName: this.tableName,
             Item: buildItemWithTimestamps(
-              seasonPk(input.seasonId),
-              teamSk(input.teamId),
+              teamPartitionKey,
+              teamSortKey,
               ENTITY_TYPE.team,
               payload,
               now,
@@ -1121,7 +1241,7 @@ export class ThreeFcRepository {
         );
       } catch (error) {
         if (isConditionalWriteFailure(error)) {
-          const concurrent = await this.getEntity(seasonPk(input.seasonId), teamSk(input.teamId), {
+          const concurrent = await this.getEntity(teamPartitionKey, teamSortKey, {
             consistentRead: true,
           });
           if (concurrent?.entityType === ENTITY_TYPE.team) {
@@ -1144,18 +1264,28 @@ export class ThreeFcRepository {
       return withTimestamps(payload, now, now);
     }
 
-    await this.putEntity(seasonPk(input.seasonId), teamSk(input.teamId), ENTITY_TYPE.team, payload, now);
+    await this.putEntity(teamPartitionKey, teamSortKey, ENTITY_TYPE.team, payload, now);
     return withTimestamps(payload, now, now);
   }
 
   async listTeamsForSeason(
     seasonId: string,
-    options: { consistentRead?: boolean } = {},
+    options: { consistentRead?: boolean; leagueId?: string } = {},
   ): Promise<TeamRecord[]> {
     requireNonEmpty("seasonId", seasonId);
-    const items = await this.queryByPrefix(seasonPk(seasonId), "TEAM#", options);
+    if (options.leagueId !== undefined) {
+      requireNonEmpty("leagueId", options.leagueId);
+    }
 
-    return items
+    const scopedItems = options.leagueId
+      ? await this.queryByPrefix(leaguePk(options.leagueId), `SEASON#${seasonId}#TEAM#`, options)
+      : [];
+    const legacyItems = options.leagueId
+      ? await this.readOwnedLegacySeasonTeamTemplateItems(seasonId, options.leagueId)
+      : await this.queryByPrefix(seasonPk(seasonId), "TEAM#", options);
+
+    const teamsById = new Map<TeamId, TeamRecord>();
+    for (const team of legacyItems
       .filter((item) => item.entityType === ENTITY_TYPE.team)
       .map((item) =>
         withTimestamps(
@@ -1163,7 +1293,26 @@ export class ThreeFcRepository {
           item.createdAt,
           item.updatedAt,
         ),
-      );
+      )) {
+      if (shouldUseTeamCandidate(teamsById.get(team.teamId), team)) {
+        teamsById.set(team.teamId, team);
+      }
+    }
+    for (const team of scopedItems
+      .filter((item) => item.entityType === ENTITY_TYPE.team)
+      .map((item) =>
+        withTimestamps(
+          item.data as Omit<TeamRecord, "createdAt" | "updatedAt">,
+          item.createdAt,
+          item.updatedAt,
+        ),
+      )) {
+      if (shouldUseTeamCandidate(teamsById.get(team.teamId), team)) {
+        teamsById.set(team.teamId, team);
+      }
+    }
+
+    return [...teamsById.values()];
   }
 
   async createGameTeamOverride(input: CreateGameTeamInput): Promise<GameTeamRecord> {
@@ -1367,16 +1516,150 @@ export class ThreeFcRepository {
   }
 
   async createSession(input: CreateSessionInput): Promise<SessionRecord> {
+    if (input.leagueId !== undefined) {
+      requireNonEmpty("leagueId", input.leagueId);
+    }
     requireNonEmpty("seasonId", input.seasonId);
     requireNonEmpty("sessionId", input.sessionId);
     requireNonEmpty("sessionDate", input.sessionDate);
 
     const now = this.clock.now();
+    const legacySeasonItem = input.leagueId
+      ? null
+      : await this.getEntity(seasonPk(input.seasonId), metadataSk(), { consistentRead: true });
+    const legacySeason =
+      legacySeasonItem?.entityType === ENTITY_TYPE.season
+        ? (legacySeasonItem.data as Partial<SeasonRecord>)
+        : null;
     const payload = {
+      ...(input.leagueId
+        ? { leagueId: input.leagueId }
+        : legacySeason?.leagueId
+          ? { leagueId: legacySeason.leagueId }
+          : {}),
       seasonId: input.seasonId,
       sessionId: input.sessionId,
       sessionDate: input.sessionDate,
     };
+
+    if (input.leagueId) {
+      const [seasonItem, globalSeasonItem, legacySeasonSessionItem, legacySessionMetadataItem] =
+        await Promise.all([
+          this.getEntity(leaguePk(input.leagueId), seasonSk(input.seasonId), {
+            consistentRead: true,
+          }),
+          this.getEntity(seasonPk(input.seasonId), metadataSk(), {
+            consistentRead: true,
+          }),
+          this.getEntity(seasonPk(input.seasonId), sessionSk(input.sessionId), {
+            consistentRead: true,
+          }),
+          this.getEntity(sessionPk(input.sessionId), metadataSk(), {
+            consistentRead: true,
+          }),
+        ]);
+      if (!seasonItem || seasonItem.entityType !== ENTITY_TYPE.season) {
+        throw new GameMutationStateError(
+          "game_state_changed",
+          `Season ${input.seasonId} changed before the session could be created. Reload and try again.`,
+        );
+      }
+      const expectedLegacySession = {
+        leagueId: input.leagueId,
+        seasonId: input.seasonId,
+        sessionId: input.sessionId,
+      };
+      const canWriteLegacyCompatibility = this.isMatchingSeasonEntity(globalSeasonItem, {
+        leagueId: input.leagueId,
+        seasonId: input.seasonId,
+      });
+      const hasForeignLegacySession = [legacySeasonSessionItem, legacySessionMetadataItem].some(
+        (item) =>
+          item &&
+          !this.isMatchingSessionEntity(item, expectedLegacySession) &&
+          !(
+            canWriteLegacyCompatibility &&
+            this.isMatchingLegacySessionEntityWithoutLeague(item, expectedLegacySession)
+          ),
+      );
+      const legacyCompatibilityWrites = hasForeignLegacySession || !canWriteLegacyCompatibility
+        ? []
+        : [
+            this.buildConditionalCheckFromStoredEntity(globalSeasonItem),
+            this.buildLegacySessionCompatibilityPut({
+              pk: seasonPk(input.seasonId),
+              sk: sessionSk(input.sessionId),
+              payload,
+              existing: legacySeasonSessionItem,
+              expected: expectedLegacySession,
+              allowLegacyWithoutLeague: true,
+              now,
+            }),
+            this.buildLegacySessionCompatibilityPut({
+              pk: sessionPk(input.sessionId),
+              sk: metadataSk(),
+              payload,
+              existing: legacySessionMetadataItem,
+              expected: expectedLegacySession,
+              allowLegacyWithoutLeague: true,
+              now,
+            }),
+          ].filter((item): item is TransactWriteItem => item !== null);
+
+      try {
+        await this.client.send(
+          new TransactWriteItemsCommand({
+            TransactItems: [
+              {
+                Put: {
+                  TableName: this.tableName,
+                  Item: buildItem(
+                    leaguePk(input.leagueId),
+                    scopedSeasonSessionSk(input.seasonId, input.sessionId),
+                    ENTITY_TYPE.session,
+                    payload,
+                    now,
+                  ),
+                },
+              },
+              ...legacyCompatibilityWrites,
+              {
+                Put: {
+                  TableName: this.tableName,
+                  Item: buildItemWithTimestamps(
+                    leaguePk(input.leagueId),
+                    seasonSk(input.seasonId),
+                    ENTITY_TYPE.season,
+                    seasonItem.data,
+                    seasonItem.createdAt,
+                    now,
+                  ),
+                  ConditionExpression: "#updatedAt = :expectedSeasonUpdatedAt AND #data = :expectedSeasonData",
+                  ExpressionAttributeNames: {
+                    "#updatedAt": "updatedAt",
+                    "#data": "data",
+                  },
+                  ExpressionAttributeValues: {
+                    ":expectedSeasonUpdatedAt": { S: seasonItem.updatedAt },
+                    ":expectedSeasonData": { S: seasonItem.rawData },
+                  },
+                },
+              },
+            ],
+          }),
+        );
+      } catch (error) {
+        if (isConditionalWriteFailure(error)) {
+          throw new GameMutationStateError(
+            "game_state_changed",
+            `Season ${input.seasonId} changed before the session could be created. Reload and try again.`,
+          );
+        }
+
+        throw error;
+      }
+      return withTimestamps(payload, now, now);
+    }
 
     await this.putEntity(
       seasonPk(input.seasonId),
@@ -1404,9 +1687,54 @@ export class ThreeFcRepository {
     );
   }
 
-  async listSessionsForSeason(seasonId: string): Promise<SessionRecord[]> {
+  async getSessionForSeason(
+    seasonId: string,
+    sessionId: string,
+    options: { leagueId?: string } = {},
+  ): Promise<SessionRecord | null> {
     requireNonEmpty("seasonId", seasonId);
-    const items = await this.queryByPrefix(seasonPk(seasonId), "SESSION#");
+    requireNonEmpty("sessionId", sessionId);
+    if (options.leagueId !== undefined) {
+      requireNonEmpty("leagueId", options.leagueId);
+      const item = await this.getEntity(
+        leaguePk(options.leagueId),
+        scopedSeasonSessionSk(seasonId, sessionId),
+        { consistentRead: true },
+      );
+
+      if (!item || item.entityType !== ENTITY_TYPE.session) {
+        return null;
+      }
+
+      return withTimestamps(
+        item.data as Omit<SessionRecord, "createdAt" | "updatedAt">,
+        item.createdAt,
+        item.updatedAt,
+      );
+    }
+
+    const session = await this.getSession(sessionId);
+    return session?.seasonId === seasonId ? session : null;
+  }
+
+  async listSessionsForSeason(
+    seasonId: string,
+    options: { leagueId?: string; consistentRead?: boolean } = {},
+  ): Promise<SessionRecord[]> {
+    requireNonEmpty("seasonId", seasonId);
+    if (options.leagueId !== undefined) {
+      requireNonEmpty("leagueId", options.leagueId);
+    }
+
+    const items = options.leagueId
+      ? await this.queryByPrefix(
+          leaguePk(options.leagueId),
+          `SEASON#${seasonId}#SESSION#`,
+          { consistentRead: options.consistentRead },
+        )
+      : await this.queryByPrefix(seasonPk(seasonId), "SESSION#", {
+          consistentRead: options.consistentRead,
+        });
 
     return items
       .filter((item) => item.entityType === ENTITY_TYPE.session)
@@ -1437,10 +1765,20 @@ export class ThreeFcRepository {
     const customJoinCode = input.joinCode?.trim()
       ? normalizeCustomJoinCode(input.joinCode)
       : null;
+    const linkSession = input.linkSession === true;
 
     for (let attempt = 0; attempt < (customJoinCode ? 1 : JOIN_CODE_GENERATION_ATTEMPTS); attempt += 1) {
       const joinCode = customJoinCode ?? generateJoinCode();
       const createRequestHash = input.createRequestHash?.trim() || null;
+      const sessionTargets = linkSession
+        ? await this.readSessionMutationTargets(input)
+        : [];
+      if (linkSession && sessionTargets.length === 0) {
+        throw new GameMutationStateError(
+          "game_state_changed",
+          `Session ${input.sessionId} changed before the game could be created. Reload and try again.`,
+        );
+      }
       const payload = {
         gameId: input.gameId,
         joinCode,
@@ -1455,35 +1793,63 @@ export class ThreeFcRepository {
         finishedAt: null,
         result: null,
       };
+      const sessionGamePayload = linkSession
+        ? {
+            sessionId: input.sessionId,
+            gameId: input.gameId,
+            gameStartTs: input.gameStartTs,
+            leagueId: input.leagueId,
+            seasonId: input.seasonId,
+          }
+        : null;
+      const transactionItems: TransactWriteItem[] = [
+        {
+          Put: {
+            TableName: this.tableName,
+            Item: buildItem(gamePk(input.gameId), metadataSk(), ENTITY_TYPE.game, payload, now),
+            ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
+          },
+        },
+        {
+          Put: {
+            TableName: this.tableName,
+            Item: buildItem(
+              joinCodePk(joinCode),
+              metadataSk(),
+              ENTITY_TYPE.gameJoinCode,
+              {
+                joinCode,
+                gameId: input.gameId,
+              },
+              now,
+            ),
+            ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
+          },
+        },
+      ];
+      if (sessionGamePayload) {
+        transactionItems.push(
+          {
+            Put: {
+              TableName: this.tableName,
+              Item: buildItem(
+                gameSessionIndexPk(input.sessionId),
+                gameSessionIndexSk(input.gameStartTs, input.gameId),
+                ENTITY_TYPE.sessionGame,
+                sessionGamePayload,
+                now,
+              ),
+              ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
+            },
+          },
+          ...sessionTargets.map((target) => this.buildConditionalPutFromStoredEntity(target, now)),
+        );
+      }
 
       try {
         await this.client.send(
           new TransactWriteItemsCommand({
-            TransactItems: [
-              {
-                Put: {
-                  TableName: this.tableName,
-                  Item: buildItem(gamePk(input.gameId), metadataSk(), ENTITY_TYPE.game, payload, now),
-                  ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
-                },
-              },
-              {
-                Put: {
-                  TableName: this.tableName,
-                  Item: buildItem(
-                    joinCodePk(joinCode),
-                    metadataSk(),
-                    ENTITY_TYPE.gameJoinCode,
-                    {
-                      joinCode,
-                      gameId: input.gameId,
-                    },
-                    now,
-                  ),
-                  ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
-                },
-              },
-            ],
+            TransactItems: transactionItems,
           }),
         );
         return withTimestamps(payload, now, now);
@@ -1499,6 +1865,19 @@ export class ThreeFcRepository {
               throw new GameJoinCodeCollisionError();
             }
             continue;
+          }
+          if (
+            linkSession &&
+            transactionItems
+              .slice(2)
+              .some((_, index) =>
+                isConditionalCancellationCode(transactionCancellationCode(error, index + 2) ?? undefined),
+              )
+          ) {
+            throw new GameMutationStateError(
+              "game_state_changed",
+              `Session ${input.sessionId} changed before the game could be created. Reload and try again.`,
+            );
           }
 
           const [existingGameItem, existingJoinCodeItem] = await Promise.all([
@@ -1525,7 +1904,12 @@ export class ThreeFcRepository {
 
   async getGame(
     gameId: string,
-    options: { consistentRead?: boolean; repairLegacyJoinCode?: boolean } = {},
+    options: {
+      consistentRead?: boolean;
+      repairLegacyJoinCode?: boolean;
+      expectedLeagueId?: string;
+      expectedSeasonId?: string;
+    } = {},
   ): Promise<GameRecord | null> {
     requireNonEmpty("gameId", gameId);
     const item = await this.getEntity(gamePk(gameId), metadataSk(), options);
@@ -1536,6 +1920,13 @@ export class ThreeFcRepository {
 
     const game = withTimestamps(normalizeGamePayload(item.data), item.createdAt, item.updatedAt);
     if (options.repairLegacyJoinCode) {
+      if (
+        (options.expectedLeagueId !== undefined && game.leagueId !== options.expectedLeagueId) ||
+        (options.expectedSeasonId !== undefined && game.seasonId !== options.expectedSeasonId)
+      ) {
+        return game;
+      }
+
       return this.repairLegacyGameJoinCode(item);
     }
 
@@ -1771,6 +2162,14 @@ export class ThreeFcRepository {
     requireNonEmpty("leagueId", input.leagueId);
     requireNonEmpty("seasonId", input.seasonId);
 
+    const sessionTargets = await this.readSessionMutationTargets(input);
+    if (sessionTargets.length === 0) {
+      throw new GameMutationStateError(
+        "game_state_changed",
+        `Session ${input.sessionId} changed before the game could be linked. Reload and try again.`,
+      );
+    }
+
     const now = this.clock.now();
     const payload = {
       sessionId: input.sessionId,
@@ -1780,20 +2179,48 @@ export class ThreeFcRepository {
       seasonId: input.seasonId,
     };
 
-    await this.putEntity(
-      gameSessionIndexPk(input.sessionId),
-      gameSessionIndexSk(input.gameStartTs, input.gameId),
-      ENTITY_TYPE.sessionGame,
-      payload,
-      now,
-    );
+    try {
+      await this.client.send(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            {
+              Put: {
+                TableName: this.tableName,
+                Item: buildItem(
+                  gameSessionIndexPk(input.sessionId),
+                  gameSessionIndexSk(input.gameStartTs, input.gameId),
+                  ENTITY_TYPE.sessionGame,
+                  payload,
+                  now,
+                ),
+              },
+            },
+            ...sessionTargets.map((target) => this.buildConditionalPutFromStoredEntity(target, now)),
+          ],
+        }),
+      );
+    } catch (error) {
+      if (isConditionalWriteFailure(error)) {
+        throw new GameMutationStateError(
+          "game_state_changed",
+          `Session ${input.sessionId} changed before the game could be linked. Reload and try again.`,
+        );
+      }
+
+      throw error;
+    }
 
     return withTimestamps(payload, now, now);
   }
 
-  async listGamesForSession(sessionId: string): Promise<SessionGameRecord[]> {
+  async listGamesForSession(
+    sessionId: string,
+    options: { consistentRead?: boolean } = {},
+  ): Promise<SessionGameRecord[]> {
     requireNonEmpty("sessionId", sessionId);
-    const items = await this.queryByPrefix(gameSessionIndexPk(sessionId), "GAME#");
+    const items = await this.queryByPrefix(gameSessionIndexPk(sessionId), "GAME#", {
+      consistentRead: options.consistentRead,
+    });
 
     return items
       .filter((item) => item.entityType === ENTITY_TYPE.sessionGame)
@@ -1806,12 +2233,48 @@ export class ThreeFcRepository {
       );
   }
 
-  async listGamesForSeason(seasonId: string): Promise<GameRecord[]> {
+  async listGamesForSeason(
+    seasonId: string,
+    options: { leagueId?: string; consistentRead?: boolean } = {},
+  ): Promise<GameRecord[]> {
     requireNonEmpty("seasonId", seasonId);
+    if (options.leagueId !== undefined) {
+      requireNonEmpty("leagueId", options.leagueId);
+    }
 
-    const sessions = await this.listSessionsForSeason(seasonId);
+    const legacySeasonItem = options.leagueId
+      ? await this.getEntity(seasonPk(seasonId), metadataSk(), {
+          consistentRead: options.consistentRead,
+        })
+      : null;
+    const canUseProvenanceLessLegacySessions =
+      options.leagueId !== undefined &&
+      this.isMatchingSeasonEntity(legacySeasonItem, {
+        leagueId: options.leagueId,
+        seasonId,
+      });
+    const scopedSessions = await this.listSessionsForSeason(seasonId, {
+      leagueId: options.leagueId,
+      consistentRead: options.consistentRead,
+    });
+    const legacySessions = options.leagueId
+      ? (await this.listSessionsForSeason(seasonId, { consistentRead: options.consistentRead })).filter(
+          (session) =>
+            session.leagueId === options.leagueId ||
+            (canUseProvenanceLessLegacySessions && session.leagueId === undefined),
+        )
+      : [];
+    const sessions = [
+      ...new Map(
+        [...scopedSessions, ...legacySessions].map((session) => [session.sessionId, session]),
+      ).values(),
+    ];
     const sessionGames = await Promise.all(
-      sessions.map((session) => this.listGamesForSession(session.sessionId)),
+      sessions.map((session) =>
+        this.listGamesForSession(session.sessionId, {
+          consistentRead: options.consistentRead,
+        }),
+      ),
     );
 
     const orderedSessionGames = sessionGames
@@ -1824,12 +2287,29 @@ export class ThreeFcRepository {
 
         return left.gameId.localeCompare(right.gameId);
       });
+    const scopedSessionGames = orderedSessionGames.filter((sessionGame) => {
+      if (sessionGame.seasonId !== seasonId) {
+        return false;
+      }
+
+      return !options.leagueId || sessionGame.leagueId === options.leagueId;
+    });
 
     const gameRecords = await Promise.all(
-      orderedSessionGames.map((sessionGame) => this.getGame(sessionGame.gameId)),
+      scopedSessionGames.map((sessionGame) =>
+        this.getGame(sessionGame.gameId, { consistentRead: options.consistentRead }),
+      ),
     );
 
-    return gameRecords.filter((game): game is GameRecord => game !== null);
+    return gameRecords
+      .filter((game): game is GameRecord => game !== null)
+      .filter((game) => {
+        if (game.seasonId !== seasonId) {
+          return false;
+        }
+
+        return !options.leagueId || game.leagueId === options.leagueId;
+      });
   }
 
   async updateGame(input: {
@@ -2250,6 +2730,7 @@ export class ThreeFcRepository {
       joinCodeItem !== null &&
       joinCodeRecord?.gameId === gameId &&
       normalizeJoinCode(joinCodeRecord.joinCode) === normalizeJoinCode(game.joinCode);
+    const sessionCleanupTargets = await this.readSessionMutationTargets(game);
     const transactionItems: TransactWriteItem[] = [
       {
         Delete: {
@@ -2314,30 +2795,184 @@ export class ThreeFcRepository {
       throw error;
     }
 
-    const remainingGames = await this.listGamesForSession(game.sessionId);
+    const remainingGames = await this.listGamesForSession(game.sessionId, {
+      consistentRead: true,
+    });
+    const sessionDeleteTargets: Array<StoredEntity<unknown>> = [];
     if (remainingGames.length === 0) {
-      await this.deleteEntity(seasonPk(game.seasonId), sessionSk(game.sessionId));
-      await this.deleteEntity(sessionPk(game.sessionId), metadataSk());
+      sessionDeleteTargets.push(
+        ...sessionCleanupTargets.filter(
+          (target) =>
+            (target.pk === seasonPk(game.seasonId) && target.sk === sessionSk(game.sessionId)) ||
+            (target.pk === sessionPk(game.sessionId) && target.sk === metadataSk()),
+        ),
+      );
     }
+    if (
+      remainingGames.every(
+        (remainingGame) =>
+          remainingGame.leagueId !== game.leagueId ||
+          remainingGame.seasonId !== game.seasonId,
+      )
+    ) {
+      sessionDeleteTargets.push(
+        ...sessionCleanupTargets.filter(
+          (target) =>
+            target.pk === leaguePk(game.leagueId) &&
+            target.sk === scopedSeasonSessionSk(game.seasonId, game.sessionId),
+        ),
+      );
+    }
+    await this.deleteSessionTargetsIfUnchanged(sessionDeleteTargets);
 
     return true;
   }
 
-  async deleteSeason(seasonId: string): Promise<boolean> {
+  async deleteSeason(
+    seasonId: string,
+    options: { leagueId?: string } = {},
+  ): Promise<boolean> {
     requireNonEmpty("seasonId", seasonId);
+    if (options.leagueId !== undefined) {
+      requireNonEmpty("leagueId", options.leagueId);
+    }
 
-    const season = await this.getSeason(seasonId);
-    if (!season) {
+    const globalSeasonItem = await this.getEntity(seasonPk(seasonId), metadataSk(), {
+      consistentRead: true,
+    });
+    const globalSeason =
+      globalSeasonItem?.entityType === ENTITY_TYPE.season
+        ? withTimestamps(
+            globalSeasonItem.data as Omit<SeasonRecord, "createdAt" | "updatedAt">,
+            globalSeasonItem.createdAt,
+            globalSeasonItem.updatedAt,
+          )
+        : null;
+    const season = options.leagueId
+      ? await this.getEntity(leaguePk(options.leagueId), seasonSk(seasonId))
+      : null;
+    const scopedSeason =
+      season?.entityType === ENTITY_TYPE.season
+        ? withTimestamps(
+            season.data as Omit<SeasonRecord, "createdAt" | "updatedAt">,
+            season.createdAt,
+            season.updatedAt,
+          )
+        : null;
+    const resolvedSeason = scopedSeason ?? (!options.leagueId ? globalSeason : null);
+    if (!resolvedSeason) {
       return false;
     }
 
-    const sessions = await this.listSessionsForSeason(seasonId);
+    const scopedSessions = await this.listSessionsForSeason(seasonId, {
+      leagueId: options.leagueId,
+      consistentRead: true,
+    });
+    const legacySessions = options.leagueId
+      ? (await this.listSessionsForSeason(seasonId, { consistentRead: true })).filter(
+          (session) => session.leagueId === options.leagueId,
+        )
+      : [];
+    const sessions = [
+      ...new Map(
+        [...scopedSessions, ...legacySessions].map((session) => [session.sessionId, session]),
+      ).values(),
+    ];
     if (sessions.length > 0) {
       throw new Error("Cannot delete season with existing games.");
     }
+    if (options.leagueId) {
+      const games = await this.listGamesForSeason(seasonId, {
+        leagueId: options.leagueId,
+        consistentRead: true,
+      });
+      if (games.length > 0) {
+        throw new Error("Cannot delete season with existing games.");
+      }
+    }
+
+    if (options.leagueId) {
+      if (!season || season.entityType !== ENTITY_TYPE.season) {
+        return false;
+      }
+      const scopedTeamItems = await this.queryByPrefix(
+        leaguePk(options.leagueId),
+        `SEASON#${seasonId}#TEAM#`,
+        { consistentRead: true },
+      );
+      const ownedLegacyTeamItems =
+        globalSeasonItem?.entityType === ENTITY_TYPE.season && globalSeason?.leagueId === options.leagueId
+          ? await this.queryByPrefix(seasonPk(seasonId), "TEAM#", { consistentRead: true })
+          : [];
+
+      const deleteItems: TransactWriteItem[] = [
+        {
+          Delete: {
+            TableName: this.tableName,
+            Key: {
+              pk: { S: leaguePk(options.leagueId) },
+              sk: { S: seasonSk(seasonId) },
+            },
+            ConditionExpression: "#scopedUpdatedAt = :expectedSeasonUpdatedAt AND #scopedData = :expectedSeasonData",
+            ExpressionAttributeNames: {
+              "#scopedUpdatedAt": "updatedAt",
+              "#scopedData": "data",
+            },
+            ExpressionAttributeValues: {
+              ":expectedSeasonUpdatedAt": { S: season.updatedAt },
+              ":expectedSeasonData": { S: season.rawData },
+            },
+          },
+        },
+        ...scopedTeamItems
+          .filter((item) => item.entityType === ENTITY_TYPE.team)
+          .map((item) => this.buildConditionalDeleteFromStoredEntity(item)),
+        ...ownedLegacyTeamItems
+          .filter((item) => this.isMatchingSeasonTeamEntity(item, {
+            seasonId,
+            leagueId: options.leagueId,
+          }))
+          .map((item) => this.buildConditionalDeleteFromStoredEntity(item)),
+      ];
+      if (globalSeasonItem?.entityType === ENTITY_TYPE.season && globalSeason?.leagueId === options.leagueId) {
+        deleteItems.push({
+          Delete: {
+            TableName: this.tableName,
+            Key: {
+              pk: { S: seasonPk(seasonId) },
+              sk: { S: metadataSk() },
+            },
+            ConditionExpression: "#globalUpdatedAt = :expectedGlobalSeasonUpdatedAt AND #globalData = :expectedGlobalSeasonData",
+            ExpressionAttributeNames: {
+              "#globalUpdatedAt": "updatedAt",
+              "#globalData": "data",
+            },
+            ExpressionAttributeValues: {
+              ":expectedGlobalSeasonUpdatedAt": { S: globalSeasonItem.updatedAt },
+              ":expectedGlobalSeasonData": { S: globalSeasonItem.rawData },
+            },
+          },
+        });
+      }
+
+      try {
+        await this.client.send(
+          new TransactWriteItemsCommand({
+            TransactItems: deleteItems,
+          }),
+        );
+      } catch (error) {
+        if (isConditionalWriteFailure(error)) {
+          throw new Error("Cannot delete season with existing games.");
+        }
+
+        throw error;
+      }
+      return true;
+    }
 
     await this.deleteEntity(seasonPk(seasonId), metadataSk());
-    await this.deleteEntity(leaguePk(season.leagueId), seasonSk(seasonId));
+    await this.deleteEntity(leaguePk(resolvedSeason.leagueId), seasonSk(seasonId));
     return true;
   }
 
@@ -5170,6 +5805,298 @@ export class ThreeFcRepository {
     }
 
     return withTimestamps(repairedGame, input.stored.createdAt, now);
+  }
+
+  private async readSessionMutationTargets(input: {
+    leagueId: string;
+    seasonId: string;
+    sessionId: string;
+  }): Promise<Array<StoredEntity<unknown>>> {
+    const [scopedSessionItem, legacySeasonSessionItem, legacySessionMetadataItem, globalSeasonItem] =
+      await Promise.all([
+        this.getEntity(
+          leaguePk(input.leagueId),
+          scopedSeasonSessionSk(input.seasonId, input.sessionId),
+          { consistentRead: true },
+        ),
+        this.getEntity(seasonPk(input.seasonId), sessionSk(input.sessionId), {
+          consistentRead: true,
+        }),
+        this.getEntity(sessionPk(input.sessionId), metadataSk(), {
+          consistentRead: true,
+        }),
+        this.getEntity(seasonPk(input.seasonId), metadataSk(), {
+          consistentRead: true,
+        }),
+      ]);
+    const isCurrentLegacyOwner = this.isMatchingSeasonEntity(globalSeasonItem, input);
+    const legacySessionTargets = [legacySeasonSessionItem, legacySessionMetadataItem].filter(
+      (item): item is StoredEntity<unknown> =>
+        this.isMatchingSessionEntity(item, input) ||
+        (isCurrentLegacyOwner && this.isMatchingLegacySessionEntityWithoutLeague(item, input)),
+    );
+
+    return [
+      ...[scopedSessionItem].filter((item): item is StoredEntity<unknown> =>
+        this.isMatchingSessionEntity(item, input),
+      ),
+      ...legacySessionTargets,
+    ];
+  }
+
+  private isMatchingSeasonEntity(
+    item: StoredEntity<unknown> | null,
+    expected: { leagueId: string; seasonId: string },
+  ): item is StoredEntity<unknown> {
+    if (!item || item.entityType !== ENTITY_TYPE.season) {
+      return false;
+    }
+
+    const season = item.data as Partial<SeasonRecord>;
+    return season.leagueId === expected.leagueId && season.seasonId === expected.seasonId;
+  }
+
+  private isMatchingSessionEntity(
+    item: StoredEntity<unknown> | null,
+    expected: { leagueId: string; seasonId: string; sessionId: string },
+  ): item is StoredEntity<unknown> {
+    if (!item || item.entityType !== ENTITY_TYPE.session) {
+      return false;
+    }
+
+    const session = item.data as Partial<SessionRecord>;
+    if (session.seasonId !== expected.seasonId || session.sessionId !== expected.sessionId) {
+      return false;
+    }
+
+    return session.leagueId === expected.leagueId;
+  }
+
+  private isMatchingLegacySessionEntityWithoutLeague(
+    item: StoredEntity<unknown> | null,
+    expected: { seasonId: string; sessionId: string },
+  ): item is StoredEntity<unknown> {
+    if (!item || item.entityType !== ENTITY_TYPE.session) {
+      return false;
+    }
+
+    const session = item.data as Partial<SessionRecord>;
+    return (
+      session.leagueId === undefined &&
+      session.seasonId === expected.seasonId &&
+      session.sessionId === expected.sessionId
+    );
+  }
+
+  private buildLegacySessionCompatibilityPut(input: {
+    pk: string;
+    sk: string;
+    payload: Omit<SessionRecord, "createdAt" | "updatedAt">;
+    existing: StoredEntity<unknown> | null;
+    expected: { leagueId: string; seasonId: string; sessionId: string };
+    allowLegacyWithoutLeague?: boolean;
+    now: string;
+  }): TransactWriteItem | null {
+    if (
+      input.existing &&
+      !this.isMatchingSessionEntity(input.existing, input.expected) &&
+      !(
+        input.allowLegacyWithoutLeague === true &&
+        this.isMatchingLegacySessionEntityWithoutLeague(input.existing, input.expected)
+      )
+    ) {
+      return null;
+    }
+
+    return {
+      Put: {
+        TableName: this.tableName,
+        Item: buildItemWithTimestamps(
+          input.pk,
+          input.sk,
+          ENTITY_TYPE.session,
+          input.payload,
+          input.existing?.createdAt ?? input.now,
+          input.now,
+        ),
+        ...(input.existing
+          ? {
+              ConditionExpression: "#updatedAt = :expectedUpdatedAt AND #data = :expectedData",
+              ExpressionAttributeNames: {
+                "#updatedAt": "updatedAt",
+                "#data": "data",
+              },
+              ExpressionAttributeValues: {
+                ":expectedUpdatedAt": { S: input.existing.updatedAt },
+                ":expectedData": { S: input.existing.rawData },
+              },
+            }
+          : {
+              ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
+            }),
+      },
+    };
+  }
+
+  private async readOwnedLegacySeasonTeamTemplateItems(
+    seasonId: string,
+    leagueId: string,
+  ): Promise<Array<StoredEntity<unknown>>> {
+    const result = (await this.client.send(
+      new TransactGetItemsCommand({
+        TransactItems: [
+          {
+            Get: {
+              TableName: this.tableName,
+              Key: {
+                pk: { S: leaguePk(leagueId) },
+                sk: { S: seasonSk(seasonId) },
+              },
+            },
+          },
+          ...TEAM_IDS.map((teamId) => ({
+            Get: {
+              TableName: this.tableName,
+              Key: {
+                pk: { S: seasonPk(seasonId) },
+                sk: { S: teamSk(teamId) },
+              },
+            },
+          })),
+        ],
+      }),
+    )) as TransactGetItemsCommandOutput;
+
+    const responses = result.Responses ?? [];
+    const seasonItem = responses[0]?.Item;
+    if (!seasonItem) {
+      return [];
+    }
+
+    const season = parseStoredEntity<Partial<SeasonRecord>>(seasonItem);
+    if (!this.isMatchingSeasonEntity(season, { leagueId, seasonId })) {
+      return [];
+    }
+
+    return responses
+      .slice(1)
+      .flatMap((response) => (response.Item ? [parseStoredEntity(response.Item)] : []))
+      .filter((item): item is StoredEntity<unknown> =>
+        this.isMatchingSeasonTeamEntity(item, { seasonId, leagueId }),
+      );
+  }
+
+  private isMatchingSeasonTeamEntity(
+    item: StoredEntity<unknown> | null,
+    expected: { seasonId: string; leagueId?: string },
+  ): item is StoredEntity<unknown> {
+    if (!item || item.entityType !== ENTITY_TYPE.team) {
+      return false;
+    }
+
+    const team = item.data as Partial<TeamRecord>;
+    if (team.seasonId !== expected.seasonId || !TEAM_IDS.includes(team.teamId as TeamId)) {
+      return false;
+    }
+
+    return expected.leagueId === undefined || team.leagueId === expected.leagueId;
+  }
+
+  private buildConditionalPutFromStoredEntity(
+    stored: StoredEntity<unknown>,
+    now: string,
+  ): TransactWriteItem {
+    return {
+      Put: {
+        TableName: this.tableName,
+        Item: buildItemWithTimestamps(
+          stored.pk,
+          stored.sk,
+          stored.entityType,
+          stored.data,
+          stored.createdAt,
+          now,
+        ),
+        ConditionExpression: "#updatedAt = :expectedUpdatedAt AND #data = :expectedData",
+        ExpressionAttributeNames: {
+          "#updatedAt": "updatedAt",
+          "#data": "data",
+        },
+        ExpressionAttributeValues: {
+          ":expectedUpdatedAt": { S: stored.updatedAt },
+          ":expectedData": { S: stored.rawData },
+        },
+      },
+    };
+  }
+
+  private buildConditionalCheckFromStoredEntity(stored: StoredEntity<unknown>): TransactWriteItem {
+    return {
+      ConditionCheck: {
+        TableName: this.tableName,
+        Key: {
+          pk: { S: stored.pk },
+          sk: { S: stored.sk },
+        },
+        ConditionExpression: "#updatedAt = :expectedUpdatedAt AND #data = :expectedData",
+        ExpressionAttributeNames: {
+          "#updatedAt": "updatedAt",
+          "#data": "data",
+        },
+        ExpressionAttributeValues: {
+          ":expectedUpdatedAt": { S: stored.updatedAt },
+          ":expectedData": { S: stored.rawData },
+        },
+      },
+    };
+  }
+
+  private buildConditionalDeleteFromStoredEntity(stored: StoredEntity<unknown>): TransactWriteItem {
+    return {
+      Delete: {
+        TableName: this.tableName,
+        Key: {
+          pk: { S: stored.pk },
+          sk: { S: stored.sk },
+        },
+        ConditionExpression: "#updatedAt = :expectedUpdatedAt AND #data = :expectedData",
+        ExpressionAttributeNames: {
+          "#updatedAt": "updatedAt",
+          "#data": "data",
+        },
+        ExpressionAttributeValues: {
+          ":expectedUpdatedAt": { S: stored.updatedAt },
+          ":expectedData": { S: stored.rawData },
+        },
+      },
+    };
+  }
+
+  private async deleteSessionTargetsIfUnchanged(
+    targets: Array<StoredEntity<unknown>>,
+  ): Promise<void> {
+    const uniqueTargets = [
+      ...new Map(targets.map((target) => [`${target.pk}|${target.sk}`, target])).values(),
+    ];
+    if (uniqueTargets.length === 0) {
+      return;
+    }
+
+    try {
+      await this.client.send(
+        new TransactWriteItemsCommand({
+          TransactItems: uniqueTargets.map((target) =>
+            this.buildConditionalDeleteFromStoredEntity(target),
+          ),
+        }),
+      );
+    } catch (error) {
+      if (isConditionalWriteFailure(error)) {
+        return;
+      }
+
+      throw error;
+    }
   }
 
   private async putEntityWithTimestampsIfUnchanged<T>(

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -2859,8 +2859,12 @@ export class ThreeFcRepository {
     const remainingGames = await this.listGamesForSession(game.sessionId, {
       consistentRead: true,
     });
+    const hasRemainingGamesForDeletedScope = remainingGames.some(
+      (remainingGame) =>
+        remainingGame.leagueId === game.leagueId && remainingGame.seasonId === game.seasonId,
+    );
     const sessionDeleteTargets: Array<StoredEntity<unknown>> = [];
-    if (remainingGames.length === 0) {
+    if (!hasRemainingGamesForDeletedScope) {
       sessionDeleteTargets.push(
         ...sessionCleanupTargets.filter(
           (target) =>
@@ -2868,14 +2872,6 @@ export class ThreeFcRepository {
             (target.pk === sessionPk(game.sessionId) && target.sk === metadataSk()),
         ),
       );
-    }
-    if (
-      remainingGames.every(
-        (remainingGame) =>
-          remainingGame.leagueId !== game.leagueId ||
-          remainingGame.seasonId !== game.seasonId,
-      )
-    ) {
       sessionDeleteTargets.push(
         ...sessionCleanupTargets.filter(
           (target) =>
@@ -2910,7 +2906,9 @@ export class ThreeFcRepository {
           )
         : null;
     const season = options.leagueId
-      ? await this.getEntity(leaguePk(options.leagueId), seasonSk(seasonId))
+      ? await this.getEntity(leaguePk(options.leagueId), seasonSk(seasonId), {
+          consistentRead: true,
+        })
       : null;
     const scopedSeason =
       season?.entityType === ENTITY_TYPE.season
@@ -2924,6 +2922,12 @@ export class ThreeFcRepository {
     if (!resolvedSeason) {
       return false;
     }
+    const canUseProvenanceLessLegacySessions =
+      options.leagueId !== undefined &&
+      this.isMatchingSeasonEntity(globalSeasonItem, {
+        leagueId: options.leagueId,
+        seasonId,
+      });
 
     const scopedSessions = await this.listSessionsForSeason(seasonId, {
       leagueId: options.leagueId,
@@ -2931,7 +2935,9 @@ export class ThreeFcRepository {
     });
     const legacySessions = options.leagueId
       ? (await this.listSessionsForSeason(seasonId, { consistentRead: true })).filter(
-          (session) => session.leagueId === options.leagueId,
+          (session) =>
+            session.leagueId === options.leagueId ||
+            (canUseProvenanceLessLegacySessions && session.leagueId === undefined),
         )
       : [];
     const sessions = [
@@ -2961,10 +2967,10 @@ export class ThreeFcRepository {
         `SEASON#${seasonId}#TEAM#`,
         { consistentRead: true },
       );
-      const ownedLegacyTeamItems =
-        globalSeasonItem?.entityType === ENTITY_TYPE.season && globalSeason?.leagueId === options.leagueId
-          ? await this.queryByPrefix(seasonPk(seasonId), "TEAM#", { consistentRead: true })
-          : [];
+      const ownedLegacyTeamItems = await this.readOwnedLegacySeasonTeamTemplateItems(
+        seasonId,
+        options.leagueId,
+      );
 
       const deleteItems: TransactWriteItem[] = [
         {

--- a/api/src/data/repository.ts
+++ b/api/src/data/repository.ts
@@ -1223,48 +1223,71 @@ export class ThreeFcRepository {
       return withTimestamps(payload, now, now);
     }
 
-    if (input.createOnly) {
-      try {
-        await this.client.send(
-          new PutItemCommand({
-            TableName: this.tableName,
-            Item: buildItemWithTimestamps(
-              teamPartitionKey,
-              teamSortKey,
-              ENTITY_TYPE.team,
-              payload,
-              now,
-              now,
-            ),
-            ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
-          }),
-        );
-      } catch (error) {
-        if (isConditionalWriteFailure(error)) {
-          const concurrent = await this.getEntity(teamPartitionKey, teamSortKey, {
-            consistentRead: true,
-          });
-          if (concurrent?.entityType === ENTITY_TYPE.team) {
-            return withTimestamps(
-              concurrent.data as Omit<TeamRecord, "createdAt" | "updatedAt">,
-              concurrent.createdAt,
-              concurrent.updatedAt,
-            );
-          }
+    if (!legacySeasonItem || legacySeasonItem.entityType !== ENTITY_TYPE.season) {
+      throw new GameMutationStateError(
+        "game_state_changed",
+        `Season ${input.seasonId} changed before the team could be created. Reload and try again.`,
+      );
+    }
 
-          throw new GameMutationStateError(
-            "game_state_changed",
-            `Season ${input.seasonId} changed before the team could be created. Reload and try again.`,
-          );
-        }
+    const teamPut: TransactWriteItem = {
+      Put: {
+        TableName: this.tableName,
+        Item: buildItemWithTimestamps(
+          teamPartitionKey,
+          teamSortKey,
+          ENTITY_TYPE.team,
+          payload,
+          now,
+          now,
+        ),
+        ...(input.createOnly
+          ? {
+              ConditionExpression: "attribute_not_exists(pk) AND attribute_not_exists(sk)",
+            }
+          : {}),
+      },
+    };
 
+    try {
+      await this.client.send(
+        new TransactWriteItemsCommand({
+          TransactItems: [
+            this.buildConditionalCheckFromStoredEntity(legacySeasonItem),
+            teamPut,
+          ],
+        }),
+      );
+    } catch (error) {
+      if (!isConditionalWriteFailure(error)) {
         throw error;
       }
 
-      return withTimestamps(payload, now, now);
+      if (input.createOnly) {
+        const [currentSeason, concurrent] = await Promise.all([
+          this.getEntity(seasonPk(input.seasonId), metadataSk(), { consistentRead: true }),
+          this.getEntity(teamPartitionKey, teamSortKey, { consistentRead: true }),
+        ]);
+        if (
+          currentSeason?.entityType === ENTITY_TYPE.season &&
+          currentSeason.updatedAt === legacySeasonItem.updatedAt &&
+          currentSeason.rawData === legacySeasonItem.rawData &&
+          concurrent?.entityType === ENTITY_TYPE.team
+        ) {
+          return withTimestamps(
+            concurrent.data as Omit<TeamRecord, "createdAt" | "updatedAt">,
+            concurrent.createdAt,
+            concurrent.updatedAt,
+          );
+        }
+      }
+
+      throw new GameMutationStateError(
+        "game_state_changed",
+        `Season ${input.seasonId} changed before the team could be created. Reload and try again.`,
+      );
     }
 
-    await this.putEntity(teamPartitionKey, teamSortKey, ENTITY_TYPE.team, payload, now);
     return withTimestamps(payload, now, now);
   }
 
@@ -2162,12 +2185,39 @@ export class ThreeFcRepository {
     requireNonEmpty("leagueId", input.leagueId);
     requireNonEmpty("seasonId", input.seasonId);
 
-    const sessionTargets = await this.readSessionMutationTargets(input);
+    const [sessionTargets, guardedGameItem] = await Promise.all([
+      this.readSessionMutationTargets(input),
+      input.requireExistingGame === true
+        ? this.getEntity(gamePk(input.gameId), metadataSk(), { consistentRead: true })
+        : Promise.resolve(null),
+    ]);
     if (sessionTargets.length === 0) {
       throw new GameMutationStateError(
         "game_state_changed",
         `Session ${input.sessionId} changed before the game could be linked. Reload and try again.`,
       );
+    }
+    if (input.requireExistingGame === true) {
+      if (!guardedGameItem || guardedGameItem.entityType !== ENTITY_TYPE.game) {
+        throw new GameMutationStateError(
+          "game_state_changed",
+          `Game ${input.gameId} changed before the session could be linked. Reload and try again.`,
+        );
+      }
+
+      const guardedGame = normalizeGamePayload(guardedGameItem.data);
+      if (
+        guardedGame.gameId !== input.gameId ||
+        guardedGame.leagueId !== input.leagueId ||
+        guardedGame.seasonId !== input.seasonId ||
+        guardedGame.sessionId !== input.sessionId ||
+        guardedGame.gameStartTs !== input.gameStartTs
+      ) {
+        throw new GameMutationStateError(
+          "game_state_changed",
+          `Game ${input.gameId} changed before the session could be linked. Reload and try again.`,
+        );
+      }
     }
 
     const now = this.clock.now();
@@ -2183,6 +2233,7 @@ export class ThreeFcRepository {
       await this.client.send(
         new TransactWriteItemsCommand({
           TransactItems: [
+            ...(guardedGameItem ? [this.buildGameConditionCheck(input.gameId, guardedGameItem)] : []),
             {
               Put: {
                 TableName: this.tableName,
@@ -2201,6 +2252,16 @@ export class ThreeFcRepository {
       );
     } catch (error) {
       if (isConditionalWriteFailure(error)) {
+        if (
+          guardedGameItem &&
+          isConditionalCancellationCode(transactionCancellationCode(error, 0) ?? undefined)
+        ) {
+          throw new GameMutationStateError(
+            "game_state_changed",
+            `Game ${input.gameId} changed before the session could be linked. Reload and try again.`,
+          );
+        }
+
         throw new GameMutationStateError(
           "game_state_changed",
           `Session ${input.sessionId} changed before the game could be linked. Reload and try again.`,

--- a/api/src/data/types.ts
+++ b/api/src/data/types.ts
@@ -30,6 +30,7 @@ export interface SeasonRecord {
 }
 
 export interface TeamRecord {
+  leagueId?: string;
   seasonId: string;
   teamId: TeamId;
   name: string;
@@ -50,6 +51,7 @@ export interface GameTeamRecord {
 }
 
 export interface SessionRecord {
+  leagueId?: string;
   seasonId: string;
   sessionId: string;
   sessionDate: string;
@@ -236,6 +238,7 @@ export interface CreateSeasonInput {
 }
 
 export interface CreateTeamInput {
+  leagueId?: string;
   seasonId: string;
   teamId: TeamId;
   name: string;
@@ -253,6 +256,7 @@ export interface CreateGameTeamInput {
 }
 
 export interface CreateSessionInput {
+  leagueId?: string;
   seasonId: string;
   sessionId: string;
   sessionDate: string;
@@ -268,6 +272,7 @@ export interface CreateGameInput {
   status?: GameStatus;
   gameStartTs: string;
   thirdLengthMinutes?: ThirdLengthMinutes;
+  linkSession?: boolean;
 }
 
 export interface CreateSessionGameInput {

--- a/api/src/data/types.ts
+++ b/api/src/data/types.ts
@@ -281,6 +281,7 @@ export interface CreateSessionGameInput {
   gameStartTs: string;
   leagueId: string;
   seasonId: string;
+  requireExistingGame?: boolean;
 }
 
 export interface CreatePlayerInput {

--- a/api/src/lambda-core.ts
+++ b/api/src/lambda-core.ts
@@ -340,6 +340,7 @@ interface RepositoryContract {
     gameStartTs: string;
     leagueId: string;
     seasonId: string;
+    requireExistingGame?: boolean;
   }): Promise<unknown>;
   listGamesForSeason(
     seasonId: string,
@@ -1757,6 +1758,7 @@ async function createGameMutationResponse(input: {
             gameStartTs: createdGame.gameStartTs,
             leagueId: createdGame.leagueId,
             seasonId: createdGame.seasonId,
+            requireExistingGame: true,
           });
         }
         await ensureGameTeamsForGame(input.dependencies.repository, createdGame, {
@@ -3870,13 +3872,23 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
             );
           }
 
-          await ensureSeasonDefaultTeams(dependencies.repository, seasonId);
-          const team = await dependencies.repository.createTeam({
-            seasonId,
-            teamId,
-            name: parsedBody.data.name,
-            color: parsedBody.data.color ?? null,
-          });
+          let team: Awaited<ReturnType<RepositoryContract["createTeam"]>>;
+          try {
+            await ensureSeasonDefaultTeams(dependencies.repository, seasonId);
+            team = await dependencies.repository.createTeam({
+              seasonId,
+              teamId,
+              name: parsedBody.data.name,
+              color: parsedBody.data.color ?? null,
+            });
+          } catch (error) {
+            if (error instanceof GameMutationStateError) {
+              status = 409;
+              return conflict(origin, dependencies.corsAllowedOrigins, error.message);
+            }
+
+            throw error;
+          }
           status = 200;
           return createJsonResponse(
             status,
@@ -4128,6 +4140,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
                     gameStartTs: createdGame.gameStartTs,
                     leagueId: createdGame.leagueId,
                     seasonId: createdGame.seasonId,
+                    requireExistingGame: true,
                   });
                 }
                 await ensureGameTeamsForGame(dependencies.repository, createdGame, {
@@ -4183,6 +4196,10 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
 
               status = 409;
               return gameJoinCodeCollisionConflictResponse(origin, dependencies.corsAllowedOrigins);
+            }
+            if (error instanceof GameMutationStateError) {
+              status = 409;
+              return conflict(origin, dependencies.corsAllowedOrigins, error.message);
             }
 
             throw error;

--- a/api/src/lambda-core.ts
+++ b/api/src/lambda-core.ts
@@ -210,8 +210,26 @@ interface RepositoryContract {
       }
     | null
   >;
+  getSeasonForLeague(
+    leagueId: string,
+    seasonId: string,
+    options?: { consistentRead?: boolean },
+  ): Promise<
+    | {
+        leagueId: string;
+        seasonId: string;
+        name: string;
+        slug: string | null;
+        startsOn: string | null;
+        endsOn: string | null;
+        createdAt: string;
+        updatedAt: string;
+      }
+    | null
+  >;
   listSeasonsForLeague(
     leagueId: string,
+    options?: { consistentRead?: boolean },
   ): Promise<
     Array<{
       leagueId: string;
@@ -242,6 +260,7 @@ interface RepositoryContract {
     updatedAt: string;
   }>;
   createTeam(input: {
+    leagueId?: string;
     seasonId: string;
     teamId: TeamId;
     name: string;
@@ -255,7 +274,7 @@ interface RepositoryContract {
     createdAt: string;
     updatedAt: string;
   }>;
-  listTeamsForSeason(seasonId: string, options?: { consistentRead?: boolean }): Promise<
+  listTeamsForSeason(seasonId: string, options?: { consistentRead?: boolean; leagueId?: string }): Promise<
     Array<{
       seasonId: string;
       teamId: TeamId;
@@ -297,7 +316,12 @@ interface RepositoryContract {
       updatedAt: string;
     }>
   >;
-  createSession(input: { seasonId: string; sessionId: string; sessionDate: string }): Promise<unknown>;
+  createSession(input: { leagueId?: string; seasonId: string; sessionId: string; sessionDate: string }): Promise<unknown>;
+  getSessionForSeason(
+    seasonId: string,
+    sessionId: string,
+    options?: { leagueId?: string },
+  ): Promise<{ seasonId: string; sessionId: string; sessionDate: string } | null>;
   createGame(input: {
     gameId: string;
     joinCode?: string | null;
@@ -308,6 +332,7 @@ interface RepositoryContract {
     status?: GameStatus;
     gameStartTs: string;
     thirdLengthMinutes?: ThirdLengthMinutes;
+    linkSession?: boolean;
   }): Promise<RepositoryGameRecord>;
   createSessionGame(input: {
     sessionId: string;
@@ -316,10 +341,18 @@ interface RepositoryContract {
     leagueId: string;
     seasonId: string;
   }): Promise<unknown>;
-  listGamesForSeason(seasonId: string): Promise<RepositoryGameRecord[]>;
+  listGamesForSeason(
+    seasonId: string,
+    options?: { leagueId?: string },
+  ): Promise<RepositoryGameRecord[]>;
   getGame(
     gameId: string,
-    options?: { consistentRead?: boolean; repairLegacyJoinCode?: boolean },
+    options?: {
+      consistentRead?: boolean;
+      repairLegacyJoinCode?: boolean;
+      expectedLeagueId?: string;
+      expectedSeasonId?: string;
+    },
   ): Promise<RepositoryGameRecord | null>;
   getGameByJoinCode(joinCode: string): Promise<RepositoryGameRecord | null>;
   joinGameByCode(input: {
@@ -346,7 +379,7 @@ interface RepositoryContract {
   finishGameThird(input: { gameId: string; third: ThirdNumber }): Promise<RepositoryGameRecord | null>;
   finishGame(input: { gameId: string }): Promise<RepositoryGameRecord | null>;
   deleteGame(gameId: string): Promise<boolean>;
-  deleteSeason(seasonId: string): Promise<boolean>;
+  deleteSeason(seasonId: string, options?: { leagueId?: string }): Promise<boolean>;
   deleteLeague(leagueId: string): Promise<boolean>;
   createPlayer(input: {
     playerId: string;
@@ -1260,9 +1293,14 @@ async function readSeasonTeams(
   return buildReadOnlySeasonTeams(season, existingTeams);
 }
 
-async function ensureSeasonDefaultTeams(repository: RepositoryContract, seasonId: string) {
+async function ensureSeasonDefaultTeams(
+  repository: RepositoryContract,
+  seasonId: string,
+  options: { leagueId?: string } = {},
+) {
   const existingTeams = await repository.listTeamsForSeason(seasonId, {
     consistentRead: true,
+    leagueId: options.leagueId,
   });
   const teamsById = new Map(existingTeams.map((team) => [team.teamId, team]));
 
@@ -1272,6 +1310,7 @@ async function ensureSeasonDefaultTeams(repository: RepositoryContract, seasonId
     }
 
     const createdTeam = await repository.createTeam({
+      leagueId: options.leagueId,
       seasonId,
       teamId: defaultTeam.teamId,
       name: defaultTeam.name,
@@ -1290,9 +1329,11 @@ async function ensureGameTeamsForGame(
     gameId: string;
     seasonId: string;
   },
-  options: { allowFinished?: boolean } = {},
+  options: { allowFinished?: boolean; leagueId?: string } = {},
 ) {
-  const seasonTeams = await ensureSeasonDefaultTeams(repository, game.seasonId);
+  const seasonTeams = await ensureSeasonDefaultTeams(repository, game.seasonId, {
+    leagueId: options.leagueId,
+  });
   const existingGameTeams = await repository.listTeamsForGame(game.gameId, {
     consistentRead: true,
   });
@@ -1614,6 +1655,169 @@ function buildCreateGameRecoveryRequestHash(input: {
     idempotencyKey: parsedIdempotencyKey,
     payload: input.payload,
   });
+}
+
+async function createGameMutationResponse(input: {
+  dependencies: CoreHandlerDependencies;
+  idempotencyKey: string | undefined;
+  session: AuthSessionRecord;
+  method: string;
+  route: string;
+  rawBody: Record<string, unknown>;
+  origin: string | undefined;
+  scope: { leagueId: string; seasonId: string; sessionId: string };
+}): Promise<ApiGatewayHttpResponse> {
+  const parsedBody = createGameRequestSchema.safeParse(input.rawBody);
+  if (!parsedBody.success) {
+    return badRequest(
+      input.origin,
+      input.dependencies.corsAllowedOrigins,
+      formatSchemaValidationError(parsedBody.error),
+    );
+  }
+
+  const createRequestHash = buildCreateGameRecoveryRequestHash({
+    idempotencyKey: input.idempotencyKey,
+    sessionEmail: input.session.email,
+    method: input.method,
+    route: input.route,
+    payload: parsedBody.data,
+  });
+
+  try {
+    return await executeIdempotentMutation({
+      repository: input.dependencies.repository,
+      idempotencyKey: input.idempotencyKey,
+      sessionEmail: input.session.email,
+      method: input.method,
+      route: input.route,
+      requestPayload: parsedBody.data,
+      origin: input.origin,
+      allowedOrigins: input.dependencies.corsAllowedOrigins,
+      execute: async () => {
+        let createdGame: RepositoryGameRecord;
+        let recoveredExistingGame = false;
+        try {
+          createdGame = await input.dependencies.repository.createGame({
+            gameId: parsedBody.data.gameId,
+            createRequestHash,
+            leagueId: input.scope.leagueId,
+            seasonId: input.scope.seasonId,
+            sessionId: input.scope.sessionId,
+            status: parsedBody.data.status as GameStatus | undefined,
+            gameStartTs: parsedBody.data.gameStartTs,
+            thirdLengthMinutes: parsedBody.data.thirdLengthMinutes,
+            linkSession: true,
+          });
+        } catch (error) {
+          if (!(error instanceof GameAlreadyExistsError)) {
+            throw error;
+          }
+
+          const replayResponse = await replayStoredIdempotencyMutation({
+            repository: input.dependencies.repository,
+            idempotencyKey: input.idempotencyKey,
+            sessionEmail: input.session.email,
+            method: input.method,
+            route: input.route,
+            requestPayload: parsedBody.data,
+            origin: input.origin,
+            allowedOrigins: input.dependencies.corsAllowedOrigins,
+          });
+          if (replayResponse) {
+            return replayResponse;
+          }
+          if (!input.idempotencyKey || !createRequestHash) {
+            throw error;
+          }
+
+          const existingGame = await input.dependencies.repository.getGame(parsedBody.data.gameId);
+          if (
+            !existingGame ||
+            !existingGameMatchesCreateRequest({
+              game: existingGame,
+              leagueId: input.scope.leagueId,
+              seasonId: input.scope.seasonId,
+              sessionId: input.scope.sessionId,
+              createRequestHash,
+              request: parsedBody.data,
+            })
+          ) {
+            throw error;
+          }
+
+          createdGame = existingGame;
+          recoveredExistingGame = true;
+        }
+
+        if (recoveredExistingGame) {
+          await input.dependencies.repository.createSessionGame({
+            sessionId: createdGame.sessionId,
+            gameId: createdGame.gameId,
+            gameStartTs: createdGame.gameStartTs,
+            leagueId: createdGame.leagueId,
+            seasonId: createdGame.seasonId,
+          });
+        }
+        await ensureGameTeamsForGame(input.dependencies.repository, createdGame, {
+          leagueId: input.scope.leagueId,
+        });
+
+        return createJsonResponse(
+          201,
+          buildGameResponse(createdGame),
+          buildCorsHeaders(input.origin, input.dependencies.corsAllowedOrigins),
+        );
+      },
+    });
+  } catch (error) {
+    if (error instanceof GameAlreadyExistsError) {
+      const replayResponse = await replayStoredIdempotencyMutation({
+        repository: input.dependencies.repository,
+        idempotencyKey: input.idempotencyKey,
+        sessionEmail: input.session.email,
+        method: input.method,
+        route: input.route,
+        requestPayload: parsedBody.data,
+        origin: input.origin,
+        allowedOrigins: input.dependencies.corsAllowedOrigins,
+      });
+      if (replayResponse) {
+        return replayResponse;
+      }
+
+      return gameAlreadyExistsConflictResponse(
+        input.origin,
+        input.dependencies.corsAllowedOrigins,
+        parsedBody.data.gameId,
+      );
+    }
+    if (error instanceof GameJoinCodeCollisionError) {
+      const replayResponse = await replayStoredIdempotencyMutation({
+        repository: input.dependencies.repository,
+        idempotencyKey: input.idempotencyKey,
+        sessionEmail: input.session.email,
+        method: input.method,
+        route: input.route,
+        requestPayload: parsedBody.data,
+        origin: input.origin,
+        allowedOrigins: input.dependencies.corsAllowedOrigins,
+      });
+      if (replayResponse) {
+        return replayResponse;
+      }
+
+      return gameJoinCodeCollisionConflictResponse(
+        input.origin,
+        input.dependencies.corsAllowedOrigins,
+      );
+    }
+    if (error instanceof GameMutationStateError) {
+      return conflict(input.origin, input.dependencies.corsAllowedOrigins, error.message);
+    }
+
+    throw error;
+  }
 }
 
 function buildPublicJoinPlayerId(joinCode: string, idempotencyKey: string): string {
@@ -3268,6 +3472,90 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
           );
         }
 
+        const getLeagueSeasonMatch = route.match(/^\/v1\/leagues\/([^/]+)\/seasons\/([^/]+)$/);
+        if (method === "GET" && getLeagueSeasonMatch) {
+          const leagueId = decodeRouteParam(getLeagueSeasonMatch[1]);
+          const seasonId = decodeRouteParam(getLeagueSeasonMatch[2]);
+          const access = await ensureLeagueAccess(dependencies.repository, leagueId, sessionUserIds(session));
+          if (!access.allowed) {
+            status = 403;
+            return forbidden(
+              origin,
+              dependencies.corsAllowedOrigins,
+              "league_access_required",
+              `Access to league ${leagueId} is required.`,
+            );
+          }
+
+          const season = await dependencies.repository.getSeasonForLeague(leagueId, seasonId, {
+            consistentRead: true,
+          });
+          if (!season) {
+            status = 404;
+            return notFound(origin, dependencies.corsAllowedOrigins, `Season ${seasonId} was not found.`);
+          }
+
+          status = 200;
+          return createJsonResponse(
+            status,
+            season,
+            buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
+          );
+        }
+
+        const listLeagueSeasonGamesMatch = route.match(/^\/v1\/leagues\/([^/]+)\/seasons\/([^/]+)\/games$/);
+        if (method === "GET" && listLeagueSeasonGamesMatch) {
+          const leagueId = decodeRouteParam(listLeagueSeasonGamesMatch[1]);
+          const seasonId = decodeRouteParam(listLeagueSeasonGamesMatch[2]);
+          const access = await ensureLeagueAccess(dependencies.repository, leagueId, sessionUserIds(session));
+          if (!access.allowed) {
+            status = 403;
+            return forbidden(
+              origin,
+              dependencies.corsAllowedOrigins,
+              "league_access_required",
+              `Access to league ${leagueId} is required.`,
+            );
+          }
+
+          const season = await dependencies.repository.getSeasonForLeague(leagueId, seasonId, {
+            consistentRead: true,
+          });
+          if (!season) {
+            status = 404;
+            return notFound(origin, dependencies.corsAllowedOrigins, `Season ${seasonId} was not found.`);
+          }
+
+          const games = await dependencies.repository.listGamesForSeason(seasonId, { leagueId });
+          const gamesWithUsableJoinCodes = await Promise.all(
+            games.map(async (game) => {
+              const refreshedGame = await dependencies.repository.getGame(game.gameId, {
+                consistentRead: true,
+                repairLegacyJoinCode: true,
+                expectedLeagueId: leagueId,
+                expectedSeasonId: seasonId,
+              });
+              if (
+                !refreshedGame ||
+                refreshedGame.leagueId !== leagueId ||
+                refreshedGame.seasonId !== seasonId
+              ) {
+                return game;
+              }
+
+              return refreshedGame;
+            }),
+          );
+          status = 200;
+          return createJsonResponse(
+            status,
+            {
+              games: gamesWithUsableJoinCodes.map((game) => buildGameResponse(game)),
+            },
+            buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
+          );
+        }
+
         const deleteLeagueMatch = route.match(/^\/v1\/leagues\/([^/]+)$/);
         if (method === "DELETE" && deleteLeagueMatch) {
           const leagueId = decodeRouteParam(deleteLeagueMatch[1]);
@@ -3303,6 +3591,85 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
 
           status = 204;
           return createNoContentResponse(buildCorsHeaders(origin, dependencies.corsAllowedOrigins));
+        }
+
+        const createLeagueSeasonSessionMatch = route.match(/^\/v1\/leagues\/([^/]+)\/seasons\/([^/]+)\/sessions$/);
+        if (method === "POST" && createLeagueSeasonSessionMatch) {
+          const leagueId = decodeRouteParam(createLeagueSeasonSessionMatch[1]);
+          const seasonId = decodeRouteParam(createLeagueSeasonSessionMatch[2]);
+          const isAdmin = await ensureLeagueAdmin(dependencies.repository, leagueId, sessionUserIds(session));
+          if (!isAdmin) {
+            status = 403;
+            return forbidden(
+              origin,
+              dependencies.corsAllowedOrigins,
+              "admin_required",
+              `Admin role is required for league ${leagueId}.`,
+            );
+          }
+
+          const season = await dependencies.repository.getSeasonForLeague(leagueId, seasonId, {
+            consistentRead: true,
+          });
+          if (!season) {
+            status = 404;
+            return notFound(origin, dependencies.corsAllowedOrigins, `Season ${seasonId} was not found.`);
+          }
+
+          let rawBody: Record<string, unknown>;
+          try {
+            rawBody = parseJsonBody(event);
+          } catch {
+            status = 400;
+            return badRequest(origin, dependencies.corsAllowedOrigins, "Request body must be valid JSON.");
+          }
+
+          const parsedBody = createSessionRequestSchema.safeParse(rawBody);
+          if (!parsedBody.success) {
+            status = 400;
+            return badRequest(
+              origin,
+              dependencies.corsAllowedOrigins,
+              formatSchemaValidationError(parsedBody.error),
+            );
+          }
+
+          const mutationResponse = await executeIdempotentMutation({
+            repository: dependencies.repository,
+            idempotencyKey,
+            sessionEmail: session.email,
+            method,
+            route,
+            requestPayload: parsedBody.data,
+            origin,
+            allowedOrigins: dependencies.corsAllowedOrigins,
+            execute: async () => {
+              let createdSession: unknown;
+              try {
+                createdSession = await dependencies.repository.createSession({
+                  leagueId,
+                  seasonId,
+                  sessionId: parsedBody.data.sessionId,
+                  sessionDate: parsedBody.data.sessionDate,
+                });
+              } catch (error) {
+                if (error instanceof GameMutationStateError) {
+                  return conflict(origin, dependencies.corsAllowedOrigins, error.message);
+                }
+
+                throw error;
+              }
+
+              return createJsonResponse(
+                201,
+                createdSession,
+                buildCorsHeaders(origin, dependencies.corsAllowedOrigins),
+              );
+            },
+          });
+
+          status = mutationResponse.statusCode;
+          return mutationResponse;
         }
 
         const createSessionMatch = route.match(/^\/v1\/seasons\/([^/]+)\/sessions$/);
@@ -3409,15 +3776,26 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
             );
           }
 
-          const games = await dependencies.repository.listGamesForSeason(seasonId);
+          const games = await dependencies.repository.listGamesForSeason(seasonId, {
+            leagueId: season.leagueId,
+          });
           const gamesWithUsableJoinCodes = await Promise.all(
             games.map(async (game) => {
-              return (
-                (await dependencies.repository.getGame(game.gameId, {
-                  consistentRead: true,
-                  repairLegacyJoinCode: true,
-                })) ?? game
-              );
+              const refreshedGame = await dependencies.repository.getGame(game.gameId, {
+                consistentRead: true,
+                repairLegacyJoinCode: true,
+                expectedLeagueId: season.leagueId,
+                expectedSeasonId: seasonId,
+              });
+              if (
+                !refreshedGame ||
+                refreshedGame.leagueId !== season.leagueId ||
+                refreshedGame.seasonId !== seasonId
+              ) {
+                return game;
+              }
+
+              return refreshedGame;
             }),
           );
           status = 200;
@@ -3507,6 +3885,40 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
           );
         }
 
+        const deleteLeagueSeasonMatch = route.match(/^\/v1\/leagues\/([^/]+)\/seasons\/([^/]+)$/);
+        if (method === "DELETE" && deleteLeagueSeasonMatch) {
+          const leagueId = decodeRouteParam(deleteLeagueSeasonMatch[1]);
+          const seasonId = decodeRouteParam(deleteLeagueSeasonMatch[2]);
+          const isAdmin = await ensureLeagueAdmin(dependencies.repository, leagueId, sessionUserIds(session));
+          if (!isAdmin) {
+            status = 403;
+            return forbidden(
+              origin,
+              dependencies.corsAllowedOrigins,
+              "admin_required",
+              `Admin role is required for league ${leagueId}.`,
+            );
+          }
+
+          try {
+            const deleted = await dependencies.repository.deleteSeason(seasonId, { leagueId });
+            if (!deleted) {
+              status = 404;
+              return notFound(origin, dependencies.corsAllowedOrigins, `Season ${seasonId} was not found.`);
+            }
+          } catch (error) {
+            if (error instanceof Error && /Cannot delete season/.test(error.message)) {
+              status = 409;
+              return conflict(origin, dependencies.corsAllowedOrigins, error.message);
+            }
+
+            throw error;
+          }
+
+          status = 204;
+          return createNoContentResponse(buildCorsHeaders(origin, dependencies.corsAllowedOrigins));
+        }
+
         const deleteSeasonMatch = route.match(/^\/v1\/seasons\/([^/]+)$/);
         if (method === "DELETE" && deleteSeasonMatch) {
           const seasonId = decodeRouteParam(deleteSeasonMatch[1]);
@@ -3544,6 +3956,62 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
 
           status = 204;
           return createNoContentResponse(buildCorsHeaders(origin, dependencies.corsAllowedOrigins));
+        }
+
+        const createLeagueSeasonSessionGameMatch = route.match(
+          /^\/v1\/leagues\/([^/]+)\/seasons\/([^/]+)\/sessions\/([^/]+)\/games$/,
+        );
+        if (method === "POST" && createLeagueSeasonSessionGameMatch) {
+          const leagueId = decodeRouteParam(createLeagueSeasonSessionGameMatch[1]);
+          const seasonId = decodeRouteParam(createLeagueSeasonSessionGameMatch[2]);
+          const sessionId = decodeRouteParam(createLeagueSeasonSessionGameMatch[3]);
+          const isAdmin = await ensureLeagueAdmin(dependencies.repository, leagueId, sessionUserIds(session));
+          if (!isAdmin) {
+            status = 403;
+            return forbidden(
+              origin,
+              dependencies.corsAllowedOrigins,
+              "admin_required",
+              `Admin role is required for league ${leagueId}.`,
+            );
+          }
+
+          const season = await dependencies.repository.getSeasonForLeague(leagueId, seasonId, {
+            consistentRead: true,
+          });
+          if (!season) {
+            status = 404;
+            return notFound(origin, dependencies.corsAllowedOrigins, `Season ${seasonId} was not found.`);
+          }
+
+          const sessionRecord = await dependencies.repository.getSessionForSeason(seasonId, sessionId, {
+            leagueId,
+          });
+          if (!sessionRecord) {
+            status = 404;
+            return notFound(origin, dependencies.corsAllowedOrigins, `Session ${sessionId} was not found.`);
+          }
+
+          let rawBody: Record<string, unknown>;
+          try {
+            rawBody = parseJsonBody(event);
+          } catch {
+            status = 400;
+            return badRequest(origin, dependencies.corsAllowedOrigins, "Request body must be valid JSON.");
+          }
+
+          const mutationResponse = await createGameMutationResponse({
+            dependencies,
+            idempotencyKey,
+            session,
+            method,
+            route,
+            rawBody,
+            origin,
+            scope: { leagueId, seasonId, sessionId },
+          });
+          status = mutationResponse.statusCode;
+          return mutationResponse;
         }
 
         const createGameMatch = route.match(/^\/v1\/sessions\/([^/]+)\/games$/);
@@ -3599,6 +4067,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
               allowedOrigins: dependencies.corsAllowedOrigins,
               execute: async () => {
                 let createdGame: RepositoryGameRecord;
+                let recoveredExistingGame = false;
                 try {
                   createdGame = await dependencies.repository.createGame({
                     gameId: parsedBody.data.gameId,
@@ -3609,6 +4078,7 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
                     status: parsedBody.data.status as GameStatus | undefined,
                     gameStartTs: parsedBody.data.gameStartTs,
                     thirdLengthMinutes: parsedBody.data.thirdLengthMinutes,
+                    linkSession: true,
                   });
                 } catch (error) {
                   if (!(error instanceof GameAlreadyExistsError)) {
@@ -3648,16 +4118,21 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
                   }
 
                   createdGame = existingGame;
+                  recoveredExistingGame = true;
                 }
 
-                await dependencies.repository.createSessionGame({
-                  sessionId: createdGame.sessionId,
-                  gameId: createdGame.gameId,
-                  gameStartTs: createdGame.gameStartTs,
+                if (recoveredExistingGame) {
+                  await dependencies.repository.createSessionGame({
+                    sessionId: createdGame.sessionId,
+                    gameId: createdGame.gameId,
+                    gameStartTs: createdGame.gameStartTs,
+                    leagueId: createdGame.leagueId,
+                    seasonId: createdGame.seasonId,
+                  });
+                }
+                await ensureGameTeamsForGame(dependencies.repository, createdGame, {
                   leagueId: createdGame.leagueId,
-                  seasonId: createdGame.seasonId,
                 });
-                await ensureGameTeamsForGame(dependencies.repository, createdGame);
 
                 return createJsonResponse(
                   201,
@@ -3745,6 +4220,8 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
             (await dependencies.repository.getGame(gameId, {
               consistentRead: true,
               repairLegacyJoinCode: true,
+              expectedLeagueId: game.leagueId,
+              expectedSeasonId: game.seasonId,
             })) ?? game;
 
           status = 200;
@@ -3893,7 +4370,9 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
                 }
 
                 try {
-                  await ensureGameTeamsForGame(dependencies.repository, currentGame);
+                  await ensureGameTeamsForGame(dependencies.repository, currentGame, {
+                    leagueId: currentGame.leagueId,
+                  });
                 } catch (error) {
                   if (error instanceof GameMutationStateError) {
                     const replayResponse = await replayStoredIdempotencyMutation({
@@ -4127,7 +4606,10 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
                   );
                 }
 
-                await ensureGameTeamsForGame(dependencies.repository, currentGame, { allowFinished });
+                await ensureGameTeamsForGame(dependencies.repository, currentGame, {
+                  allowFinished,
+                  leagueId: currentGame.leagueId,
+                });
                 const result = await dependencies.repository.createGoal({
                   gameId,
                   eventId: buildGoalEventId({
@@ -4583,7 +5065,9 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
 
           let team;
           try {
-            await ensureGameTeamsForGame(dependencies.repository, game);
+            await ensureGameTeamsForGame(dependencies.repository, game, {
+              leagueId: game.leagueId,
+            });
             team = await dependencies.repository.createGameTeamOverride({
               gameId,
               teamId,
@@ -4946,7 +5430,9 @@ export function createLambdaCoreHandler(dependencies: CoreHandlerDependencies) {
             );
           }
 
-          const teams = await ensureGameTeamsForGame(dependencies.repository, game);
+          const teams = await ensureGameTeamsForGame(dependencies.repository, game, {
+            leagueId: game.leagueId,
+          });
           if (!teams.some((team) => team.teamId === parsedBody.data.teamId)) {
             status = 400;
             return badRequest(origin, dependencies.corsAllowedOrigins, "Team ID must be active for this game.");

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -2594,6 +2594,7 @@ async function createGameWithDerivedRecords(input: {
       gameStartTs: game.gameStartTs,
       leagueId: game.leagueId,
       seasonId: game.seasonId,
+      requireExistingGame: true,
     });
   }
   await ensureGameTeamsForGame(game, input.repositoryClient, {
@@ -4070,13 +4071,23 @@ async function start(): Promise<void> {
           return;
         }
 
-        await ensureSeasonDefaultTeams(seasonId);
-        const team = await repository.createTeam({
-          seasonId,
-          teamId,
-          name: parsedBody.data.name,
-          color: parsedBody.data.color ?? null,
-        });
+        let team;
+        try {
+          await ensureSeasonDefaultTeams(seasonId);
+          team = await repository.createTeam({
+            seasonId,
+            teamId,
+            name: parsedBody.data.name,
+            color: parsedBody.data.color ?? null,
+          });
+        } catch (error) {
+          if (error instanceof GameMutationStateError) {
+            status = conflict(request, response, error.message);
+            return;
+          }
+
+          throw error;
+        }
         status = 200;
         sendJsonWithCors(request, response, status, team);
         return;

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -817,9 +817,11 @@ async function readSeasonTeams(season: {
 async function ensureSeasonDefaultTeams(
   seasonId: string,
   repositoryClient: Pick<ThreeFcRepository, "listTeamsForSeason" | "createTeam"> = repository,
+  options: { leagueId?: string } = {},
 ) {
   const existingTeams = await repositoryClient.listTeamsForSeason(seasonId, {
     consistentRead: true,
+    leagueId: options.leagueId,
   });
   const teamsById = new Map(existingTeams.map((team) => [team.teamId, team]));
 
@@ -829,6 +831,7 @@ async function ensureSeasonDefaultTeams(
     }
 
     const createdTeam = await repositoryClient.createTeam({
+      leagueId: options.leagueId,
       seasonId,
       teamId: defaultTeam.teamId,
       name: defaultTeam.name,
@@ -847,9 +850,11 @@ async function ensureGameTeamsForGame(
     ThreeFcRepository,
     "listTeamsForSeason" | "createTeam" | "listTeamsForGame" | "createGameTeamOverride"
   > = repository,
-  options: { allowFinished?: boolean } = {},
+  options: { allowFinished?: boolean; leagueId?: string } = {},
 ) {
-  const seasonTeams = await ensureSeasonDefaultTeams(game.seasonId, repositoryClient);
+  const seasonTeams = await ensureSeasonDefaultTeams(game.seasonId, repositoryClient, {
+    leagueId: options.leagueId,
+  });
   const existingGameTeams = await repositoryClient.listTeamsForGame(game.gameId, {
     consistentRead: true,
   });
@@ -1471,6 +1476,7 @@ async function recoverLocalFinishedGameForFinishRoute(input: {
   if (!current || current.status !== "finished") {
     return null;
   }
+  const currentLeagueId = current.leagueId;
 
   if (isCompleteFinishedGame(current)) {
     return {
@@ -1482,7 +1488,10 @@ async function recoverLocalFinishedGameForFinishRoute(input: {
   let repaired: GameRecord | null = current;
   for (let attempt = 0; attempt < FINISHED_REPAIR_MAX_ATTEMPTS; attempt += 1) {
     try {
-      await ensureGameTeamsForGame(current, input.repositoryClient, { allowFinished: true });
+      await ensureGameTeamsForGame(current, input.repositoryClient, {
+        allowFinished: true,
+        leagueId: currentLeagueId,
+      });
       repaired = await input.repositoryClient.finishGame({ gameId: input.gameId });
       if (isCompleteFinishedGame(repaired)) {
         break;
@@ -2024,6 +2033,8 @@ export async function handleLocalGetGameRoute(input: {
     (await repositoryClient.getGame(input.gameId, {
       consistentRead: true,
       repairLegacyJoinCode: true,
+      expectedLeagueId: game.leagueId,
+      expectedSeasonId: game.seasonId,
     })) ?? game;
 
   sendJsonWithCors(input.request, input.response, 200, buildGameResponse(responseGame));
@@ -2063,7 +2074,9 @@ export async function handleLocalFinishGameRoute(input: {
         }
 
         try {
-          await ensureGameTeamsForGame(currentGame, repositoryClient);
+          await ensureGameTeamsForGame(currentGame, repositoryClient, {
+            leagueId: currentGame.leagueId,
+          });
         } catch (error) {
           if (error instanceof GameMutationStateError) {
             const recovered = await recoverLocalFinishedGameForFinishRoute({
@@ -2240,7 +2253,9 @@ export async function handleLocalUpdateGameTeamRoute(input: {
 
   let team;
   try {
-    await ensureGameTeamsForGame(game, repositoryClient);
+    await ensureGameTeamsForGame(game, repositoryClient, {
+      leagueId: game.leagueId,
+    });
     team = await repositoryClient.createGameTeamOverride({
       gameId: input.gameId,
       teamId: input.teamId,
@@ -2461,6 +2476,7 @@ async function handleCreateSession(
   sessionEmail: string,
   method: string,
   route: string,
+  leagueId?: string,
 ): Promise<number> {
   let rawBody: Record<string, unknown>;
 
@@ -2483,11 +2499,28 @@ async function handleCreateSession(
     route,
     requestPayload: parsedBody.data,
     execute: async () => {
-      const session = await repository.createSession({
-        seasonId,
-        sessionId: parsedBody.data.sessionId,
-        sessionDate: parsedBody.data.sessionDate,
-      });
+      let session: unknown;
+      try {
+        session = await repository.createSession({
+          leagueId,
+          seasonId,
+          sessionId: parsedBody.data.sessionId,
+          sessionDate: parsedBody.data.sessionDate,
+        });
+      } catch (error) {
+        if (error instanceof GameMutationStateError) {
+          return {
+            statusCode: 409,
+            payload: {
+              error: "conflict",
+              code: error.code,
+              message: error.message,
+            },
+          };
+        }
+
+        throw error;
+      }
 
       return {
         statusCode: 201,
@@ -2500,6 +2533,7 @@ async function handleCreateSession(
 async function createGameWithDerivedRecords(input: {
   repositoryClient: LocalCreateGameRouteRepository;
   scope: { leagueId: string; seasonId: string; sessionId: string };
+  seasonTeamLeagueId?: string;
   allowExistingGameRecovery: boolean;
   request: {
     gameId: string;
@@ -2510,6 +2544,7 @@ async function createGameWithDerivedRecords(input: {
   createRequestHash: string | null;
 }) {
   let game;
+  let recoveredExistingGame = false;
   try {
     game = await input.repositoryClient.createGame({
       gameId: input.request.gameId,
@@ -2520,6 +2555,7 @@ async function createGameWithDerivedRecords(input: {
       status: input.request.status,
       gameStartTs: input.request.gameStartTs,
       thirdLengthMinutes: input.request.thirdLengthMinutes,
+      linkSession: true,
     });
   } catch (error) {
     if (!(error instanceof GameAlreadyExistsError)) {
@@ -2548,16 +2584,21 @@ async function createGameWithDerivedRecords(input: {
     }
 
     game = existingGame;
+    recoveredExistingGame = true;
   }
 
-  await input.repositoryClient.createSessionGame({
-    sessionId: game.sessionId,
-    gameId: game.gameId,
-    gameStartTs: game.gameStartTs,
-    leagueId: game.leagueId,
-    seasonId: game.seasonId,
+  if (recoveredExistingGame) {
+    await input.repositoryClient.createSessionGame({
+      sessionId: game.sessionId,
+      gameId: game.gameId,
+      gameStartTs: game.gameStartTs,
+      leagueId: game.leagueId,
+      seasonId: game.seasonId,
+    });
+  }
+  await ensureGameTeamsForGame(game, input.repositoryClient, {
+    leagueId: input.seasonTeamLeagueId,
   });
-  await ensureGameTeamsForGame(game, input.repositoryClient);
 
   return game;
 }
@@ -2609,6 +2650,7 @@ export async function handleLocalCreateGameRoute(input: {
         const game = await createGameWithDerivedRecords({
           repositoryClient,
           scope: input.scope,
+          seasonTeamLeagueId: input.scope.leagueId,
           allowExistingGameRecovery: createRequestHash !== null,
           request: parsedBody.data,
           createRequestHash,
@@ -2652,6 +2694,9 @@ export async function handleLocalCreateGameRoute(input: {
       }
 
       return gameJoinCodeCollisionConflict(input.request, input.response);
+    }
+    if (error instanceof GameMutationStateError) {
+      return conflict(input.request, input.response, error.message);
     }
 
     throw error;
@@ -3668,6 +3713,102 @@ async function start(): Promise<void> {
         return;
       }
 
+      const getLeagueSeasonMatch = route.match(/^\/v1\/leagues\/([^/]+)\/seasons\/([^/]+)$/);
+      if (method === "GET" && getLeagueSeasonMatch) {
+        if (!authGate.session) {
+          status = 500;
+          sendJsonWithCors(request, response, status, {
+            error: "internal_error",
+            message: "Session should be available for authenticated route.",
+          });
+          return;
+        }
+
+        const leagueId = decodeURIComponent(getLeagueSeasonMatch[1]);
+        const seasonId = decodeURIComponent(getLeagueSeasonMatch[2]);
+        const access = await ensureLeagueAccess(leagueId, sessionUserIds(authGate.session));
+        if (!access.allowed) {
+          status = forbidden(
+            request,
+            response,
+            "league_access_required",
+            `Access to league ${leagueId} is required.`,
+          );
+          return;
+        }
+
+        const season = await repository.getSeasonForLeague(leagueId, seasonId, {
+          consistentRead: true,
+        });
+        if (!season) {
+          status = notFound(request, response, `Season ${seasonId} was not found.`);
+          return;
+        }
+
+        status = 200;
+        sendJsonWithCors(request, response, status, season);
+        return;
+      }
+
+      const listLeagueSeasonGamesMatch = route.match(/^\/v1\/leagues\/([^/]+)\/seasons\/([^/]+)\/games$/);
+      if (method === "GET" && listLeagueSeasonGamesMatch) {
+        if (!authGate.session) {
+          status = 500;
+          sendJsonWithCors(request, response, status, {
+            error: "internal_error",
+            message: "Session should be available for authenticated route.",
+          });
+          return;
+        }
+
+        const leagueId = decodeURIComponent(listLeagueSeasonGamesMatch[1]);
+        const seasonId = decodeURIComponent(listLeagueSeasonGamesMatch[2]);
+        const access = await ensureLeagueAccess(leagueId, sessionUserIds(authGate.session));
+        if (!access.allowed) {
+          status = forbidden(
+            request,
+            response,
+            "league_access_required",
+            `Access to league ${leagueId} is required.`,
+          );
+          return;
+        }
+
+        const season = await repository.getSeasonForLeague(leagueId, seasonId, {
+          consistentRead: true,
+        });
+        if (!season) {
+          status = notFound(request, response, `Season ${seasonId} was not found.`);
+          return;
+        }
+
+        const games = await repository.listGamesForSeason(seasonId, { leagueId });
+        const gamesWithUsableJoinCodes = await Promise.all(
+          games.map(async (game) => {
+            const refreshedGame = await repository.getGame(game.gameId, {
+              consistentRead: true,
+              repairLegacyJoinCode: true,
+              expectedLeagueId: leagueId,
+              expectedSeasonId: seasonId,
+            });
+            if (
+              !refreshedGame ||
+              refreshedGame.leagueId !== leagueId ||
+              refreshedGame.seasonId !== seasonId
+            ) {
+              return game;
+            }
+
+            return refreshedGame;
+          }),
+        );
+        status = 200;
+        sendJsonWithCors(request, response, status, {
+          games: gamesWithUsableJoinCodes.map((game) => buildGameResponse(game)),
+        });
+        return;
+      }
+
       const deleteLeagueMatch = route.match(/^\/v1\/leagues\/([^/]+)$/);
       if (method === "DELETE" && deleteLeagueMatch) {
         if (!authGate.session) {
@@ -3708,6 +3849,50 @@ async function start(): Promise<void> {
 
         status = 204;
         sendNoContentWithCors(request, response);
+        return;
+      }
+
+      const createLeagueSeasonSessionMatch = route.match(/^\/v1\/leagues\/([^/]+)\/seasons\/([^/]+)\/sessions$/);
+      if (method === "POST" && createLeagueSeasonSessionMatch) {
+        if (!authGate.session) {
+          status = 500;
+          sendJsonWithCors(request, response, status, {
+            error: "internal_error",
+            message: "Session should be available for authenticated route.",
+          });
+          return;
+        }
+
+        const leagueId = decodeURIComponent(createLeagueSeasonSessionMatch[1]);
+        const seasonId = decodeURIComponent(createLeagueSeasonSessionMatch[2]);
+        const isAdmin = await ensureLeagueAdmin(leagueId, sessionUserIds(authGate.session));
+        if (!isAdmin) {
+          status = forbidden(
+            request,
+            response,
+            "admin_required",
+            `Admin role is required for league ${leagueId}.`,
+          );
+          return;
+        }
+
+        const season = await repository.getSeasonForLeague(leagueId, seasonId, {
+          consistentRead: true,
+        });
+        if (!season) {
+          status = notFound(request, response, `Season ${seasonId} was not found.`);
+          return;
+        }
+
+        status = await handleCreateSession(
+          request,
+          response,
+          seasonId,
+          authGate.session.email,
+          method,
+          route,
+          leagueId,
+        );
         return;
       }
 
@@ -3796,15 +3981,26 @@ async function start(): Promise<void> {
           return;
         }
 
-        const games = await repository.listGamesForSeason(seasonId);
+        const games = await repository.listGamesForSeason(seasonId, {
+          leagueId: season.leagueId,
+        });
         const gamesWithUsableJoinCodes = await Promise.all(
           games.map(async (game) => {
-            return (
-              (await repository.getGame(game.gameId, {
-                consistentRead: true,
-                repairLegacyJoinCode: true,
-              })) ?? game
-            );
+            const refreshedGame = await repository.getGame(game.gameId, {
+              consistentRead: true,
+              repairLegacyJoinCode: true,
+              expectedLeagueId: season.leagueId,
+              expectedSeasonId: seasonId,
+            });
+            if (
+              !refreshedGame ||
+              refreshedGame.leagueId !== season.leagueId ||
+              refreshedGame.seasonId !== seasonId
+            ) {
+              return game;
+            }
+
+            return refreshedGame;
           }),
         );
         status = 200;
@@ -3886,6 +4082,50 @@ async function start(): Promise<void> {
         return;
       }
 
+      const deleteLeagueSeasonMatch = route.match(/^\/v1\/leagues\/([^/]+)\/seasons\/([^/]+)$/);
+      if (method === "DELETE" && deleteLeagueSeasonMatch) {
+        if (!authGate.session) {
+          status = 500;
+          sendJsonWithCors(request, response, status, {
+            error: "internal_error",
+            message: "Session should be available for authenticated route.",
+          });
+          return;
+        }
+
+        const leagueId = decodeURIComponent(deleteLeagueSeasonMatch[1]);
+        const seasonId = decodeURIComponent(deleteLeagueSeasonMatch[2]);
+        const isAdmin = await ensureLeagueAdmin(leagueId, sessionUserIds(authGate.session));
+        if (!isAdmin) {
+          status = forbidden(
+            request,
+            response,
+            "admin_required",
+            `Admin role is required for league ${leagueId}.`,
+          );
+          return;
+        }
+
+        try {
+          const deleted = await repository.deleteSeason(seasonId, { leagueId });
+          if (!deleted) {
+            status = notFound(request, response, `Season ${seasonId} was not found.`);
+            return;
+          }
+        } catch (error) {
+          if (error instanceof Error && /Cannot delete season/.test(error.message)) {
+            status = conflict(request, response, error.message);
+            return;
+          }
+
+          throw error;
+        }
+
+        status = 204;
+        sendNoContentWithCors(request, response);
+        return;
+      }
+
       const deleteSeasonMatch = route.match(/^\/v1\/seasons\/([^/]+)$/);
       if (method === "DELETE" && deleteSeasonMatch) {
         if (!authGate.session) {
@@ -3928,6 +4168,57 @@ async function start(): Promise<void> {
 
         status = 204;
         sendNoContentWithCors(request, response);
+        return;
+      }
+
+      const createLeagueSeasonSessionGameMatch = route.match(
+        /^\/v1\/leagues\/([^/]+)\/seasons\/([^/]+)\/sessions\/([^/]+)\/games$/,
+      );
+      if (method === "POST" && createLeagueSeasonSessionGameMatch) {
+        if (!authGate.session) {
+          status = 500;
+          sendJsonWithCors(request, response, status, {
+            error: "internal_error",
+            message: "Session should be available for authenticated route.",
+          });
+          return;
+        }
+
+        const leagueId = decodeURIComponent(createLeagueSeasonSessionGameMatch[1]);
+        const seasonId = decodeURIComponent(createLeagueSeasonSessionGameMatch[2]);
+        const sessionId = decodeURIComponent(createLeagueSeasonSessionGameMatch[3]);
+        const isAdmin = await ensureLeagueAdmin(leagueId, sessionUserIds(authGate.session));
+        if (!isAdmin) {
+          status = forbidden(
+            request,
+            response,
+            "admin_required",
+            `Admin role is required for league ${leagueId}.`,
+          );
+          return;
+        }
+
+        const season = await repository.getSeasonForLeague(leagueId, seasonId, {
+          consistentRead: true,
+        });
+        if (!season) {
+          status = notFound(request, response, `Season ${seasonId} was not found.`);
+          return;
+        }
+
+        const session = await repository.getSessionForSeason(seasonId, sessionId, {
+          leagueId,
+        });
+        if (!session) {
+          status = notFound(request, response, `Session ${sessionId} was not found.`);
+          return;
+        }
+
+        status = await handleCreateGame(request, response, {
+          leagueId,
+          seasonId,
+          sessionId,
+        }, authGate.session.email, method, route);
         return;
       }
 
@@ -4139,7 +4430,10 @@ async function start(): Promise<void> {
                 );
               }
 
-              await ensureGameTeamsForGame(currentGame, repository, { allowFinished });
+              await ensureGameTeamsForGame(currentGame, repository, {
+                allowFinished,
+                leagueId: currentGame.leagueId,
+              });
               const result = await repository.createGoal({
                 gameId,
                 eventId: buildGoalEventId({
@@ -4923,7 +5217,9 @@ async function start(): Promise<void> {
           return;
         }
 
-        const teams = await ensureGameTeamsForGame(game);
+        const teams = await ensureGameTeamsForGame(game, repository, {
+          leagueId: game.leagueId,
+        });
         if (!teams.some((team) => team.teamId === parsedBody.data.teamId)) {
           status = badRequest(request, response, "Team ID must be active for this game.");
           return;

--- a/api/src/tests/deployment-config.test.ts
+++ b/api/src/tests/deployment-config.test.ts
@@ -23,6 +23,15 @@ test("api core deployment config registers claim and access routes", () => {
   assertServerlessRoute("OPTIONS", "/v1/leagues/{leagueId}/organiser-invites");
   assertServerlessRoute("POST", "/v1/invites/{inviteCode}/accept");
   assertServerlessRoute("OPTIONS", "/v1/invites/{inviteCode}/accept");
+  assertServerlessRoute("GET", "/v1/leagues/{leagueId}/seasons/{seasonId}");
+  assertServerlessRoute("DELETE", "/v1/leagues/{leagueId}/seasons/{seasonId}");
+  assertServerlessRoute("OPTIONS", "/v1/leagues/{leagueId}/seasons/{seasonId}");
+  assertServerlessRoute("GET", "/v1/leagues/{leagueId}/seasons/{seasonId}/games");
+  assertServerlessRoute("OPTIONS", "/v1/leagues/{leagueId}/seasons/{seasonId}/games");
+  assertServerlessRoute("POST", "/v1/leagues/{leagueId}/seasons/{seasonId}/sessions");
+  assertServerlessRoute("OPTIONS", "/v1/leagues/{leagueId}/seasons/{seasonId}/sessions");
+  assertServerlessRoute("POST", "/v1/leagues/{leagueId}/seasons/{seasonId}/sessions/{sessionId}/games");
+  assertServerlessRoute("OPTIONS", "/v1/leagues/{leagueId}/seasons/{seasonId}/sessions/{sessionId}/games");
 });
 
 test("api core deployment config sets canonical public invite link origins", () => {

--- a/api/src/tests/lambda-core.test.ts
+++ b/api/src/tests/lambda-core.test.ts
@@ -220,6 +220,7 @@ interface CreatedSessionGameInput {
   gameStartTs: string;
   leagueId: string;
   seasonId: string;
+  requireExistingGame?: boolean;
 }
 
 interface StoredIdempotencyRecord {
@@ -321,6 +322,17 @@ function buildTestIdempotencyRequestHash(scope: string, payload: unknown): strin
   return createHash("sha256")
     .update(`${scope}:${JSON.stringify(normalizePayloadForTestHash(payload))}`)
     .digest("hex");
+}
+
+function buildTestKeyedRecoveryRequestHash(input: {
+  scope: string;
+  idempotencyKey: string;
+  payload: unknown;
+}): string {
+  return buildTestIdempotencyRequestHash(input.scope, {
+    idempotencyKey: input.idempotencyKey,
+    payload: input.payload,
+  });
 }
 
 function buildTestOrganiserInviteCode(scope: string, idempotencyKey: string): string {
@@ -5065,6 +5077,99 @@ test("core lambda recovers idempotent create game retry after atomic session-lin
   const replayResponse = await harness.handler(event);
   assert.equal(replayResponse.statusCode, 201);
   assert.equal(harness.createdSessionGames.length, 1);
+});
+
+test("core lambda guards duplicate-game recovery session linking with the existing game", async () => {
+  const key = "create-game-existing-recover-1";
+  const route = "/v1/sessions/session-abc/games";
+  const scope = `admin@example.com:POST:${route}`;
+  const requestPayload = {
+    gameId: "game-1",
+    gameStartTs: "2026-02-23T10:00:00Z",
+  };
+  const harness = createHarness({
+    sessions: {
+      "session-1": {
+        sessionId: "session-1",
+        email: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    seasonSessions: {
+      "session-abc": {
+        seasonId: "season-1",
+        sessionId: "session-abc",
+        sessionDate: "2026-02-23",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    seasons: {
+      "season-1": {
+        leagueId: "league-1",
+        seasonId: "season-1",
+        name: "Season 1",
+        slug: null,
+        startsOn: null,
+        endsOn: null,
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    games: {
+      "game-1": {
+        gameId: "game-1",
+        createRequestHash: buildTestKeyedRecoveryRequestHash({
+          scope,
+          idempotencyKey: key,
+          payload: requestPayload,
+        }),
+        leagueId: "league-1",
+        seasonId: "season-1",
+        sessionId: "session-abc",
+        status: "scheduled",
+        gameStartTs: "2026-02-23T10:00:00Z",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueAccess: {
+      "league-1:admin@example.com": {
+        leagueId: "league-1",
+        userId: "admin@example.com",
+        role: "admin",
+        grantedByUserId: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  const response = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: route,
+      headers: {
+        Cookie: "threefc_session=session-1",
+        "Idempotency-Key": key,
+      },
+      body: requestPayload,
+    }),
+  );
+
+  assert.equal(response.statusCode, 201);
+  assert.equal(harness.createdGames.length, 0);
+  assert.deepEqual(harness.createdSessionGames, [
+    {
+      sessionId: "session-abc",
+      gameId: "game-1",
+      gameStartTs: "2026-02-23T10:00:00Z",
+      leagueId: "league-1",
+      seasonId: "season-1",
+      requireExistingGame: true,
+    },
+  ]);
 });
 
 test("core lambda maps duplicate game IDs to conflict on game creation", async () => {

--- a/api/src/tests/lambda-core.test.ts
+++ b/api/src/tests/lambda-core.test.ts
@@ -116,6 +116,7 @@ type MockGameInput = Omit<MockGameRecord, "joinCode" | "thirdLengthMinutes" | "t
   Partial<Pick<MockGameRecord, "joinCode" | "thirdLengthMinutes" | "thirds" | "finishedAt" | "result">>;
 
 interface MockSeasonTeamRecord {
+  leagueId?: string;
   seasonId: string;
   teamId: TeamId;
   name: string;
@@ -257,6 +258,11 @@ interface HarnessConfig {
   assignRosterPlayerStateChangedOnce?: boolean;
   finishBeforeGoalCorrectionOnce?: boolean;
   createSessionGameFailures?: number;
+  afterListGamesForSeason?: (input: {
+    seasonId: string;
+    leagueId: string | null;
+    games: Map<string, MockGameRecord>;
+  }) => void;
   rateLimitDecision?:
     | RateLimitDecision
     | ((input: { email: string; clientIp: string }) => RateLimitDecision);
@@ -344,6 +350,7 @@ function createHarness(config: HarnessConfig = {}) {
   const createdGames: CreatedGameInput[] = [];
   const createdSessionGames: CreatedSessionGameInput[] = [];
   const createdSeasonTeams: Array<{
+    leagueId?: string;
     seasonId: string;
     teamId: TeamId;
     name: string;
@@ -386,9 +393,14 @@ function createHarness(config: HarnessConfig = {}) {
     gameId: string;
     consistentRead: boolean;
     repairLegacyJoinCode: boolean;
+    expectedLeagueId: string | null;
+    expectedSeasonId: string | null;
   }> = [];
+  const getSessionForSeasonCalls: Array<{ seasonId: string; sessionId: string; leagueId: string | null }> = [];
+  const listGamesForSeasonCalls: Array<{ seasonId: string; leagueId: string | null }> = [];
+  const getSeasonForLeagueCalls: Array<{ leagueId: string; seasonId: string; consistentRead: boolean }> = [];
   const grantedLeagueAccess: MockLeagueAccessRecord[] = [];
-  const listTeamsForSeasonCalls: Array<{ seasonId: string; consistentRead: boolean }> = [];
+  const listTeamsForSeasonCalls: Array<{ seasonId: string; consistentRead: boolean; leagueId: string | null }> = [];
   const listTeamsForGameCalls: Array<{ gameId: string; consistentRead: boolean }> = [];
   const idempotencyRecords = new Map<string, StoredIdempotencyRecord>();
   let finishGameStateChangedOnce = config.finishGameStateChangedOnce ?? false;
@@ -411,6 +423,8 @@ function createHarness(config: HarnessConfig = {}) {
   const sessionEntities = new Map<string, MockSessionEntity>(
     Object.entries(config.seasonSessions ?? {}),
   );
+  const scopedSessionKey = (leagueId: string | undefined, seasonId: string, sessionId: string) =>
+    leagueId ? `${leagueId}:${seasonId}:${sessionId}` : sessionId;
   const games = new Map<string, MockGameRecord>(
     Object.entries(config.games ?? {}).map(([gameId, game]) => [
       gameId,
@@ -824,6 +838,19 @@ function createHarness(config: HarnessConfig = {}) {
       async getLeague(leagueId: string) {
         return leagues.get(leagueId) ?? null;
       },
+      async getSeasonForLeague(
+        leagueId: string,
+        seasonId: string,
+        options: { consistentRead?: boolean } = {},
+      ) {
+        getSeasonForLeagueCalls.push({
+          leagueId,
+          seasonId,
+          consistentRead: options.consistentRead ?? false,
+        });
+        const season = seasons.get(seasonId) ?? null;
+        return season?.leagueId === leagueId ? season : null;
+      },
       async listSeasonsForLeague(leagueId: string) {
         return [...seasons.values()].filter((season) => season.leagueId === leagueId);
       },
@@ -844,8 +871,12 @@ function createHarness(config: HarnessConfig = {}) {
       },
       async createTeam(input) {
         createdSeasonTeams.push(input);
-        const existing = seasonTeams.get(`${input.seasonId}:${input.teamId}`);
+        const teamKey = input.leagueId
+          ? `${input.leagueId}:${input.seasonId}:${input.teamId}`
+          : `${input.seasonId}:${input.teamId}`;
+        const existing = seasonTeams.get(teamKey);
         const record = {
+          ...(input.leagueId ? { leagueId: input.leagueId } : {}),
           seasonId: input.seasonId,
           teamId: input.teamId,
           name: input.name,
@@ -853,12 +884,22 @@ function createHarness(config: HarnessConfig = {}) {
           createdAt: existing?.createdAt ?? "2026-02-23T00:00:00.000Z",
           updatedAt: "2026-02-23T00:00:00.000Z",
         };
-        seasonTeams.set(`${input.seasonId}:${input.teamId}`, record);
+        seasonTeams.set(teamKey, record);
         return record;
       },
-      async listTeamsForSeason(seasonId: string, options: { consistentRead?: boolean } = {}) {
-        listTeamsForSeasonCalls.push({ seasonId, consistentRead: options.consistentRead ?? false });
-        return [...seasonTeams.values()].filter((team) => team.seasonId === seasonId);
+      async listTeamsForSeason(seasonId: string, options: { consistentRead?: boolean; leagueId?: string } = {}) {
+        listTeamsForSeasonCalls.push({
+          seasonId,
+          consistentRead: options.consistentRead ?? false,
+          leagueId: options.leagueId ?? null,
+        });
+        return [...seasonTeams.values()].filter((team) => {
+          if (team.seasonId !== seasonId) {
+            return false;
+          }
+
+          return !options.leagueId || team.leagueId === options.leagueId;
+        });
       },
       async createGameTeamOverride(input) {
         if (createGameTeamOverrideFinishesIncompleteOnce) {
@@ -923,7 +964,7 @@ function createHarness(config: HarnessConfig = {}) {
           createdAt: "2026-02-23T00:00:00.000Z",
           updatedAt: "2026-02-23T00:00:00.000Z",
         };
-        sessionEntities.set(input.sessionId, record);
+        sessionEntities.set(scopedSessionKey(input.leagueId, input.seasonId, input.sessionId), record);
         return record;
       },
       async createGame(input) {
@@ -937,6 +978,10 @@ function createHarness(config: HarnessConfig = {}) {
           )
         ) {
           throw new GameJoinCodeCollisionError();
+        }
+        if (input.linkSession === true && createSessionGameFailures > 0) {
+          createSessionGameFailures -= 1;
+          throw new Error("Session game index write failed.");
         }
 
         createdGames.push(input);
@@ -957,6 +1002,15 @@ function createHarness(config: HarnessConfig = {}) {
           updatedAt: "2026-02-23T00:00:00.000Z",
         };
         games.set(input.gameId, record);
+        if (input.linkSession === true) {
+          createdSessionGames.push({
+            sessionId: input.sessionId,
+            gameId: input.gameId,
+            gameStartTs: input.gameStartTs,
+            leagueId: input.leagueId,
+            seasonId: input.seasonId,
+          });
+        }
         return record;
       },
       async createSessionGame(input) {
@@ -968,17 +1022,34 @@ function createHarness(config: HarnessConfig = {}) {
         createdSessionGames.push(input);
         return input;
       },
-      async listGamesForSeason(seasonId: string) {
-        return [...games.values()].filter((game) => game.seasonId === seasonId);
+      async listGamesForSeason(seasonId: string, options: { leagueId?: string } = {}) {
+        const leagueId = options.leagueId ?? null;
+        listGamesForSeasonCalls.push({ seasonId, leagueId });
+        const listedGames = [...games.values()].filter((game) => {
+          if (game.seasonId !== seasonId) {
+            return false;
+          }
+
+          return !options.leagueId || game.leagueId === options.leagueId;
+        });
+        config.afterListGamesForSeason?.({ seasonId, leagueId, games });
+        return listedGames;
       },
       async getGame(
         gameId: string,
-        options: { consistentRead?: boolean; repairLegacyJoinCode?: boolean } = {},
+        options: {
+          consistentRead?: boolean;
+          repairLegacyJoinCode?: boolean;
+          expectedLeagueId?: string;
+          expectedSeasonId?: string;
+        } = {},
       ) {
         getGameCalls.push({
           gameId,
           consistentRead: options.consistentRead ?? false,
           repairLegacyJoinCode: options.repairLegacyJoinCode ?? false,
+          expectedLeagueId: options.expectedLeagueId ?? null,
+          expectedSeasonId: options.expectedSeasonId ?? null,
         });
         const game = games.get(gameId) ?? null;
         if (
@@ -1001,7 +1072,11 @@ function createHarness(config: HarnessConfig = {}) {
         }
 
         const repairedJoinCode = config.legacyJoinCodeRepairs?.[gameId];
-        if (game && options.repairLegacyJoinCode && repairedJoinCode) {
+        const repairScopeMatches =
+          game &&
+          (options.expectedLeagueId === undefined || game.leagueId === options.expectedLeagueId) &&
+          (options.expectedSeasonId === undefined || game.seasonId === options.expectedSeasonId);
+        if (game && options.repairLegacyJoinCode && repairScopeMatches && repairedJoinCode) {
           const repairedGame = {
             ...game,
             joinCode: repairedJoinCode,
@@ -1316,7 +1391,12 @@ function createHarness(config: HarnessConfig = {}) {
         deletedGames.push(gameId);
         return games.delete(gameId);
       },
-      async deleteSeason(seasonId: string) {
+      async deleteSeason(seasonId: string, options: { leagueId?: string } = {}) {
+        const season = seasons.get(seasonId);
+        if (!season || (options.leagueId && season.leagueId !== options.leagueId)) {
+          return false;
+        }
+
         return seasons.delete(seasonId);
       },
       async deleteLeague(leagueId: string) {
@@ -1823,6 +1903,11 @@ function createHarness(config: HarnessConfig = {}) {
       async getSession(sessionId: string) {
         return sessionEntities.get(sessionId) ?? null;
       },
+      async getSessionForSeason(seasonId: string, sessionId: string, options: { leagueId?: string } = {}) {
+        getSessionForSeasonCalls.push({ seasonId, sessionId, leagueId: options.leagueId ?? null });
+        const session = sessionEntities.get(scopedSessionKey(options.leagueId, seasonId, sessionId)) ?? null;
+        return session?.seasonId === seasonId ? session : null;
+      },
       async getIdempotencyRecord(scope: string, key: string) {
         const recordKey = `${scope}:${key}`;
         const readCount = (idempotencyRecordReads.get(recordKey) ?? 0) + 1;
@@ -1913,7 +1998,10 @@ function createHarness(config: HarnessConfig = {}) {
     magicLinkCompletes,
     magicLinkRateLimitChecks,
     grantedLeagueAccess,
+    listGamesForSeasonCalls,
+    getSeasonForLeagueCalls,
     getGameCalls,
+    getSessionForSeasonCalls,
     listTeamsForSeasonCalls,
     listTeamsForGameCalls,
     idempotencyRecords,
@@ -2346,6 +2434,8 @@ test("core lambda does not repair legacy join codes before game access is author
       gameId: "game-legacy",
       consistentRead: false,
       repairLegacyJoinCode: false,
+      expectedLeagueId: null,
+      expectedSeasonId: null,
     },
   ]);
 });
@@ -2405,11 +2495,277 @@ test("core lambda repairs legacy join codes only after game access is authorized
       gameId: "game-legacy",
       consistentRead: false,
       repairLegacyJoinCode: false,
+      expectedLeagueId: null,
+      expectedSeasonId: null,
     },
     {
       gameId: "game-legacy",
       consistentRead: true,
       repairLegacyJoinCode: true,
+      expectedLeagueId: "league-1",
+      expectedSeasonId: "season-1",
+    },
+  ]);
+});
+
+test("core lambda scopes season game listings to the authorized season league", async () => {
+  const harness = createHarness({
+    sessions: {
+      "session-1": {
+        sessionId: "session-1",
+        email: "viewer@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    seasons: {
+      "season-1": {
+        leagueId: "league-1",
+        seasonId: "season-1",
+        name: "Season 1",
+        slug: null,
+        startsOn: null,
+        endsOn: null,
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    games: {
+      "game-visible": {
+        gameId: "game-visible",
+        joinCode: "JOIN1111",
+        leagueId: "league-1",
+        seasonId: "season-1",
+        sessionId: "shared-session",
+        status: "scheduled",
+        gameStartTs: "2026-02-23T10:00:00.000Z",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+      "game-other-league": {
+        gameId: "game-other-league",
+        joinCode: "JOIN2222",
+        leagueId: "league-2",
+        seasonId: "season-1",
+        sessionId: "shared-session",
+        status: "scheduled",
+        gameStartTs: "2026-02-23T10:05:00.000Z",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueAccess: {
+      "league-1:viewer@example.com": {
+        leagueId: "league-1",
+        userId: "viewer@example.com",
+        role: "viewer",
+        grantedByUserId: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  const response = await harness.handler(
+    createEvent({
+      method: "GET",
+      path: "/v1/seasons/season-1/games",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+    }),
+  );
+
+  assert.equal(response.statusCode, 200);
+  const body = JSON.parse(response.body) as { games: Array<{ gameId: string }> };
+  assert.deepEqual(
+    body.games.map((game) => game.gameId),
+    ["game-visible"],
+  );
+  assert.deepEqual(harness.listGamesForSeasonCalls, [{ seasonId: "season-1", leagueId: "league-1" }]);
+  assert.deepEqual(harness.getGameCalls, [
+    {
+      gameId: "game-visible",
+      consistentRead: true,
+      repairLegacyJoinCode: true,
+      expectedLeagueId: "league-1",
+      expectedSeasonId: "season-1",
+    },
+  ]);
+});
+
+test("core lambda serves league-scoped season game listings without global season lookup", async () => {
+  const harness = createHarness({
+    sessions: {
+      "session-1": {
+        sessionId: "session-1",
+        email: "viewer@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    seasons: {
+      "season-1": {
+        leagueId: "league-1",
+        seasonId: "season-1",
+        name: "Season 1",
+        slug: null,
+        startsOn: null,
+        endsOn: null,
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    games: {
+      "game-visible": {
+        gameId: "game-visible",
+        joinCode: "JOIN1111",
+        leagueId: "league-1",
+        seasonId: "season-1",
+        sessionId: "shared-session",
+        status: "scheduled",
+        gameStartTs: "2026-02-23T10:00:00.000Z",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+      "game-other-league": {
+        gameId: "game-other-league",
+        joinCode: "JOIN2222",
+        leagueId: "league-2",
+        seasonId: "season-1",
+        sessionId: "shared-session",
+        status: "scheduled",
+        gameStartTs: "2026-02-23T10:05:00.000Z",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueAccess: {
+      "league-1:viewer@example.com": {
+        leagueId: "league-1",
+        userId: "viewer@example.com",
+        role: "viewer",
+        grantedByUserId: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  const response = await harness.handler(
+    createEvent({
+      method: "GET",
+      path: "/v1/leagues/league-1/seasons/season-1/games",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+    }),
+  );
+
+  assert.equal(response.statusCode, 200);
+  const body = JSON.parse(response.body) as { games: Array<{ gameId: string }> };
+  assert.deepEqual(
+    body.games.map((game) => game.gameId),
+    ["game-visible"],
+  );
+  assert.deepEqual(harness.getSeasonForLeagueCalls, [
+    { leagueId: "league-1", seasonId: "season-1", consistentRead: true },
+  ]);
+  assert.deepEqual(harness.listGamesForSeasonCalls, [{ seasonId: "season-1", leagueId: "league-1" }]);
+});
+
+test("core lambda keeps scoped season listing when join-code refresh sees foreign game metadata", async () => {
+  const harness = createHarness({
+    sessions: {
+      "session-1": {
+        sessionId: "session-1",
+        email: "viewer@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    seasons: {
+      "season-1": {
+        leagueId: "league-1",
+        seasonId: "season-1",
+        name: "Season 1",
+        slug: null,
+        startsOn: null,
+        endsOn: null,
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    games: {
+      "game-visible": {
+        gameId: "game-visible",
+        joinCode: "JOIN1111",
+        leagueId: "league-1",
+        seasonId: "season-1",
+        sessionId: "shared-session",
+        status: "scheduled",
+        gameStartTs: "2026-02-23T10:00:00.000Z",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    legacyJoinCodeRepairs: {
+      "game-visible": "JOIN3333",
+    },
+    leagueAccess: {
+      "league-1:viewer@example.com": {
+        leagueId: "league-1",
+        userId: "viewer@example.com",
+        role: "viewer",
+        grantedByUserId: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    afterListGamesForSeason: ({ games }) => {
+      const listedGame = games.get("game-visible");
+      if (!listedGame) {
+        return;
+      }
+
+      games.set("game-visible", {
+        ...listedGame,
+        joinCode: "JOIN2222",
+        leagueId: "league-2",
+        updatedAt: "2026-02-23T00:00:01.000Z",
+      });
+    },
+  });
+
+  const response = await harness.handler(
+    createEvent({
+      method: "GET",
+      path: "/v1/leagues/league-1/seasons/season-1/games",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+    }),
+  );
+
+  assert.equal(response.statusCode, 200);
+  const body = JSON.parse(response.body) as {
+    games: Array<{ gameId: string; leagueId: string; joinCode: string }>;
+  };
+  assert.deepEqual(
+    body.games.map((game) => ({
+      gameId: game.gameId,
+      leagueId: game.leagueId,
+      joinCode: game.joinCode,
+    })),
+    [{ gameId: "game-visible", leagueId: "league-1", joinCode: "JOIN1111" }],
+  );
+  assert.deepEqual(harness.getGameCalls, [
+    {
+      gameId: "game-visible",
+      consistentRead: true,
+      repairLegacyJoinCode: true,
+      expectedLeagueId: "league-1",
+      expectedSeasonId: "season-1",
     },
   ]);
 });
@@ -2484,6 +2840,8 @@ test("core lambda repairs legacy join codes in authorized season game listings",
       gameId: "game-legacy",
       consistentRead: true,
       repairLegacyJoinCode: true,
+      expectedLeagueId: "league-1",
+      expectedSeasonId: "season-1",
     },
   ]);
 });
@@ -4408,6 +4766,154 @@ test("core lambda creates game for admin with resolved ACL scope", async () => {
   );
 });
 
+test("core lambda creates league-scoped games from sessions in the requested league", async () => {
+  const harness = createHarness({
+    sessions: {
+      "session-1": {
+        sessionId: "session-1",
+        email: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    seasonSessions: {
+      "league-1:season-1:session-abc": {
+        seasonId: "season-1",
+        sessionId: "session-abc",
+        sessionDate: "2026-02-23",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    seasons: {
+      "season-1": {
+        leagueId: "league-1",
+        seasonId: "season-1",
+        name: "Season 1",
+        slug: null,
+        startsOn: null,
+        endsOn: null,
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueAccess: {
+      "league-1:admin@example.com": {
+        leagueId: "league-1",
+        userId: "admin@example.com",
+        role: "admin",
+        grantedByUserId: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  const response = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/leagues/league-1/seasons/season-1/sessions/session-abc/games",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+      body: {
+        gameId: "game-1",
+        gameStartTs: "2026-02-23T10:00:00Z",
+      },
+    }),
+  );
+
+  assert.equal(response.statusCode, 201);
+  assert.deepEqual(harness.getSeasonForLeagueCalls, [
+    { leagueId: "league-1", seasonId: "season-1", consistentRead: true },
+  ]);
+  assert.deepEqual(harness.getSessionForSeasonCalls, [
+    { seasonId: "season-1", sessionId: "session-abc", leagueId: "league-1" },
+  ]);
+  assert.equal(harness.createdGames[0]?.leagueId, "league-1");
+  assert.equal(harness.createdGames[0]?.seasonId, "season-1");
+  assert.equal(harness.createdGames[0]?.sessionId, "session-abc");
+  assert.deepEqual(
+    harness.createdSeasonTeams.map((team) => ({ leagueId: team.leagueId, teamId: team.teamId })),
+    [
+      { leagueId: "league-1", teamId: "red" },
+      { leagueId: "league-1", teamId: "blue" },
+      { leagueId: "league-1", teamId: "yellow" },
+    ],
+  );
+  assert.deepEqual(harness.listTeamsForSeasonCalls, [
+    { seasonId: "season-1", consistentRead: true, leagueId: "league-1" },
+  ]);
+});
+
+test("core lambda rejects league-scoped game creation for a session in another league", async () => {
+  const harness = createHarness({
+    sessions: {
+      "session-1": {
+        sessionId: "session-1",
+        email: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        expiresAt: "2026-02-24T00:00:00.000Z",
+      },
+    },
+    seasonSessions: {
+      "league-2:season-1:session-abc": {
+        seasonId: "season-1",
+        sessionId: "session-abc",
+        sessionDate: "2026-02-23",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    seasons: {
+      "season-1": {
+        leagueId: "league-1",
+        seasonId: "season-1",
+        name: "Season 1",
+        slug: null,
+        startsOn: null,
+        endsOn: null,
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+    leagueAccess: {
+      "league-1:admin@example.com": {
+        leagueId: "league-1",
+        userId: "admin@example.com",
+        role: "admin",
+        grantedByUserId: "admin@example.com",
+        createdAt: "2026-02-23T00:00:00.000Z",
+        updatedAt: "2026-02-23T00:00:00.000Z",
+      },
+    },
+  });
+
+  const response = await harness.handler(
+    createEvent({
+      method: "POST",
+      path: "/v1/leagues/league-1/seasons/season-1/sessions/session-abc/games",
+      headers: {
+        Cookie: "threefc_session=session-1",
+      },
+      body: {
+        gameId: "game-1",
+        gameStartTs: "2026-02-23T10:00:00Z",
+      },
+    }),
+  );
+
+  assert.equal(response.statusCode, 404);
+  assert.deepEqual(harness.getSeasonForLeagueCalls, [
+    { leagueId: "league-1", seasonId: "season-1", consistentRead: true },
+  ]);
+  assert.deepEqual(harness.getSessionForSeasonCalls, [
+    { seasonId: "season-1", sessionId: "session-abc", leagueId: "league-1" },
+  ]);
+  assert.equal(harness.createdGames.length, 0);
+  assert.equal(harness.createdSessionGames.length, 0);
+});
+
 test("core lambda rejects creating games directly as finished", async () => {
   const harness = createHarness({
     sessions: {
@@ -4472,7 +4978,7 @@ test("core lambda rejects creating games directly as finished", async () => {
   assert.equal(harness.createdSessionGames.length, 0);
 });
 
-test("core lambda recovers idempotent create game retry after the game write commits", async () => {
+test("core lambda recovers idempotent create game retry after atomic session-link failure", async () => {
   const harness = createHarness({
     createSessionGameFailures: 1,
     sessions: {
@@ -4531,68 +5037,16 @@ test("core lambda recovers idempotent create game retry after the game write com
 
   const failedResponse = await harness.handler(event);
   assert.equal(failedResponse.statusCode, 500);
-  assert.equal(harness.createdGames.length, 1);
-  assert.ok(harness.createdGames[0]?.createRequestHash);
+  assert.equal(harness.createdGames.length, 0);
   assert.equal(harness.createdSessionGames.length, 0);
-  const existingGame = harness.games.get("game-1");
-  assert.ok(existingGame);
-  harness.games.set("game-1", {
-    ...existingGame,
-    status: "live",
-    gameStartTs: "2026-02-23T11:00:00Z",
-    thirdLengthMinutes: 25,
-    updatedAt: "2026-02-23T00:01:00.000Z",
-  });
-
-  const unrelatedRetryResponse = await harness.handler(
-    createEvent({
-      method: "POST",
-      path: "/v1/sessions/session-abc/games",
-      headers: {
-        Cookie: "threefc_session=session-1",
-        "Idempotency-Key": "create-game-recover-1",
-      },
-      body: {
-        gameId: "game-1",
-        gameStartTs: "2026-02-23T12:00:00Z",
-      },
-    }),
-  );
-  assert.equal(unrelatedRetryResponse.statusCode, 409);
-  assert.deepEqual(JSON.parse(unrelatedRetryResponse.body), {
-    error: "conflict",
-    code: "game_exists",
-    message: "Game game-1 already exists.",
-  });
-  assert.equal(harness.createdSessionGames.length, 0);
-
-  const differentKeyRetryResponse = await harness.handler(
-    createEvent({
-      method: "POST",
-      path: "/v1/sessions/session-abc/games",
-      headers: {
-        Cookie: "threefc_session=session-1",
-        "Idempotency-Key": "create-game-recover-2",
-      },
-      body: {
-        gameId: "game-1",
-        gameStartTs: "2026-02-23T10:00:00Z",
-      },
-    }),
-  );
-  assert.equal(differentKeyRetryResponse.statusCode, 409);
-  assert.deepEqual(JSON.parse(differentKeyRetryResponse.body), {
-    error: "conflict",
-    code: "game_exists",
-    message: "Game game-1 already exists.",
-  });
-  assert.equal(harness.createdSessionGames.length, 0);
+  assert.equal(harness.games.get("game-1"), undefined);
 
   const retryResponse = await harness.handler(event);
   assert.equal(retryResponse.statusCode, 201);
   assert.equal(harness.createdGames.length, 1);
+  assert.ok(harness.createdGames[0]?.createRequestHash);
   assert.equal(harness.createdSessionGames.length, 1);
-  assert.equal(harness.createdSessionGames[0]?.gameStartTs, "2026-02-23T11:00:00Z");
+  assert.equal(harness.createdSessionGames[0]?.gameStartTs, "2026-02-23T10:00:00Z");
   assert.deepEqual(
     harness.createdGameTeams.map((team) => team.teamId),
     ["red", "blue", "yellow"],
@@ -4603,9 +5057,9 @@ test("core lambda recovers idempotent create game retry after the game write com
     gameStartTs: string;
     thirdLengthMinutes: number;
   };
-  assert.equal(retryBody.status, "live");
-  assert.equal(retryBody.gameStartTs, "2026-02-23T11:00:00Z");
-  assert.equal(retryBody.thirdLengthMinutes, 25);
+  assert.equal(retryBody.status, "scheduled");
+  assert.equal(retryBody.gameStartTs, "2026-02-23T10:00:00Z");
+  assert.equal(retryBody.thirdLengthMinutes, 20);
   assert.equal("createRequestHash" in retryBody, false);
 
   const replayResponse = await harness.handler(event);

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -1905,6 +1905,72 @@ test("repository scoped game cleanup deletes row-attributed legacy sessions afte
   assert.equal(client.readItem("SESSION#20260222", "METADATA"), undefined);
 });
 
+test("repository scoped game cleanup deletes owned legacy sessions despite foreign games", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  await repository.createLeague({
+    leagueId: "league-1",
+    name: "League One",
+    createdByUserId: "admin@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    name: "League One Season",
+  });
+  await repository.createSession({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "20260222",
+    sessionDate: "2026-02-22",
+  });
+  await repository.createGame({
+    gameId: "game-1",
+    joinCode: "ABCD2345",
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "20260222",
+    status: "scheduled",
+    gameStartTs: "2026-02-22T10:00:00Z",
+    linkSession: true,
+  });
+  await repository.createLeague({
+    leagueId: "league-2",
+    name: "League Two",
+    createdByUserId: "other@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-2",
+    seasonId: "season-1",
+    name: "League Two Season",
+  });
+  await repository.createSession({
+    leagueId: "league-2",
+    seasonId: "season-1",
+    sessionId: "20260222",
+    sessionDate: "2026-02-22",
+  });
+  await repository.createGame({
+    gameId: "game-2",
+    joinCode: "WXYZ6789",
+    leagueId: "league-2",
+    seasonId: "season-1",
+    sessionId: "20260222",
+    status: "scheduled",
+    gameStartTs: "2026-02-22T10:05:00Z",
+    linkSession: true,
+  });
+
+  const deleted = await repository.deleteGame("game-1");
+
+  assert.equal(deleted, true);
+  assert.equal(client.readItem("LEAGUE#league-1", "SEASON#season-1#SESSION#20260222"), undefined);
+  assert.equal(client.readItem("SEASON#season-1", "SESSION#20260222"), undefined);
+  assert.equal(client.readItem("SESSION#20260222", "METADATA"), undefined);
+  assert.ok(client.readItem("LEAGUE#league-2", "SEASON#season-1#SESSION#20260222"));
+  assert.ok(client.readItem("SESSION#20260222", "GAME#2026-02-22T10:05:00Z#game-2"));
+});
+
 test("repository scoped season game listings include owned provenance-less legacy sessions", async () => {
   const { repository, client } = createRepositoryHarness();
 
@@ -3066,6 +3132,57 @@ test("repository scoped season delete blocks owned legacy sessions without games
   );
 });
 
+test("repository scoped season delete blocks owned provenance-less legacy sessions without games", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  await repository.createLeague({
+    leagueId: "league-1",
+    name: "Three FC",
+    createdByUserId: "admin@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    name: "Season One",
+  });
+  client.seedItem({
+    pk: { S: "SEASON#season-1" },
+    sk: { S: "SESSION#20260222" },
+    entityType: { S: "session" },
+    createdAt: { S: "2026-02-22T10:00:00.000Z" },
+    updatedAt: { S: "2026-02-22T10:00:00.000Z" },
+    data: {
+      S: JSON.stringify({
+        seasonId: "season-1",
+        sessionId: "20260222",
+        sessionDate: "2026-02-22",
+      }),
+    },
+  });
+  client.seedItem({
+    pk: { S: "SESSION#20260222" },
+    sk: { S: "METADATA" },
+    entityType: { S: "session" },
+    createdAt: { S: "2026-02-22T10:00:00.000Z" },
+    updatedAt: { S: "2026-02-22T10:00:00.000Z" },
+    data: {
+      S: JSON.stringify({
+        seasonId: "season-1",
+        sessionId: "20260222",
+        sessionDate: "2026-02-22",
+      }),
+    },
+  });
+
+  await assert.rejects(
+    repository.deleteSeason("season-1", { leagueId: "league-1" }),
+    /Cannot delete season with existing games/,
+  );
+  assert.ok(client.readItem("LEAGUE#league-1", "SEASON#season-1"));
+  assert.ok(client.readItem("SEASON#season-1", "SESSION#20260222"));
+  assert.ok(client.readItem("SESSION#20260222", "METADATA"));
+});
+
 test("repository scoped session creation touches season metadata to serialize deletion", async () => {
   const { repository, client } = createRepositoryHarness();
 
@@ -3405,6 +3522,14 @@ test("repository scoped season delete uses consistent descendant reads", async (
           query.consistentRead === true,
       ),
   );
+  assert.ok(
+    client.getItemRequests.some(
+      (request) =>
+        request.pk === "LEAGUE#league-1" &&
+        request.sk === "SEASON#season-1" &&
+        request.consistentRead === true,
+    ),
+  );
 });
 
 test("repository scoped season delete conditionally preserves a replaced global mirror", async () => {
@@ -3519,6 +3644,54 @@ test("repository scoped season delete removes owned legacy season team templates
   assert.equal(deleted, true);
   assert.equal(client.readItem("SEASON#season-1", "TEAM#red"), undefined);
   assert.equal(client.readItem("SEASON#season-1", "TEAM#blue"), undefined);
+});
+
+test("repository scoped season delete removes row-attributed legacy templates after mirror replacement", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  await repository.createLeague({
+    leagueId: "league-1",
+    name: "League One",
+    createdByUserId: "admin@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    name: "League One Season",
+  });
+  await repository.createTeam({
+    seasonId: "season-1",
+    teamId: "red",
+    name: "Legacy Red",
+    color: "#ff0000",
+  });
+  await repository.createTeam({
+    seasonId: "season-1",
+    teamId: "blue",
+    name: "Legacy Blue",
+    color: "#0000ff",
+  });
+  await repository.createLeague({
+    leagueId: "league-2",
+    name: "League Two",
+    createdByUserId: "other@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-2",
+    seasonId: "season-1",
+    name: "League Two Season",
+  });
+
+  const deleted = await repository.deleteSeason("season-1", { leagueId: "league-1" });
+
+  assert.equal(deleted, true);
+  assert.equal(client.readItem("LEAGUE#league-1", "SEASON#season-1"), undefined);
+  assert.equal(client.readItem("SEASON#season-1", "TEAM#red"), undefined);
+  assert.equal(client.readItem("SEASON#season-1", "TEAM#blue"), undefined);
+  assert.equal(
+    JSON.parse(client.readItem("SEASON#season-1", "METADATA")?.data?.S ?? "{}").leagueId,
+    "league-2",
+  );
 });
 
 test("repository supports idempotency record create/get semantics", async () => {

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -56,6 +56,10 @@ class InMemoryDynamoClient {
     return this.items.get(`${pk}|${sk}`);
   }
 
+  deleteItem(pk: string, sk: string): void {
+    this.items.delete(`${pk}|${sk}`);
+  }
+
   readQueries(): readonly ObservedQuery[] {
     return this.queries;
   }
@@ -475,6 +479,7 @@ function seedStoredGameTeam(
 function seedStoredSeasonTeam(
   client: InMemoryDynamoClient,
   input: {
+    leagueId?: string;
     seasonId: string;
     teamId: TeamId;
     name: string;
@@ -491,6 +496,7 @@ function seedStoredSeasonTeam(
     updatedAt: { S: input.updatedAt },
     data: {
       S: JSON.stringify({
+        ...(input.leagueId ? { leagueId: input.leagueId } : {}),
         seasonId: input.seasonId,
         teamId: input.teamId,
         name: input.name,
@@ -734,6 +740,36 @@ test("repository prefers newer owned legacy season team templates over older sco
   assert.deepEqual(await repository.listTeamsForSeason("season-1", { leagueId: "league-1" }), [
     updatedLegacyTemplate,
   ]);
+});
+
+test("repository rejects legacy season team writes when the season is deleted before commit", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  await repository.createLeague({
+    leagueId: "league-1",
+    name: "League One",
+    createdByUserId: "admin@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    name: "League One Season",
+  });
+  client.runBeforeNextPut(() => {
+    client.deleteItem("LEAGUE#league-1", "SEASON#season-1");
+    client.deleteItem("SEASON#season-1", "METADATA");
+  });
+
+  await assert.rejects(
+    repository.createTeam({
+      seasonId: "season-1",
+      teamId: "red",
+      name: "Late Red",
+      color: "#ff0000",
+    }),
+    /Season season-1 changed before the team could be created/,
+  );
+  assert.equal(client.readItem("SEASON#season-1", "TEAM#red"), undefined);
 });
 
 test("repository does not treat another league's legacy templates as owned after mirror replacement", async () => {
@@ -2138,8 +2174,19 @@ test("repository create-only season teams preserve existing configuration", asyn
 
 test("repository create-only season teams do not replace concurrent teams", async () => {
   const { repository, client } = createRepositoryHarness();
+  await repository.createLeague({
+    leagueId: "league-1",
+    name: "League One",
+    createdByUserId: "admin@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    name: "League One Season",
+  });
   client.runBeforeNextPut(() => {
     seedStoredSeasonTeam(client, {
+      leagueId: "league-1",
       seasonId: "season-1",
       teamId: "red",
       name: "Concurrent Red",
@@ -2158,6 +2205,7 @@ test("repository create-only season teams do not replace concurrent teams", asyn
   });
 
   assert.deepEqual(concurrent, {
+    leagueId: "league-1",
     seasonId: "season-1",
     teamId: "red",
     name: "Concurrent Red",
@@ -3228,6 +3276,52 @@ test("repository scoped session-game linking touches session metadata to seriali
   const after = client.readItem("LEAGUE#league-1", "SEASON#season-1#SESSION#20260222");
   assert.ok(after);
   assert.notEqual(after.updatedAt?.S, before.updatedAt?.S);
+});
+
+test("repository recovery session linking rejects games deleted before commit", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  await repository.createLeague({
+    leagueId: "league-1",
+    name: "Three FC",
+    createdByUserId: "admin@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    name: "Season One",
+  });
+  await repository.createSession({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "20260222",
+    sessionDate: "2026-02-22",
+  });
+  await repository.createGame({
+    gameId: "game-1",
+    joinCode: "ABCD2345",
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "20260222",
+    gameStartTs: "2026-02-22T10:00:00Z",
+    linkSession: false,
+  });
+  client.runBeforeNextPut(() => {
+    client.deleteItem("GAME#game-1", "METADATA");
+  });
+
+  await assert.rejects(
+    repository.createSessionGame({
+      sessionId: "20260222",
+      gameId: "game-1",
+      gameStartTs: "2026-02-22T10:00:00Z",
+      leagueId: "league-1",
+      seasonId: "season-1",
+      requireExistingGame: true,
+    }),
+    /Game game-1 changed before the session could be linked/,
+  );
+  assert.equal(client.readItem("SESSION#20260222", "GAME#2026-02-22T10:00:00Z#game-1"), undefined);
 });
 
 test("repository scoped season delete rejects sessions created after descendant checks", async () => {

--- a/api/src/tests/repository.test.ts
+++ b/api/src/tests/repository.test.ts
@@ -8,6 +8,7 @@ import {
   type AttributeValue,
   PutItemCommand,
   QueryCommand,
+  TransactGetItemsCommand,
   TransactWriteItemsCommand,
 } from "@aws-sdk/client-dynamodb";
 import {
@@ -41,7 +42,9 @@ class InMemoryDynamoClient {
   private readonly items = new Map<string, Item>();
   private readonly queries: ObservedQuery[] = [];
   private beforeNextPut: (() => void) | null = null;
+  private afterNextQuery: (() => void) | null = null;
   readonly getItemRequests: Array<{ pk: string; sk: string; consistentRead: boolean }> = [];
+  readonly transactGetRequests: Array<Array<{ pk: string; sk: string }>> = [];
 
   seedItem(item: Item): void {
     const pk = this.readString(item.pk, "pk");
@@ -59,6 +62,10 @@ class InMemoryDynamoClient {
 
   runBeforeNextPut(callback: () => void): void {
     this.beforeNextPut = callback;
+  }
+
+  runAfterNextQuery(callback: () => void): void {
+    this.afterNextQuery = callback;
   }
 
   async send(command: unknown): Promise<unknown> {
@@ -129,12 +136,40 @@ class InMemoryDynamoClient {
         .sort((left, right) =>
           this.readString(left.sk, "sk").localeCompare(this.readString(right.sk, "sk")),
         );
+      if (this.afterNextQuery) {
+        const callback = this.afterNextQuery;
+        this.afterNextQuery = null;
+        callback();
+      }
 
       return { Items: items };
     }
 
     if (command instanceof ScanCommand) {
       return { Items: [...this.items.values()] };
+    }
+
+    if (command instanceof TransactGetItemsCommand) {
+      const gets = command.input.TransactItems ?? [];
+      const request = gets.map((item) => {
+        const key = item.Get?.Key;
+        if (!key) {
+          throw new Error("TransactGetItemsCommand item is missing Get.Key.");
+        }
+
+        return {
+          pk: this.readString(key.pk, "pk"),
+          sk: this.readString(key.sk, "sk"),
+        };
+      });
+      this.transactGetRequests.push(request);
+
+      return {
+        Responses: request.map(({ pk, sk }) => {
+          const item = this.items.get(`${pk}|${sk}`);
+          return item ? { Item: item } : {};
+        }),
+      };
     }
 
     if (command instanceof DeleteItemCommand) {
@@ -465,6 +500,68 @@ function seedStoredSeasonTeam(
   });
 }
 
+function seedStoredSessionGame(
+  client: InMemoryDynamoClient,
+  input: {
+    sessionId: string;
+    gameId: string;
+    gameStartTs: string;
+    leagueId: string;
+    seasonId: string;
+    createdAt: string;
+    updatedAt: string;
+  },
+): void {
+  client.seedItem({
+    pk: { S: `SESSION#${input.sessionId}` },
+    sk: { S: `GAME#${input.gameStartTs}#${input.gameId}` },
+    entityType: { S: "sessionGame" },
+    createdAt: { S: input.createdAt },
+    updatedAt: { S: input.updatedAt },
+    data: {
+      S: JSON.stringify({
+        sessionId: input.sessionId,
+        gameId: input.gameId,
+        gameStartTs: input.gameStartTs,
+        leagueId: input.leagueId,
+        seasonId: input.seasonId,
+      }),
+    },
+  });
+}
+
+function touchStoredLeagueSeason(
+  client: InMemoryDynamoClient,
+  input: {
+    leagueId: string;
+    seasonId: string;
+    updatedAt: string;
+  },
+): void {
+  const item = client.readItem(`LEAGUE#${input.leagueId}`, `SEASON#${input.seasonId}`);
+  assert.ok(item);
+  item.updatedAt = { S: input.updatedAt };
+  client.seedItem(item);
+}
+
+function touchStoredScopedSession(
+  client: InMemoryDynamoClient,
+  input: {
+    leagueId: string;
+    seasonId: string;
+    sessionId: string;
+    updatedAt: string;
+  },
+): void {
+  const item = client.readItem(
+    `LEAGUE#${input.leagueId}`,
+    `SEASON#${input.seasonId}#SESSION#${input.sessionId}`,
+  );
+  assert.ok(item);
+  item.updatedAt = { S: input.updatedAt };
+  client.seedItem(item);
+}
+
 test("repository supports round-trip create/read for core entities", async () => {
   const repository = createRepository();
 
@@ -575,6 +672,115 @@ test("repository supports round-trip create/read for core entities", async () =>
   });
   assert.deepEqual(await repository.listGameRoster("game-1"), [reassignedRoster]);
   assert.equal(reassignedRoster.teamId, "blue");
+});
+
+test("repository reads owned legacy season team templates for scoped season teams", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  await repository.createSeason({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    name: "Season One",
+  });
+  const legacyTemplate = await repository.createTeam({
+    seasonId: "season-1",
+    teamId: "blue",
+    name: "Legacy Blue",
+    color: "#0000ff",
+  });
+  assert.equal(legacyTemplate.leagueId, "league-1");
+
+  assert.deepEqual(await repository.listTeamsForSeason("season-1", { leagueId: "league-1" }), [
+    legacyTemplate,
+  ]);
+  assert.deepEqual(client.transactGetRequests.at(-1), [
+    { pk: "LEAGUE#league-1", sk: "SEASON#season-1" },
+    { pk: "SEASON#season-1", sk: "TEAM#red" },
+    { pk: "SEASON#season-1", sk: "TEAM#blue" },
+    { pk: "SEASON#season-1", sk: "TEAM#yellow" },
+  ]);
+  assert.equal(
+    client.readQueries().some((query) => query.pk === "SEASON#season-1" && query.skPrefix === "TEAM#"),
+    false,
+  );
+  assert.deepEqual(await repository.listTeamsForSeason("season-1", { leagueId: "league-2" }), []);
+});
+
+test("repository prefers newer owned legacy season team templates over older scoped defaults", async () => {
+  const clock = new MutableClock("2026-02-22T10:00:00.000Z");
+  const repository = new ThreeFcRepository(new InMemoryDynamoClient(), "threefc_test", clock);
+
+  await repository.createSeason({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    name: "Season One",
+  });
+  clock.set("2026-02-22T10:01:00.000Z");
+  await repository.createTeam({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    teamId: "red",
+    name: "Default Red",
+    color: "#ff0000",
+  });
+  clock.set("2026-02-22T10:02:00.000Z");
+  const updatedLegacyTemplate = await repository.createTeam({
+    seasonId: "season-1",
+    teamId: "red",
+    name: "Custom Red",
+    color: "#aa0000",
+  });
+
+  assert.deepEqual(await repository.listTeamsForSeason("season-1", { leagueId: "league-1" }), [
+    updatedLegacyTemplate,
+  ]);
+});
+
+test("repository does not treat another league's legacy templates as owned after mirror replacement", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  await repository.createLeague({
+    leagueId: "league-1",
+    name: "League One",
+    createdByUserId: "admin@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    name: "League One Season",
+  });
+  const leagueOneTemplate = await repository.createTeam({
+    seasonId: "season-1",
+    teamId: "red",
+    name: "League One Red",
+    color: "#ff0000",
+  });
+  await repository.createLeague({
+    leagueId: "league-2",
+    name: "League Two",
+    createdByUserId: "other@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-2",
+    seasonId: "season-1",
+    name: "League Two Season",
+  });
+
+  assert.deepEqual(await repository.listTeamsForSeason("season-1", { leagueId: "league-2" }), []);
+  assert.equal(await repository.deleteSeason("season-1", { leagueId: "league-2" }), true);
+  assert.deepEqual(await repository.listTeamsForSeason("season-1", { leagueId: "league-1" }), [
+    leagueOneTemplate,
+  ]);
+  assert.deepEqual(
+    JSON.parse(client.readItem("SEASON#season-1", "TEAM#red")?.data?.S ?? "{}"),
+    {
+      leagueId: "league-1",
+      seasonId: leagueOneTemplate.seasonId,
+      teamId: leagueOneTemplate.teamId,
+      name: leagueOneTemplate.name,
+      color: leagueOneTemplate.color,
+    },
+  );
 });
 
 test("repository claims players idempotently for one user and rejects another user", async () => {
@@ -963,9 +1169,105 @@ test("repository strongly reads game join-code lookups", async () => {
   );
 });
 
+test("repository links scoped sessions atomically when creating games", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  await repository.createLeague({
+    leagueId: "league-1",
+    name: "Three FC",
+    createdByUserId: "admin@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    name: "Season One",
+  });
+  await repository.createSession({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "session-1",
+    sessionDate: "2026-02-22",
+  });
+
+  const game = await repository.createGame({
+    gameId: "game-1",
+    joinCode: "ABCD2345",
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "session-1",
+    gameStartTs: "2026-02-22T10:00:00Z",
+    linkSession: true,
+  });
+
+  assert.equal(game.gameId, "game-1");
+  assert.ok(client.readItem("GAME#game-1", "METADATA"));
+  assert.ok(client.readItem("JOIN_CODE#ABCD2345", "METADATA"));
+  assert.ok(client.readItem("SESSION#session-1", "GAME#2026-02-22T10:00:00Z#game-1"));
+});
+
+test("repository rolls back scoped game creation when session linking loses a race", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  await repository.createLeague({
+    leagueId: "league-1",
+    name: "Three FC",
+    createdByUserId: "admin@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    name: "Season One",
+  });
+  await repository.createSession({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "session-1",
+    sessionDate: "2026-02-22",
+  });
+  client.runBeforeNextPut(() => {
+    touchStoredScopedSession(client, {
+      leagueId: "league-1",
+      seasonId: "season-1",
+      sessionId: "session-1",
+      updatedAt: "2026-02-22T10:03:00.000Z",
+    });
+  });
+
+  await assert.rejects(
+    repository.createGame({
+      gameId: "game-1",
+      joinCode: "ABCD2345",
+      leagueId: "league-1",
+      seasonId: "season-1",
+      sessionId: "session-1",
+      gameStartTs: "2026-02-22T10:00:00Z",
+      linkSession: true,
+    }),
+    /Session session-1 changed before the game could be created/,
+  );
+  assert.equal(client.readItem("GAME#game-1", "METADATA"), undefined);
+  assert.equal(client.readItem("JOIN_CODE#ABCD2345", "METADATA"), undefined);
+  assert.equal(client.readItem("SESSION#session-1", "GAME#2026-02-22T10:00:00Z#game-1"), undefined);
+});
+
 test("repository query supports deterministic session->games ordering", async () => {
   const repository = createRepository();
 
+  await repository.createLeague({
+    leagueId: "league-1",
+    name: "Three FC",
+    createdByUserId: "admin@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-1",
+    seasonId: "2026",
+    name: "2026 Season",
+  });
+  await repository.createSession({
+    seasonId: "2026",
+    sessionId: "session-a",
+    sessionDate: "2026-02-22",
+  });
   await repository.createSessionGame({
     sessionId: "session-a",
     gameId: "game-late",
@@ -1346,6 +1648,340 @@ test("repository supports update and delete of games", async () => {
   assert.equal(deleted, true);
   assert.equal(await repository.getGame("game-1"), null);
   assert.deepEqual(await repository.listSessionsForSeason("season-1"), []);
+});
+
+test("repository strongly reads session-game index before scoped game cleanup", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  await repository.createLeague({
+    leagueId: "league-1",
+    name: "Three FC",
+    createdByUserId: "admin@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    name: "Season One",
+  });
+  await repository.createSession({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "20260222",
+    sessionDate: "2026-02-22",
+  });
+  await repository.createGame({
+    gameId: "game-1",
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "20260222",
+    status: "scheduled",
+    gameStartTs: "2026-02-22T10:00:00Z",
+  });
+  await repository.createSessionGame({
+    sessionId: "20260222",
+    gameId: "game-1",
+    gameStartTs: "2026-02-22T10:00:00Z",
+    leagueId: "league-1",
+    seasonId: "season-1",
+  });
+
+  const deleted = await repository.deleteGame("game-1");
+
+  assert.equal(deleted, true);
+  assert.equal(client.readItem("LEAGUE#league-1", "SEASON#season-1#SESSION#20260222"), undefined);
+  assert.ok(
+    client
+      .readQueries()
+      .some(
+        (query) =>
+          query.pk === "SESSION#20260222" &&
+          query.skPrefix === "GAME#" &&
+          query.consistentRead === true,
+      ),
+  );
+});
+
+test("repository keeps scoped session when concurrent game linking wins cleanup race", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  await repository.createLeague({
+    leagueId: "league-1",
+    name: "Three FC",
+    createdByUserId: "admin@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    name: "Season One",
+  });
+  await repository.createSession({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "20260222",
+    sessionDate: "2026-02-22",
+  });
+  await repository.createGame({
+    gameId: "game-1",
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "20260222",
+    status: "scheduled",
+    gameStartTs: "2026-02-22T10:00:00Z",
+  });
+  await repository.createSessionGame({
+    sessionId: "20260222",
+    gameId: "game-1",
+    gameStartTs: "2026-02-22T10:00:00Z",
+    leagueId: "league-1",
+    seasonId: "season-1",
+  });
+
+  client.runAfterNextQuery(() => {
+    touchStoredScopedSession(client, {
+      leagueId: "league-1",
+      seasonId: "season-1",
+      sessionId: "20260222",
+      updatedAt: "2026-02-22T10:05:00.000Z",
+    });
+    client.seedItem({
+      pk: { S: "SESSION#20260222" },
+      sk: { S: "GAME#2026-02-22T10:05:00Z#game-2" },
+      entityType: { S: "sessionGame" },
+      createdAt: { S: "2026-02-22T10:05:00.000Z" },
+      updatedAt: { S: "2026-02-22T10:05:00.000Z" },
+      data: {
+        S: JSON.stringify({
+          sessionId: "20260222",
+          gameId: "game-2",
+          gameStartTs: "2026-02-22T10:05:00Z",
+          leagueId: "league-1",
+          seasonId: "season-1",
+        }),
+      },
+    });
+  });
+
+  const deleted = await repository.deleteGame("game-1");
+
+  assert.equal(deleted, true);
+  assert.ok(client.readItem("LEAGUE#league-1", "SEASON#season-1#SESSION#20260222"));
+  assert.ok(client.readItem("SESSION#20260222", "GAME#2026-02-22T10:05:00Z#game-2"));
+});
+
+test("repository scoped game cleanup leaves unowned legacy sessions untouched", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  await repository.createLeague({
+    leagueId: "league-1",
+    name: "League One",
+    createdByUserId: "admin@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    name: "League One Season",
+  });
+  await repository.createSession({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "20260222",
+    sessionDate: "2026-02-22",
+  });
+  await repository.createGame({
+    gameId: "game-1",
+    joinCode: "ABCD2345",
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "20260222",
+    status: "scheduled",
+    gameStartTs: "2026-02-22T10:00:00Z",
+    linkSession: true,
+  });
+  await repository.createLeague({
+    leagueId: "league-2",
+    name: "League Two",
+    createdByUserId: "other@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-2",
+    seasonId: "season-1",
+    name: "League Two Season",
+  });
+  await repository.createSession({
+    seasonId: "season-1",
+    sessionId: "20260222",
+    sessionDate: "2026-02-22",
+  });
+
+  const deleted = await repository.deleteGame("game-1");
+
+  assert.equal(deleted, true);
+  assert.equal(client.readItem("LEAGUE#league-1", "SEASON#season-1#SESSION#20260222"), undefined);
+  assert.ok(client.readItem("SEASON#season-1", "SESSION#20260222"));
+  assert.ok(client.readItem("SESSION#20260222", "METADATA"));
+});
+
+test("repository scoped game cleanup deletes row-attributed legacy sessions after mirror replacement", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  await repository.createLeague({
+    leagueId: "league-1",
+    name: "League One",
+    createdByUserId: "admin@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    name: "League One Season",
+  });
+  await repository.createSession({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "20260222",
+    sessionDate: "2026-02-22",
+  });
+  await repository.createGame({
+    gameId: "game-1",
+    joinCode: "ABCD2345",
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "20260222",
+    status: "scheduled",
+    gameStartTs: "2026-02-22T10:00:00Z",
+    linkSession: true,
+  });
+  await repository.createLeague({
+    leagueId: "league-2",
+    name: "League Two",
+    createdByUserId: "other@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-2",
+    seasonId: "season-1",
+    name: "League Two Season",
+  });
+
+  const deleted = await repository.deleteGame("game-1");
+
+  assert.equal(deleted, true);
+  assert.equal(client.readItem("LEAGUE#league-1", "SEASON#season-1#SESSION#20260222"), undefined);
+  assert.equal(client.readItem("SEASON#season-1", "SESSION#20260222"), undefined);
+  assert.equal(client.readItem("SESSION#20260222", "METADATA"), undefined);
+});
+
+test("repository scoped season game listings include owned provenance-less legacy sessions", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  await repository.createLeague({
+    leagueId: "league-1",
+    name: "Three FC",
+    createdByUserId: "admin@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    name: "Season One",
+  });
+  client.seedItem({
+    pk: { S: "SEASON#season-1" },
+    sk: { S: "SESSION#20260222" },
+    entityType: { S: "session" },
+    createdAt: { S: "2026-02-22T10:00:00.000Z" },
+    updatedAt: { S: "2026-02-22T10:00:00.000Z" },
+    data: {
+      S: JSON.stringify({
+        seasonId: "season-1",
+        sessionId: "20260222",
+        sessionDate: "2026-02-22",
+      }),
+    },
+  });
+  await repository.createGame({
+    gameId: "game-visible",
+    joinCode: "ABCD2345",
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "20260222",
+    status: "scheduled",
+    gameStartTs: "2026-02-22T10:00:00Z",
+  });
+  seedStoredSessionGame(client, {
+    sessionId: "20260222",
+    gameId: "game-visible",
+    gameStartTs: "2026-02-22T10:00:00Z",
+    leagueId: "league-1",
+    seasonId: "season-1",
+    createdAt: "2026-02-22T10:00:00.000Z",
+    updatedAt: "2026-02-22T10:00:00.000Z",
+  });
+
+  const listed = await repository.listGamesForSeason("season-1", { leagueId: "league-1" });
+
+  assert.deepEqual(
+    listed.map((game) => game.gameId),
+    ["game-visible"],
+  );
+});
+
+test("repository scopes season game listings by league when session indexes collide", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  await repository.createLeague({
+    leagueId: "league-1",
+    name: "Three FC",
+    createdByUserId: "admin@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    name: "Season One",
+  });
+  await repository.createSession({
+    seasonId: "season-1",
+    sessionId: "20260222",
+    sessionDate: "2026-02-22",
+  });
+  await repository.createGame({
+    gameId: "game-visible",
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "20260222",
+    status: "scheduled",
+    gameStartTs: "2026-02-22T10:00:00Z",
+  });
+  seedStoredSessionGame(client, {
+    sessionId: "20260222",
+    gameId: "game-visible",
+    gameStartTs: "2026-02-22T10:00:00Z",
+    leagueId: "league-1",
+    seasonId: "season-1",
+    createdAt: "2026-02-22T10:00:00.000Z",
+    updatedAt: "2026-02-22T10:00:00.000Z",
+  });
+  await repository.createGame({
+    gameId: "game-other-league",
+    leagueId: "league-2",
+    seasonId: "season-1",
+    sessionId: "20260222",
+    status: "scheduled",
+    gameStartTs: "2026-02-22T10:05:00Z",
+  });
+  seedStoredSessionGame(client, {
+    sessionId: "20260222",
+    gameId: "game-other-league",
+    gameStartTs: "2026-02-22T10:05:00Z",
+    leagueId: "league-2",
+    seasonId: "season-1",
+    createdAt: "2026-02-22T10:05:00.000Z",
+    updatedAt: "2026-02-22T10:05:00.000Z",
+  });
+
+  const listed = await repository.listGamesForSeason("season-1", { leagueId: "league-1" });
+
+  assert.deepEqual(
+    listed.map((game) => game.gameId),
+    ["game-visible"],
+  );
 });
 
 test("repository does not delete a game if it finishes before the delete transaction commits", async () => {
@@ -1740,6 +2376,44 @@ test("repository repairs legacy game join codes with a random usable lookup when
     joinCode: game.joinCode,
     gameId: "game-legacy",
   });
+});
+
+test("repository skips legacy game join-code repair when expected scope does not match", async () => {
+  const { repository, client } = createRepositoryHarness();
+  const fallbackJoinCode = buildJoinCodeForGameId("game-legacy");
+
+  client.seedItem({
+    pk: { S: "GAME#game-legacy" },
+    sk: { S: "METADATA" },
+    entityType: { S: "game" },
+    createdAt: { S: "2026-02-22T00:00:00.000Z" },
+    updatedAt: { S: "2026-02-22T00:00:00.000Z" },
+    data: {
+      S: JSON.stringify({
+        gameId: "game-legacy",
+        leagueId: "league-2",
+        seasonId: "season-1",
+        sessionId: "session-1",
+        status: "scheduled",
+        gameStartTs: "2026-02-22T10:00:00.000Z",
+      }),
+    },
+  });
+
+  const game = await repository.getGame("game-legacy", {
+    repairLegacyJoinCode: true,
+    expectedLeagueId: "league-1",
+    expectedSeasonId: "season-1",
+  });
+
+  assert.ok(game);
+  assert.equal(game.leagueId, "league-2");
+  assert.equal(game.joinCode, fallbackJoinCode);
+  assert.equal(client.readItem(`JOIN_CODE#${fallbackJoinCode}`, "METADATA") ?? null, null);
+  assert.equal(
+    JSON.parse(client.readItem("GAME#game-legacy", "METADATA")?.data?.S ?? "{}").joinCode,
+    undefined,
+  );
 });
 
 test("repository repairs legacy game join-code collisions with a usable fallback", async () => {
@@ -2317,6 +2991,440 @@ test("repository blocks deleting season or league while descendants exist", asyn
     repository.deleteLeague("league-1"),
     /Cannot delete league with existing seasons/,
   );
+});
+
+test("repository scoped season delete blocks owned legacy sessions without games", async () => {
+  const repository = createRepository();
+
+  await repository.createLeague({
+    leagueId: "league-1",
+    name: "Three FC",
+    createdByUserId: "admin@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    name: "Season One",
+  });
+  await repository.createSession({
+    seasonId: "season-1",
+    sessionId: "20260222",
+    sessionDate: "2026-02-22",
+  });
+
+  await assert.rejects(
+    repository.deleteSeason("season-1", { leagueId: "league-1" }),
+    /Cannot delete season with existing games/,
+  );
+});
+
+test("repository scoped session creation touches season metadata to serialize deletion", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  await repository.createLeague({
+    leagueId: "league-1",
+    name: "Three FC",
+    createdByUserId: "admin@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    name: "Season One",
+  });
+  const before = client.readItem("LEAGUE#league-1", "SEASON#season-1");
+  assert.ok(before);
+
+  await repository.createSession({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "20260222",
+    sessionDate: "2026-02-22",
+  });
+
+  const after = client.readItem("LEAGUE#league-1", "SEASON#season-1");
+  assert.ok(after);
+  assert.notEqual(after.updatedAt?.S, before.updatedAt?.S);
+  assert.ok(client.readItem("LEAGUE#league-1", "SEASON#season-1#SESSION#20260222"));
+  assert.equal(
+    JSON.parse(client.readItem("SEASON#season-1", "SESSION#20260222")?.data?.S ?? "{}").leagueId,
+    "league-1",
+  );
+  assert.equal(
+    JSON.parse(client.readItem("SESSION#20260222", "METADATA")?.data?.S ?? "{}").leagueId,
+    "league-1",
+  );
+});
+
+test("repository scoped session creation skips legacy compatibility rows when global mirror belongs to another league", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  await repository.createLeague({
+    leagueId: "league-1",
+    name: "League One",
+    createdByUserId: "admin@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    name: "League One Season",
+  });
+  await repository.createLeague({
+    leagueId: "league-2",
+    name: "League Two",
+    createdByUserId: "other@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-2",
+    seasonId: "season-1",
+    name: "League Two Season",
+  });
+
+  await repository.createSession({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "20260222",
+    sessionDate: "2026-02-22",
+  });
+
+  assert.ok(client.readItem("LEAGUE#league-1", "SEASON#season-1#SESSION#20260222"));
+  assert.equal(client.readItem("SEASON#season-1", "SESSION#20260222"), undefined);
+  assert.equal(client.readItem("SESSION#20260222", "METADATA"), undefined);
+});
+
+test("repository scoped session creation aborts compatibility writes if global mirror changes", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  await repository.createLeague({
+    leagueId: "league-1",
+    name: "League One",
+    createdByUserId: "admin@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    name: "League One Season",
+  });
+  client.runBeforeNextPut(() => {
+    const globalSeason = client.readItem("SEASON#season-1", "METADATA");
+    assert.ok(globalSeason);
+    globalSeason.updatedAt = { S: "2026-02-23T00:00:00.000Z" };
+    globalSeason.data = {
+      S: JSON.stringify({
+        leagueId: "league-2",
+        seasonId: "season-1",
+        name: "League Two Season",
+        slug: null,
+        startsOn: null,
+        endsOn: null,
+      }),
+    };
+    client.seedItem(globalSeason);
+  });
+
+  await assert.rejects(
+    repository.createSession({
+      leagueId: "league-1",
+      seasonId: "season-1",
+      sessionId: "20260222",
+      sessionDate: "2026-02-22",
+    }),
+    /Season season-1 changed before the session could be created/,
+  );
+  assert.equal(client.readItem("LEAGUE#league-1", "SEASON#season-1#SESSION#20260222"), undefined);
+  assert.equal(client.readItem("SEASON#season-1", "SESSION#20260222"), undefined);
+  assert.equal(client.readItem("SESSION#20260222", "METADATA"), undefined);
+});
+
+test("repository scoped session creation leaves foreign legacy session compatibility rows untouched", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  await repository.createLeague({
+    leagueId: "league-1",
+    name: "League One",
+    createdByUserId: "admin@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    name: "League One Season",
+  });
+  await repository.createLeague({
+    leagueId: "league-2",
+    name: "League Two",
+    createdByUserId: "other@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-2",
+    seasonId: "season-1",
+    name: "League Two Season",
+  });
+  await repository.createSession({
+    seasonId: "season-1",
+    sessionId: "20260222",
+    sessionDate: "2026-02-23",
+  });
+
+  await repository.createSession({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "20260222",
+    sessionDate: "2026-02-22",
+  });
+
+  assert.equal(
+    JSON.parse(client.readItem("LEAGUE#league-1", "SEASON#season-1#SESSION#20260222")?.data?.S ?? "{}").leagueId,
+    "league-1",
+  );
+  assert.deepEqual(
+    JSON.parse(client.readItem("SEASON#season-1", "SESSION#20260222")?.data?.S ?? "{}"),
+    {
+      leagueId: "league-2",
+      seasonId: "season-1",
+      sessionId: "20260222",
+      sessionDate: "2026-02-23",
+    },
+  );
+  assert.deepEqual(
+    JSON.parse(client.readItem("SESSION#20260222", "METADATA")?.data?.S ?? "{}"),
+    {
+      leagueId: "league-2",
+      seasonId: "season-1",
+      sessionId: "20260222",
+      sessionDate: "2026-02-23",
+    },
+  );
+});
+
+test("repository scoped session-game linking touches session metadata to serialize cleanup", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  await repository.createLeague({
+    leagueId: "league-1",
+    name: "Three FC",
+    createdByUserId: "admin@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    name: "Season One",
+  });
+  await repository.createSession({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "20260222",
+    sessionDate: "2026-02-22",
+  });
+  const before = client.readItem("LEAGUE#league-1", "SEASON#season-1#SESSION#20260222");
+  assert.ok(before);
+
+  await repository.createSessionGame({
+    sessionId: "20260222",
+    gameId: "game-1",
+    gameStartTs: "2026-02-22T10:00:00Z",
+    leagueId: "league-1",
+    seasonId: "season-1",
+  });
+
+  const after = client.readItem("LEAGUE#league-1", "SEASON#season-1#SESSION#20260222");
+  assert.ok(after);
+  assert.notEqual(after.updatedAt?.S, before.updatedAt?.S);
+});
+
+test("repository scoped season delete rejects sessions created after descendant checks", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  await repository.createLeague({
+    leagueId: "league-1",
+    name: "Three FC",
+    createdByUserId: "admin@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    name: "Season One",
+  });
+  client.runBeforeNextPut(() => {
+    touchStoredLeagueSeason(client, {
+      leagueId: "league-1",
+      seasonId: "season-1",
+      updatedAt: "2026-02-22T10:03:00.000Z",
+    });
+    client.seedItem({
+      pk: { S: "LEAGUE#league-1" },
+      sk: { S: "SEASON#season-1#SESSION#late-session" },
+      entityType: { S: "session" },
+      createdAt: { S: "2026-02-22T10:03:00.000Z" },
+      updatedAt: { S: "2026-02-22T10:03:00.000Z" },
+      data: {
+        S: JSON.stringify({
+          leagueId: "league-1",
+          seasonId: "season-1",
+          sessionId: "late-session",
+          sessionDate: "2026-02-22",
+        }),
+      },
+    });
+  });
+
+  await assert.rejects(
+    repository.deleteSeason("season-1", { leagueId: "league-1" }),
+    /Cannot delete season with existing games/,
+  );
+  assert.ok(client.readItem("LEAGUE#league-1", "SEASON#season-1"));
+  assert.ok(client.readItem("LEAGUE#league-1", "SEASON#season-1#SESSION#late-session"));
+});
+
+test("repository scoped season delete uses consistent descendant reads", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  await repository.createLeague({
+    leagueId: "league-1",
+    name: "Three FC",
+    createdByUserId: "admin@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    name: "Season One",
+  });
+
+  const deleted = await repository.deleteSeason("season-1", { leagueId: "league-1" });
+
+  assert.equal(deleted, true);
+  assert.ok(
+    client
+      .readQueries()
+      .some(
+        (query) =>
+          query.pk === "LEAGUE#league-1" &&
+          query.skPrefix === "SEASON#season-1#SESSION#" &&
+          query.consistentRead === true,
+      ),
+  );
+  assert.ok(
+    client
+      .readQueries()
+      .some(
+        (query) =>
+          query.pk === "SEASON#season-1" &&
+          query.skPrefix === "SESSION#" &&
+          query.consistentRead === true,
+      ),
+  );
+});
+
+test("repository scoped season delete conditionally preserves a replaced global mirror", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  await repository.createLeague({
+    leagueId: "league-1",
+    name: "Three FC",
+    createdByUserId: "admin@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    name: "Season One",
+  });
+  await repository.createTeam({
+    seasonId: "season-1",
+    teamId: "red",
+    name: "Legacy Red",
+    color: "#ff0000",
+  });
+
+  client.runBeforeNextPut(() => {
+    const item = client.readItem("SEASON#season-1", "METADATA");
+    assert.ok(item);
+    const data = JSON.parse(item.data?.S ?? "{}") as Record<string, unknown>;
+    item.updatedAt = { S: "2026-02-22T10:05:00.000Z" };
+    item.data = {
+      S: JSON.stringify({
+        ...data,
+        leagueId: "league-2",
+      }),
+    };
+    client.seedItem(item);
+  });
+
+  await assert.rejects(
+    repository.deleteSeason("season-1", { leagueId: "league-1" }),
+    /Cannot delete season with existing games/,
+  );
+  assert.ok(client.readItem("LEAGUE#league-1", "SEASON#season-1"));
+  assert.equal(
+    JSON.parse(client.readItem("SEASON#season-1", "METADATA")?.data?.S ?? "{}").leagueId,
+    "league-2",
+  );
+  assert.ok(client.readItem("SEASON#season-1", "TEAM#red"));
+});
+
+test("repository scoped season delete removes scoped season teams", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  await repository.createLeague({
+    leagueId: "league-1",
+    name: "Three FC",
+    createdByUserId: "admin@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    name: "Season One",
+  });
+  await repository.createTeam({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    teamId: "red",
+    name: "Red",
+    color: "#ff0000",
+  });
+  await repository.createTeam({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    teamId: "blue",
+    name: "Blue",
+    color: "#0000ff",
+  });
+
+  const deleted = await repository.deleteSeason("season-1", { leagueId: "league-1" });
+
+  assert.equal(deleted, true);
+  assert.equal(client.readItem("LEAGUE#league-1", "SEASON#season-1#TEAM#red"), undefined);
+  assert.equal(client.readItem("LEAGUE#league-1", "SEASON#season-1#TEAM#blue"), undefined);
+});
+
+test("repository scoped season delete removes owned legacy season team templates", async () => {
+  const { repository, client } = createRepositoryHarness();
+
+  await repository.createLeague({
+    leagueId: "league-1",
+    name: "Three FC",
+    createdByUserId: "admin@example.com",
+  });
+  await repository.createSeason({
+    leagueId: "league-1",
+    seasonId: "season-1",
+    name: "Season One",
+  });
+  await repository.createTeam({
+    seasonId: "season-1",
+    teamId: "red",
+    name: "Legacy Red",
+    color: "#ff0000",
+  });
+  await repository.createTeam({
+    seasonId: "season-1",
+    teamId: "blue",
+    name: "Legacy Blue",
+    color: "#0000ff",
+  });
+
+  const deleted = await repository.deleteSeason("season-1", { leagueId: "league-1" });
+
+  assert.equal(deleted, true);
+  assert.equal(client.readItem("SEASON#season-1", "TEAM#red"), undefined);
+  assert.equal(client.readItem("SEASON#season-1", "TEAM#blue"), undefined);
 });
 
 test("repository supports idempotency record create/get semantics", async () => {

--- a/api/src/tests/server-route.test.ts
+++ b/api/src/tests/server-route.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import test from "node:test";
 
@@ -18,6 +19,40 @@ import {
   GameTimerTransitionError,
 } from "../data/repository.js";
 import type { GameRecord, GameTeamRecord } from "../data/types.js";
+
+function normalizePayloadForTestHash(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(normalizePayloadForTestHash);
+  }
+
+  if (value && typeof value === "object") {
+    const source = value as Record<string, unknown>;
+    return Object.fromEntries(
+      Object.keys(source)
+        .sort()
+        .map((key) => [key, normalizePayloadForTestHash(source[key])] as const),
+    );
+  }
+
+  return value;
+}
+
+function buildTestIdempotencyRequestHash(scope: string, payload: unknown): string {
+  return createHash("sha256")
+    .update(`${scope}:${JSON.stringify(normalizePayloadForTestHash(payload))}`)
+    .digest("hex");
+}
+
+function buildTestKeyedRecoveryRequestHash(input: {
+  scope: string;
+  idempotencyKey: string;
+  payload: unknown;
+}): string {
+  return buildTestIdempotencyRequestHash(input.scope, {
+    idempotencyKey: input.idempotencyKey,
+    payload: input.payload,
+  });
+}
 
 class MockResponse {
   statusCode = 0;
@@ -278,6 +313,7 @@ test("local server create game route recovers retry after atomic session-link fa
     gameStartTs: string;
     leagueId: string;
     seasonId: string;
+    requireExistingGame?: boolean;
   }> = [];
   const createdGameTeams: GameTeamRecord[] = [];
   let createSessionGameFailures = 1;
@@ -371,6 +407,7 @@ test("local server create game route recovers retry after atomic session-link fa
       gameStartTs: string;
       leagueId: string;
       seasonId: string;
+      requireExistingGame?: boolean;
     }) {
       if (createSessionGameFailures > 0) {
         createSessionGameFailures -= 1;
@@ -476,6 +513,49 @@ test("local server create game route recovers retry after atomic session-link fa
   assert.equal(createdSessionGames.length, 1);
   assert.equal(JSON.parse(replayResponse.body).gameId, "game-local");
   assert.equal("createRequestHash" in JSON.parse(replayResponse.body), false);
+
+  const duplicateRecoveryBody = {
+    gameId: "game-existing",
+    gameStartTs: "2026-02-23T11:00:00.000Z",
+  };
+  const duplicateRecoveryKey = "local-create-game-existing-recover-1";
+  games.set("game-existing", {
+    ...gameRecord({
+      status: "scheduled",
+      thirds: createDefaultThirdTimerSegments(),
+    }),
+    gameId: "game-existing",
+    createRequestHash: buildTestKeyedRecoveryRequestHash({
+      scope: "admin@example.com:POST:/v1/sessions/session-1/games",
+      idempotencyKey: duplicateRecoveryKey,
+      payload: duplicateRecoveryBody,
+    }),
+    joinCode: "EXIST234",
+    leagueId: "league-1",
+    seasonId: "season-1",
+    sessionId: "session-1",
+    gameStartTs: duplicateRecoveryBody.gameStartTs,
+    thirdLengthMinutes: 20,
+  });
+  const duplicateRecoveryResponse = createMockResponse();
+  const duplicateRecoveryStatus = await handleLocalCreateGameRoute({
+    request: buildRequest(duplicateRecoveryBody, duplicateRecoveryKey),
+    response: duplicateRecoveryResponse,
+    scope: { leagueId: "league-1", seasonId: "season-1", sessionId: "session-1" },
+    sessionEmail: "admin@example.com",
+    method: "POST",
+    route: "/v1/sessions/session-1/games",
+    repositoryClient,
+  });
+  assert.equal(duplicateRecoveryStatus, 201);
+  assert.deepEqual(createdSessionGames.at(-1), {
+    sessionId: "session-1",
+    gameId: "game-existing",
+    gameStartTs: "2026-02-23T11:00:00.000Z",
+    leagueId: "league-1",
+    seasonId: "season-1",
+    requireExistingGame: true,
+  });
 });
 
 test("local server finish route returns finished game result", async () => {

--- a/api/src/tests/server-route.test.ts
+++ b/api/src/tests/server-route.test.ts
@@ -151,12 +151,27 @@ const scorekeeperAccess = {
 test("local server get game route does not repair legacy join codes before access is authorized", async () => {
   const request = createMockRequest();
   const response = createMockResponse();
-  const getGameCalls: Array<{ consistentRead: boolean; repairLegacyJoinCode: boolean }> = [];
+  const getGameCalls: Array<{
+    consistentRead: boolean;
+    repairLegacyJoinCode: boolean;
+    expectedLeagueId: string | null;
+    expectedSeasonId: string | null;
+  }> = [];
   const repositoryClient = {
-    async getGame(_gameId: string, options: { consistentRead?: boolean; repairLegacyJoinCode?: boolean } = {}) {
+    async getGame(
+      _gameId: string,
+      options: {
+        consistentRead?: boolean;
+        repairLegacyJoinCode?: boolean;
+        expectedLeagueId?: string;
+        expectedSeasonId?: string;
+      } = {},
+    ) {
       getGameCalls.push({
         consistentRead: options.consistentRead ?? false,
         repairLegacyJoinCode: options.repairLegacyJoinCode ?? false,
+        expectedLeagueId: options.expectedLeagueId ?? null,
+        expectedSeasonId: options.expectedSeasonId ?? null,
       });
       return gameRecord({ status: "scheduled", joinCode: "FALL2345" });
     },
@@ -175,18 +190,40 @@ test("local server get game route does not repair legacy join codes before acces
 
   assert.equal(status, 403);
   assert.equal(response.statusCode, 403);
-  assert.deepEqual(getGameCalls, [{ consistentRead: false, repairLegacyJoinCode: false }]);
+  assert.deepEqual(getGameCalls, [
+    {
+      consistentRead: false,
+      repairLegacyJoinCode: false,
+      expectedLeagueId: null,
+      expectedSeasonId: null,
+    },
+  ]);
 });
 
 test("local server get game route repairs legacy join codes after access is authorized", async () => {
   const request = createMockRequest();
   const response = createMockResponse();
-  const getGameCalls: Array<{ consistentRead: boolean; repairLegacyJoinCode: boolean }> = [];
+  const getGameCalls: Array<{
+    consistentRead: boolean;
+    repairLegacyJoinCode: boolean;
+    expectedLeagueId: string | null;
+    expectedSeasonId: string | null;
+  }> = [];
   const repositoryClient = {
-    async getGame(_gameId: string, options: { consistentRead?: boolean; repairLegacyJoinCode?: boolean } = {}) {
+    async getGame(
+      _gameId: string,
+      options: {
+        consistentRead?: boolean;
+        repairLegacyJoinCode?: boolean;
+        expectedLeagueId?: string;
+        expectedSeasonId?: string;
+      } = {},
+    ) {
       getGameCalls.push({
         consistentRead: options.consistentRead ?? false,
         repairLegacyJoinCode: options.repairLegacyJoinCode ?? false,
+        expectedLeagueId: options.expectedLeagueId ?? null,
+        expectedSeasonId: options.expectedSeasonId ?? null,
       });
       return options.repairLegacyJoinCode
         ? gameRecord({ status: "scheduled", joinCode: "RNDM2345" })
@@ -209,12 +246,22 @@ test("local server get game route repairs legacy join codes after access is auth
   assert.equal(response.statusCode, 200);
   assert.equal((JSON.parse(response.body) as { joinCode: string }).joinCode, "RNDM2345");
   assert.deepEqual(getGameCalls, [
-    { consistentRead: false, repairLegacyJoinCode: false },
-    { consistentRead: true, repairLegacyJoinCode: true },
+    {
+      consistentRead: false,
+      repairLegacyJoinCode: false,
+      expectedLeagueId: null,
+      expectedSeasonId: null,
+    },
+    {
+      consistentRead: true,
+      repairLegacyJoinCode: true,
+      expectedLeagueId: "league-1",
+      expectedSeasonId: "season-1",
+    },
   ]);
 });
 
-test("local server create game route recovers retry after the game write commits", async () => {
+test("local server create game route recovers retry after atomic session-link failure", async () => {
   const idempotencyRecords = new Map<string, {
     scope: string;
     key: string;
@@ -279,9 +326,14 @@ test("local server create game route recovers retry after the game write commits
       status?: "scheduled" | "live" | "finished";
       gameStartTs: string;
       thirdLengthMinutes?: ThirdLengthMinutes;
+      linkSession?: boolean;
     }) {
       if (games.has(input.gameId)) {
         throw new GameAlreadyExistsError(input.gameId);
+      }
+      if (input.linkSession === true && createSessionGameFailures > 0) {
+        createSessionGameFailures -= 1;
+        throw new Error("Session game index write failed.");
       }
 
       const game = {
@@ -299,6 +351,15 @@ test("local server create game route recovers retry after the game write commits
         thirdLengthMinutes: input.thirdLengthMinutes ?? 20,
       };
       games.set(input.gameId, game);
+      if (input.linkSession === true) {
+        createdSessionGames.push({
+          sessionId: input.sessionId,
+          gameId: input.gameId,
+          gameStartTs: input.gameStartTs,
+          leagueId: input.leagueId,
+          seasonId: input.seasonId,
+        });
+      }
       return game;
     },
     async getGame(gameId: string) {
@@ -365,55 +426,7 @@ test("local server create game route recovers retry after the game write commits
     }),
     /Session game index write failed/,
   );
-  assert.equal(games.size, 1);
-  assert.equal(createdSessionGames.length, 0);
-  const existingGame = games.get("game-local");
-  assert.ok(existingGame);
-  games.set("game-local", {
-    ...existingGame,
-    status: "live",
-    gameStartTs: "2026-02-23T11:00:00.000Z",
-    thirdLengthMinutes: 25,
-    updatedAt: "2026-02-23T00:01:00.000Z",
-  });
-
-  const unrelatedRetryResponse = createMockResponse();
-  const unrelatedRetryStatus = await handleLocalCreateGameRoute({
-    request: buildRequest({
-      gameId: "game-local",
-      gameStartTs: "2026-02-23T12:00:00.000Z",
-    }),
-    response: unrelatedRetryResponse,
-    scope: { leagueId: "league-1", seasonId: "season-1", sessionId: "session-1" },
-    sessionEmail: "admin@example.com",
-    method: "POST",
-    route: "/v1/sessions/session-1/games",
-    repositoryClient,
-  });
-  assert.equal(unrelatedRetryStatus, 409);
-  assert.deepEqual(JSON.parse(unrelatedRetryResponse.body), {
-    error: "conflict",
-    code: "game_exists",
-    message: "Game game-local already exists.",
-  });
-  assert.equal(createdSessionGames.length, 0);
-
-  const differentKeyRetryResponse = createMockResponse();
-  const differentKeyRetryStatus = await handleLocalCreateGameRoute({
-    request: buildRequest(undefined, "local-create-game-recover-2"),
-    response: differentKeyRetryResponse,
-    scope: { leagueId: "league-1", seasonId: "season-1", sessionId: "session-1" },
-    sessionEmail: "admin@example.com",
-    method: "POST",
-    route: "/v1/sessions/session-1/games",
-    repositoryClient,
-  });
-  assert.equal(differentKeyRetryStatus, 409);
-  assert.deepEqual(JSON.parse(differentKeyRetryResponse.body), {
-    error: "conflict",
-    code: "game_exists",
-    message: "Game game-local already exists.",
-  });
+  assert.equal(games.size, 0);
   assert.equal(createdSessionGames.length, 0);
 
   const retryResponse = createMockResponse();
@@ -427,8 +440,9 @@ test("local server create game route recovers retry after the game write commits
     repositoryClient,
   });
   assert.equal(retryStatus, 201);
+  assert.equal(games.size, 1);
   assert.equal(createdSessionGames.length, 1);
-  assert.equal(createdSessionGames[0]?.gameStartTs, "2026-02-23T11:00:00.000Z");
+  assert.equal(createdSessionGames[0]?.gameStartTs, "2026-02-23T10:00:00.000Z");
   assert.deepEqual(
     createdGameTeams.map((team) => team.teamId),
     ["red", "blue", "yellow"],
@@ -442,9 +456,9 @@ test("local server create game route recovers retry after the game write commits
     },
     {
       gameId: "game-local",
-      status: "live",
-      gameStartTs: "2026-02-23T11:00:00.000Z",
-      thirdLengthMinutes: 25,
+      status: "scheduled",
+      gameStartTs: "2026-02-23T10:00:00.000Z",
+      thirdLengthMinutes: 20,
     },
   );
 

--- a/api/src/tests/session.test.ts
+++ b/api/src/tests/session.test.ts
@@ -37,6 +37,9 @@ test("isAuthenticatedApiRoute marks protected routes only", () => {
   assert.equal(isAuthenticatedApiRoute("GET", "/v1/leagues"), true);
   assert.equal(isAuthenticatedApiRoute("GET", "/v1/leagues/league-1"), true);
   assert.equal(isAuthenticatedApiRoute("GET", "/v1/leagues/league-1/seasons"), true);
+  assert.equal(isAuthenticatedApiRoute("GET", "/v1/leagues/league-1/seasons/season-1"), true);
+  assert.equal(isAuthenticatedApiRoute("DELETE", "/v1/leagues/league-1/seasons/season-1"), true);
+  assert.equal(isAuthenticatedApiRoute("GET", "/v1/leagues/league-1/seasons/season-1/games"), true);
   assert.equal(isAuthenticatedApiRoute("DELETE", "/v1/leagues/league-1"), true);
   assert.equal(isAuthenticatedApiRoute("GET", "/v1/seasons/season-1"), true);
   assert.equal(isAuthenticatedApiRoute("GET", "/v1/seasons/season-1/games"), true);
@@ -59,6 +62,11 @@ test("isAuthenticatedApiRoute marks protected routes only", () => {
   assert.equal(isAuthenticatedApiRoute("GET", "/v1/auth/session"), true);
   assert.equal(isAuthenticatedApiRoute("POST", "/v1/leagues"), true);
   assert.equal(isAuthenticatedApiRoute("POST", "/v1/leagues/league-1/seasons"), true);
+  assert.equal(isAuthenticatedApiRoute("POST", "/v1/leagues/league-1/seasons/season-1/sessions"), true);
+  assert.equal(
+    isAuthenticatedApiRoute("POST", "/v1/leagues/league-1/seasons/season-1/sessions/session-1/games"),
+    true,
+  );
   assert.equal(isAuthenticatedApiRoute("POST", "/v1/seasons/season-1/sessions"), true);
   assert.equal(isAuthenticatedApiRoute("POST", "/v1/sessions/session-1/games"), true);
   assert.equal(isAuthenticatedApiRoute("POST", "/v1/dev/items"), true);

--- a/app/src/server.ts
+++ b/app/src/server.ts
@@ -206,6 +206,21 @@ export function createAppRequestHandler(apiBaseUrl: string) {
       return;
     }
 
+    const leagueSeasonPageMatch = route.match(/^\/leagues\/([^/]+)\/seasons\/([^/]+)$/);
+    if (method === "GET" && leagueSeasonPageMatch) {
+      sendHtml(
+        response,
+        securityHeaders,
+        200,
+        renderSeasonPage(
+          apiBaseUrl,
+          decodeURIComponent(leagueSeasonPageMatch[2]),
+          decodeURIComponent(leagueSeasonPageMatch[1]),
+        ),
+      );
+      return;
+    }
+
     const seasonPageMatch = route.match(/^\/seasons\/([^/]+)$/);
     if (method === "GET" && seasonPageMatch) {
       sendHtml(

--- a/app/src/tests/server.test.ts
+++ b/app/src/tests/server.test.ts
@@ -138,6 +138,11 @@ test("league, season, game, join, and invite routes render their shells", () => 
   assert.match(seasonResponse.body, /data-testid="season-shell"/);
   assert.match(seasonResponse.body, /data-page="season"/);
 
+  const leagueSeasonResponse = executeRoute("GET", "/leagues/league-1/seasons/season-1");
+  assert.equal(leagueSeasonResponse.statusCode, 200);
+  assert.match(leagueSeasonResponse.body, /data-testid="season-shell"/);
+  assert.match(leagueSeasonResponse.body, /data-league-id="league-1"/);
+
   const response = executeRoute(
     "GET",
     "/games/game-123",

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -149,6 +149,7 @@ interface MockApiState {
   storage: Map<string, string>;
   pendingToken: string | null;
   pendingEmail: string | null;
+  disableScopedSeasonApi: boolean;
   session: MockSession | null;
   leagues: Map<string, MockLeague>;
   leagueAccess: Map<string, MockLeagueRole>;
@@ -170,6 +171,7 @@ interface MockApiState {
     body: Record<string, unknown>;
     idempotencyKey: string | null;
   } | null;
+  seasonDeleteRequests: Array<{ path: string; leagueId: string | null; seasonId: string }>;
 }
 
 function readUiScript(fileName: string): string {
@@ -182,6 +184,7 @@ function createMockApiState(): MockApiState {
     storage: new Map<string, string>(),
     pendingToken: null,
     pendingEmail: null,
+    disableScopedSeasonApi: false,
     session: null,
     leagues: new Map<string, MockLeague>(),
     leagueAccess: new Map<string, MockLeagueRole>(),
@@ -199,6 +202,7 @@ function createMockApiState(): MockApiState {
     lastPublicJoinRequest: null,
     lastGrantAccessRequest: null,
     lastOrganiserInviteRequest: null,
+    seasonDeleteRequests: [],
   };
 }
 
@@ -1071,6 +1075,121 @@ function createMockFetch(state: MockApiState) {
       return createJsonResponse(201, season);
     }
 
+    const leagueSeasonMatch = path.match(/^\/v1\/leagues\/([^/]+)\/seasons\/([^/]+)$/);
+    if (method === "GET" && leagueSeasonMatch) {
+      if (state.disableScopedSeasonApi) {
+        return createJsonResponse(404, { error: "not_found", message: "Route not found." });
+      }
+
+      const leagueId = decodeURIComponent(leagueSeasonMatch[1]);
+      const seasonId = decodeURIComponent(leagueSeasonMatch[2]);
+      const season =
+        [...state.seasons.values()].find(
+          (candidate) => candidate.leagueId === leagueId && candidate.seasonId === seasonId,
+        ) ?? null;
+      if (!season) {
+        return createJsonResponse(404, { error: "not_found", message: "Season not found." });
+      }
+
+      return createJsonResponse(200, season);
+    }
+
+    const leagueSeasonGamesMatch = path.match(/^\/v1\/leagues\/([^/]+)\/seasons\/([^/]+)\/games$/);
+    if (method === "GET" && leagueSeasonGamesMatch) {
+      if (state.disableScopedSeasonApi) {
+        return createJsonResponse(404, { error: "not_found", message: "Route not found." });
+      }
+
+      const leagueId = decodeURIComponent(leagueSeasonGamesMatch[1]);
+      const seasonId = decodeURIComponent(leagueSeasonGamesMatch[2]);
+      return createJsonResponse(200, {
+        games: [...state.games.values()].filter(
+          (game) => game.leagueId === leagueId && game.seasonId === seasonId,
+        ),
+      });
+    }
+
+    const leagueSeasonSessionsMatch = path.match(/^\/v1\/leagues\/([^/]+)\/seasons\/([^/]+)\/sessions$/);
+    if (method === "POST" && leagueSeasonSessionsMatch) {
+      if (state.disableScopedSeasonApi) {
+        return createJsonResponse(404, { error: "not_found", message: "Route not found." });
+      }
+
+      const seasonId = decodeURIComponent(leagueSeasonSessionsMatch[2]);
+      const sessionId = String(body.sessionId ?? "");
+      const sessionDate = String(body.sessionDate ?? "");
+      const now = "2026-03-28T11:00:03.000Z";
+      const sessionRecord: MockSessionEntity = {
+        seasonId,
+        sessionId,
+        sessionDate,
+        createdAt: now,
+        updatedAt: now,
+      };
+      state.sessions.set(sessionId, sessionRecord);
+      return createJsonResponse(201, sessionRecord);
+    }
+
+    const leagueSeasonSessionGamesMatch = path.match(
+      /^\/v1\/leagues\/([^/]+)\/seasons\/([^/]+)\/sessions\/([^/]+)\/games$/,
+    );
+    if (method === "POST" && leagueSeasonSessionGamesMatch) {
+      if (state.disableScopedSeasonApi) {
+        return createJsonResponse(404, { error: "not_found", message: "Route not found." });
+      }
+
+      const leagueId = decodeURIComponent(leagueSeasonSessionGamesMatch[1]);
+      const seasonId = decodeURIComponent(leagueSeasonSessionGamesMatch[2]);
+      const sessionId = decodeURIComponent(leagueSeasonSessionGamesMatch[3]);
+      const gameId = String(body.gameId ?? "");
+      const now = "2026-03-28T11:00:04.000Z";
+      const game: MockGame = {
+        gameId,
+        joinCode: `JOIN${gameId.slice(-4).toUpperCase()}`,
+        leagueId,
+        seasonId,
+        sessionId,
+        status: body.status === "live" || body.status === "finished" ? body.status : "scheduled",
+        gameStartTs: String(body.gameStartTs ?? ""),
+        thirdLengthMinutes:
+          body.thirdLengthMinutes === 25 || body.thirdLengthMinutes === 30
+            ? body.thirdLengthMinutes
+            : DEFAULT_THIRD_LENGTH_MINUTES,
+        thirds: createDefaultThirdTimerSegments(),
+        finishedAt: null,
+        result: null,
+        createdAt: now,
+        updatedAt: now,
+      };
+      state.games.set(gameId, game);
+      ensureGameTeams(state, game);
+      return createJsonResponse(201, game);
+    }
+
+    if (method === "DELETE" && leagueSeasonMatch) {
+      if (state.disableScopedSeasonApi) {
+        return createJsonResponse(404, { error: "not_found", message: "Route not found." });
+      }
+
+      const leagueId = decodeURIComponent(leagueSeasonMatch[1]);
+      const seasonId = decodeURIComponent(leagueSeasonMatch[2]);
+      state.seasonDeleteRequests.push({ path, leagueId, seasonId });
+      const season = state.seasons.get(seasonId);
+      if (!season || season.leagueId !== leagueId) {
+        return createJsonResponse(404, { error: "not_found", message: "Season not found." });
+      }
+
+      if ([...state.games.values()].some((game) => game.leagueId === leagueId && game.seasonId === seasonId)) {
+        return createJsonResponse(409, {
+          error: "conflict",
+          message: "Cannot delete season with existing games.",
+        });
+      }
+
+      state.seasons.delete(seasonId);
+      return new Response(null, { status: 204 });
+    }
+
     const seasonMatch = path.match(/^\/v1\/seasons\/([^/]+)$/);
     if (method === "GET" && seasonMatch) {
       const season = state.seasons.get(decodeURIComponent(seasonMatch[1]));
@@ -1083,6 +1202,7 @@ function createMockFetch(state: MockApiState) {
 
     if (method === "DELETE" && seasonMatch) {
       const seasonId = decodeURIComponent(seasonMatch[1]);
+      state.seasonDeleteRequests.push({ path, leagueId: null, seasonId });
       if (![...state.seasons.keys()].includes(seasonId)) {
         return createJsonResponse(404, { error: "not_found", message: "Season not found." });
       }
@@ -1938,11 +2058,11 @@ test("setup flow shows inline validation for blank required fields", async () =>
 
   const seasonNavigation = leaguePage.navigations.at(-1);
   assert(seasonNavigation);
-  assert.equal(seasonNavigation.url, "/seasons/autumn-2026");
+  assert.equal(seasonNavigation.url, "/leagues/autumn-league/seasons/autumn-2026");
 
   const seasonPage = await bootPage({
-    html: renderSeasonPage("http://localhost:3001", "autumn-2026"),
-    url: "http://localhost:3000/seasons/autumn-2026",
+    html: renderSeasonPage("http://localhost:3001", "autumn-2026", "autumn-league"),
+    url: "http://localhost:3000/leagues/autumn-league/seasons/autumn-2026",
     scriptFile: "setup-flow.js",
     apiState,
   });
@@ -2309,6 +2429,106 @@ test("season page renders game kickoff times in the user local timezone", async 
   assert.doesNotMatch(gamesBody.textContent ?? "", /Z\b|UTC/);
 });
 
+test("league static shell remounts nested league season routes as scoped season pages", async () => {
+  const apiState = createMockApiState();
+  seedGoalScoringGame(apiState, {
+    gameId: "game-season-static-fallback",
+    role: "admin",
+  });
+
+  const page = await bootPage({
+    html: renderLeaguePage("http://localhost:3001", ""),
+    url: "http://localhost:3000/leagues/three-sided-football-club/seasons/autumn-cup",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+
+  const root = page.document.getElementById("setup-flow-root");
+  const shell = page.document.querySelector('[data-testid="season-shell"]');
+  const gamesBody = page.document.getElementById("season-games-body");
+
+  assert(shell instanceof page.window.HTMLElement);
+  assert.equal(root?.getAttribute("data-page"), "season");
+  assert.equal(root?.getAttribute("data-league-id"), "three-sided-football-club");
+  assert.equal(root?.getAttribute("data-season-id"), "autumn-cup");
+  assert.equal(page.document.getElementById("season-title")?.textContent, "Autumn Cup");
+  assert(gamesBody instanceof page.window.HTMLElement);
+  assert.match(gamesBody.textContent ?? "", /game-season-static-fallback/);
+});
+
+test("season page falls back to legacy season APIs during site-first scoped rollout", async () => {
+  const apiState = createMockApiState();
+  apiState.disableScopedSeasonApi = true;
+  apiState.session = {
+    sessionId: "session-1",
+    email: "organizer@3fc.football",
+    createdAt: "2026-03-28T11:00:00.000Z",
+    expiresAt: "2026-03-29T11:00:00.000Z",
+  };
+  apiState.cookieJar = "threefc_session=session-1";
+  apiState.leagues.set("league-a", {
+    leagueId: "league-a",
+    name: "League A",
+    slug: "league-a",
+    createdByUserId: "organizer@3fc.football",
+    createdAt: "2026-03-28T11:00:01.000Z",
+    updatedAt: "2026-03-28T11:00:01.000Z",
+  });
+  apiState.seasons.set("winter-2026", {
+    leagueId: "league-a",
+    seasonId: "winter-2026",
+    name: "Winter 2026",
+    slug: "winter-2026",
+    startsOn: null,
+    endsOn: null,
+    createdAt: "2026-03-28T11:00:02.000Z",
+    updatedAt: "2026-03-28T11:00:02.000Z",
+  });
+  apiState.games.set("game-visible", {
+    gameId: "game-visible",
+    joinCode: "JOIN1111",
+    leagueId: "league-a",
+    seasonId: "winter-2026",
+    sessionId: "session-shared",
+    status: "scheduled",
+    gameStartTs: "2026-06-21T10:00:00.000Z",
+    thirdLengthMinutes: DEFAULT_THIRD_LENGTH_MINUTES,
+    thirds: createDefaultThirdTimerSegments(),
+    finishedAt: null,
+    result: null,
+    createdAt: "2026-03-28T11:00:03.000Z",
+    updatedAt: "2026-03-28T11:00:03.000Z",
+  });
+  apiState.games.set("game-foreign", {
+    gameId: "game-foreign",
+    joinCode: "JOIN2222",
+    leagueId: "league-b",
+    seasonId: "winter-2026",
+    sessionId: "session-shared",
+    status: "scheduled",
+    gameStartTs: "2026-06-21T10:05:00.000Z",
+    thirdLengthMinutes: DEFAULT_THIRD_LENGTH_MINUTES,
+    thirds: createDefaultThirdTimerSegments(),
+    finishedAt: null,
+    result: null,
+    createdAt: "2026-03-28T11:00:04.000Z",
+    updatedAt: "2026-03-28T11:00:04.000Z",
+  });
+
+  const page = await bootPage({
+    html: renderSeasonPage("http://localhost:3001", "winter-2026", "league-a"),
+    url: "http://localhost:3000/leagues/league-a/seasons/winter-2026",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+
+  const gamesBody = page.document.getElementById("season-games-body");
+  assert(gamesBody instanceof page.window.HTMLElement);
+  assert.equal(page.document.getElementById("season-title")?.textContent, "Winter 2026");
+  assert.match(gamesBody.textContent ?? "", /game-visible/);
+  assert.doesNotMatch(gamesBody.textContent ?? "", /game-foreign/);
+});
+
 test("setup happy path runs from sign-in to created game context", async () => {
   const apiState = createMockApiState();
 
@@ -2392,11 +2612,11 @@ test("setup happy path runs from sign-in to created game context", async () => {
 
   const seasonNavigation = leaguePage.navigations.at(-1);
   assert(seasonNavigation);
-  assert.equal(seasonNavigation.url, "/seasons/autumn-cup");
+  assert.equal(seasonNavigation.url, "/leagues/three-sided-football-club/seasons/autumn-cup");
 
   const seasonPage = await bootPage({
-    html: renderSeasonPage("http://localhost:3001", "autumn-cup"),
-    url: "http://localhost:3000/seasons/autumn-cup",
+    html: renderSeasonPage("http://localhost:3001", "autumn-cup", "three-sided-football-club"),
+    url: "http://localhost:3000/leagues/three-sided-football-club/seasons/autumn-cup",
     scriptFile: "setup-flow.js",
     apiState,
   });
@@ -2443,7 +2663,66 @@ test("setup happy path runs from sign-in to created game context", async () => {
   assert.doesNotMatch(subtitle?.textContent ?? "", /Z\b|UTC/);
   assert.equal(leagueId?.textContent, "three-sided-football-club");
   assert.equal(seasonId?.textContent, "autumn-cup");
-  assert.equal(createAnotherLink?.getAttribute("href"), "/seasons/autumn-cup");
+  assert.equal(
+    createAnotherLink?.getAttribute("href"),
+    "/leagues/three-sided-football-club/seasons/autumn-cup",
+  );
+});
+
+test("season page does not fall back to legacy create routes when scoped writes are unavailable", async () => {
+  const apiState = createMockApiState();
+  apiState.disableScopedSeasonApi = true;
+  apiState.session = {
+    sessionId: "session-1",
+    email: "organizer@3fc.football",
+    createdAt: "2026-03-28T11:00:00.000Z",
+    expiresAt: "2026-03-29T11:00:00.000Z",
+  };
+  apiState.cookieJar = "threefc_session=session-1";
+  apiState.leagues.set("three-sided-football-club", {
+    leagueId: "three-sided-football-club",
+    name: "Three Sided Football Club",
+    slug: "three-sided-football-club",
+    createdByUserId: apiState.session.email,
+    createdAt: "2026-03-28T11:00:01.000Z",
+    updatedAt: "2026-03-28T11:00:01.000Z",
+  });
+  apiState.seasons.set("autumn-cup", {
+    leagueId: "three-sided-football-club",
+    seasonId: "autumn-cup",
+    name: "Autumn Cup",
+    slug: "autumn-cup",
+    startsOn: null,
+    endsOn: null,
+    createdAt: "2026-03-28T11:00:02.000Z",
+    updatedAt: "2026-03-28T11:00:02.000Z",
+  });
+
+  const seasonPage = await bootPage({
+    html: renderSeasonPage("http://localhost:3001", "autumn-cup", "three-sided-football-club"),
+    url: "http://localhost:3000/leagues/three-sided-football-club/seasons/autumn-cup",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+
+  const gameDateInput = seasonPage.document.getElementById("game-date");
+  const gameKickoffInput = seasonPage.document.getElementById("game-kickoff");
+  const createGameButton = seasonPage.document.querySelector('[data-action="create-game"]');
+  assert(gameDateInput instanceof seasonPage.window.HTMLInputElement);
+  assert(gameKickoffInput instanceof seasonPage.window.HTMLInputElement);
+  assert(createGameButton instanceof seasonPage.window.HTMLButtonElement);
+
+  gameDateInput.value = "2026-03-28";
+  gameDateInput.dispatchEvent(new seasonPage.window.Event("change", { bubbles: true }));
+  gameKickoffInput.value = "2026-03-28T10:00";
+  gameKickoffInput.dispatchEvent(new seasonPage.window.Event("change", { bubbles: true }));
+  dispatchClick(createGameButton);
+  await flushAsync();
+
+  assert.equal(apiState.sessions.size, 0);
+  assert.equal(apiState.games.size, 0);
+  assert.equal(seasonPage.navigations.length, 0);
+  assert.equal(seasonPage.document.getElementById("setup-status")?.textContent, "Game creation failed.");
 });
 
 test("league page header delete button deletes an empty league", async () => {
@@ -2529,7 +2808,65 @@ test("season page header delete button deletes an empty season", async () => {
   await flushAsync();
 
   assert.equal(apiState.seasons.has("autumn-cup"), false);
+  assert.deepEqual(apiState.seasonDeleteRequests, [
+    {
+      path: "/v1/leagues/three-sided-football-club/seasons/autumn-cup",
+      leagueId: "three-sided-football-club",
+      seasonId: "autumn-cup",
+    },
+  ]);
   assert.equal(page.navigations.at(-1)?.url, "/leagues/three-sided-football-club");
+});
+
+test("season page delete does not fall back to legacy API during site-first scoped rollout", async () => {
+  const apiState = createMockApiState();
+  apiState.disableScopedSeasonApi = true;
+  apiState.session = {
+    sessionId: "session-1",
+    email: "organizer@3fc.football",
+    createdAt: "2026-03-28T11:00:00.000Z",
+    expiresAt: "2026-03-29T11:00:00.000Z",
+  };
+  apiState.cookieJar = "threefc_session=session-1";
+  apiState.leagues.set("three-sided-football-club", {
+    leagueId: "three-sided-football-club",
+    name: "Three Sided Football Club",
+    slug: "three-sided-football-club",
+    createdByUserId: apiState.session.email,
+    createdAt: "2026-03-28T11:00:01.000Z",
+    updatedAt: "2026-03-28T11:00:01.000Z",
+  });
+  apiState.seasons.set("autumn-cup", {
+    leagueId: "three-sided-football-club",
+    seasonId: "autumn-cup",
+    name: "Autumn Cup",
+    slug: "autumn-cup",
+    startsOn: null,
+    endsOn: null,
+    createdAt: "2026-03-28T11:00:02.000Z",
+    updatedAt: "2026-03-28T11:00:02.000Z",
+  });
+
+  const page = await bootPage({
+    html: renderSeasonPage("http://localhost:3001", "autumn-cup", "three-sided-football-club"),
+    url: "http://localhost:3000/leagues/three-sided-football-club/seasons/autumn-cup",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+  Object.defineProperty(page.window, "confirm", {
+    value: () => true,
+    configurable: true,
+  });
+
+  const deleteSeasonButton = page.document.querySelector('[data-testid="delete-season"]');
+  assert(deleteSeasonButton instanceof page.window.HTMLButtonElement);
+  dispatchClick(deleteSeasonButton);
+  await flushAsync();
+
+  assert.equal(apiState.seasons.has("autumn-cup"), true);
+  assert.deepEqual(apiState.seasonDeleteRequests, []);
+  assert.equal(page.navigations.length, 0);
+  assert.equal(page.document.getElementById("setup-status")?.textContent, "Season deletion failed.");
 });
 
 test("game page quick-creates and assigns roster players", async () => {

--- a/app/src/tests/static-export.test.ts
+++ b/app/src/tests/static-export.test.ts
@@ -74,5 +74,6 @@ test("CloudFront router maps deployed join deep links to exported shells", () =>
   assert.equal(runCloudFrontRouter("/join/ABCD2345"), "/join/index.html");
   assert.equal(runCloudFrontRouter("/invites"), "/invites/index.html");
   assert.equal(runCloudFrontRouter("/invites/ABCD2345"), "/invites/index.html");
+  assert.equal(runCloudFrontRouter("/leagues/league-1/seasons/season-1"), "/seasons/index.html");
   assert.equal(runCloudFrontRouter("/ui/setup-flow.js"), "/ui/setup-flow.js");
 });

--- a/app/src/ui/layout.ts
+++ b/app/src/ui/layout.ts
@@ -406,8 +406,9 @@ export function renderInvitePage(apiBaseUrl: string, inviteCode: string): string
 </html>`;
 }
 
-export function renderSeasonPage(apiBaseUrl: string, seasonId: string): string {
+export function renderSeasonPage(apiBaseUrl: string, seasonId: string, leagueId = ""): string {
   const safeSeasonId = escapeHtml(seasonId);
+  const safeLeagueId = escapeHtml(leagueId);
   const seasonHeading = safeSeasonId.length > 0 ? safeSeasonId : "Season";
   const createGamePanel = renderPanel(
     "Create game",
@@ -463,7 +464,7 @@ export function renderSeasonPage(apiBaseUrl: string, seasonId: string): string {
     ${renderStylesheetLink()}
   </head>
   <body data-api-base-url="${escapeHtml(apiBaseUrl)}">
-    <main data-ui="app-shell" data-testid="season-shell" data-api-base-url="${escapeHtml(apiBaseUrl)}">
+    <main data-ui="app-shell" data-testid="season-shell" data-api-base-url="${escapeHtml(apiBaseUrl)}" data-season-id="${safeSeasonId}" data-league-id="${safeLeagueId}">
       <section data-ui="hero">
         <span data-ui="hero-kicker"><a href="/setup">Dashboard</a> / <a id="season-league-link" href="/setup">League</a> / Season</span>
         <h1 id="season-title">${seasonHeading}</h1>
@@ -474,7 +475,7 @@ export function renderSeasonPage(apiBaseUrl: string, seasonId: string): string {
           "data-testid": "delete-season",
         })}</div>
       </section>
-      <section data-ui="setup-flow" id="setup-flow-root" data-testid="setup-flow-root" data-page="season" data-api-base-url="${escapeHtml(apiBaseUrl)}" data-season-id="${safeSeasonId}">
+      <section data-ui="setup-flow" id="setup-flow-root" data-testid="setup-flow-root" data-page="season" data-api-base-url="${escapeHtml(apiBaseUrl)}" data-season-id="${safeSeasonId}" data-league-id="${safeLeagueId}">
         <p data-ui="status-note" id="setup-status">Loading season data…</p>
         <p data-ui="status-note" data-state="error" id="setup-error" hidden></p>
         <section data-ui="panel-grid" data-testid="season-grid">

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -1,14 +1,29 @@
 (() => {
-  const root = document.getElementById("setup-flow-root");
-  if (!root) {
-    return;
+  let root = document.getElementById("setup-flow-root");
+  let apiBaseUrl = "";
+  let page = "dashboard";
+  let statusElement = null;
+  let errorElement = null;
+
+  function refreshShellReferences() {
+    root = document.getElementById("setup-flow-root");
+    if (!root) {
+      return false;
+    }
+
+    apiBaseUrl =
+      root.getAttribute("data-api-base-url") ??
+      document.body.getAttribute("data-api-base-url") ??
+      "";
+    page = root.getAttribute("data-page") ?? "dashboard";
+    statusElement = document.getElementById("setup-status");
+    errorElement = document.getElementById("setup-error");
+    return true;
   }
 
-  const apiBaseUrl = root.getAttribute("data-api-base-url") ?? "";
-  const page = root.getAttribute("data-page") ?? "dashboard";
-
-  const statusElement = document.getElementById("setup-status");
-  const errorElement = document.getElementById("setup-error");
+  if (!refreshShellReferences()) {
+    return;
+  }
 
   function escapeHtml(value) {
     return value
@@ -182,6 +197,159 @@
     } catch {
       return pathSegments[collectionIndex + 1];
     }
+  }
+
+  function buildLeagueSeasonPath(leagueId, seasonId) {
+    return `/leagues/${encodeURIComponent(leagueId)}/seasons/${encodeURIComponent(seasonId)}`;
+  }
+
+  function resolveNestedLeagueSeasonRoute() {
+    const pathSegments = window.location.pathname
+      .split("/")
+      .map((segment) => segment.trim())
+      .filter((segment) => segment.length > 0);
+
+    const leaguesIndex = pathSegments.indexOf("leagues");
+    if (
+      leaguesIndex < 0 ||
+      pathSegments[leaguesIndex + 2] !== "seasons" ||
+      pathSegments.length <= leaguesIndex + 3
+    ) {
+      return null;
+    }
+
+    try {
+      return {
+        leagueId: decodeURIComponent(pathSegments[leaguesIndex + 1]),
+        seasonId: decodeURIComponent(pathSegments[leaguesIndex + 3]),
+      };
+    } catch {
+      return {
+        leagueId: pathSegments[leaguesIndex + 1],
+        seasonId: pathSegments[leaguesIndex + 3],
+      };
+    }
+  }
+
+  function renderClientValidatedField({ id, label, type, required = false }) {
+    return `<div data-ui="field">
+      <label for="${escapeHtml(id)}">${escapeHtml(label)}</label>
+      <input id="${escapeHtml(id)}" data-ui="input" data-testid="${escapeHtml(id)}" type="${escapeHtml(type)}"${required ? " required" : ""} />
+      <p data-ui="field-hint" id="${escapeHtml(id)}-notice" data-default-kind="empty" data-default-message=""></p>
+    </div>`;
+  }
+
+  function renderClientPanel(title, description, body, footer, testId) {
+    return `<article data-ui="panel" data-testid="${escapeHtml(testId)}">
+      <div data-ui="panel-heading">
+        <h2>${escapeHtml(title)}</h2>
+        <p>${escapeHtml(description)}</p>
+      </div>
+      <div data-ui="panel-body">${body}</div>
+      ${footer ? `<div data-ui="panel-footer">${footer}</div>` : ""}
+    </article>`;
+  }
+
+  function renderClientButton(label, variant, attributes) {
+    const renderedAttributes = Object.entries(attributes)
+      .map(([name, value]) => `${name}="${escapeHtml(String(value))}"`)
+      .join(" ");
+    return `<button data-ui="button" data-variant="${escapeHtml(variant)}" ${renderedAttributes}>${escapeHtml(label)}</button>`;
+  }
+
+  function renderClientTableShell({ tableTestId, bodyId, emptyId, emptyText, headers }) {
+    return `<div data-ui="table-wrap" data-testid="${escapeHtml(tableTestId)}" hidden>
+      <table>
+        <thead>
+          <tr>${headers.map((header) => `<th>${escapeHtml(header)}</th>`).join("")}</tr>
+        </thead>
+        <tbody id="${escapeHtml(bodyId)}"></tbody>
+      </table>
+    </div>
+    <p data-ui="empty-state" id="${escapeHtml(emptyId)}">${escapeHtml(emptyText)}</p>`;
+  }
+
+  function mountSeasonShellForNestedLeagueRoute() {
+    if (page !== "league") {
+      return;
+    }
+
+    const route = resolveNestedLeagueSeasonRoute();
+    if (!route) {
+      return;
+    }
+
+    const safeApiBaseUrl = escapeHtml(apiBaseUrl);
+    const safeLeagueId = escapeHtml(route.leagueId);
+    const safeSeasonId = escapeHtml(route.seasonId);
+    const createGamePanel = renderClientPanel(
+      "Create game",
+      "Add a game into this season.",
+      `${renderClientValidatedField({
+        id: "game-date",
+        label: "Game date",
+        type: "date",
+        required: true,
+      })}${renderClientValidatedField({
+        id: "game-kickoff",
+        label: "Kickoff time",
+        type: "datetime-local",
+        required: true,
+      })}
+      <div data-ui="field">
+        <label for="game-third-length">Third length</label>
+        <select id="game-third-length" data-ui="input" data-testid="game-third-length">
+          <option value="20" selected>20 minutes</option>
+          <option value="25">25 minutes</option>
+          <option value="30">30 minutes</option>
+        </select>
+      </div>
+      <dl data-ui="id-preview"><div><dt>Game ID</dt><dd id="game-id-display">Not generated yet</dd></div></dl>`,
+      `<div data-ui="button-row">${renderClientButton("Create game", "primary", {
+        type: "button",
+        "data-action": "create-game",
+        "data-testid": "create-game",
+      })}</div>`,
+      "panel-season-create-game",
+    );
+    const gamesPanel = renderClientPanel(
+      "Games",
+      "Manage scheduled games for this season.",
+      renderClientTableShell({
+        tableTestId: "season-games-table",
+        bodyId: "season-games-body",
+        emptyId: "season-games-empty",
+        emptyText: "No games yet. Create your first game.",
+        headers: ["Game", "Kickoff", "Status", "Actions"],
+      }),
+      "",
+      "panel-season-games",
+    );
+
+    document.title = "3FC Season";
+    document.body.setAttribute("data-api-base-url", apiBaseUrl);
+    document.body.innerHTML = `<main data-ui="app-shell" data-testid="season-shell" data-api-base-url="${safeApiBaseUrl}" data-season-id="${safeSeasonId}" data-league-id="${safeLeagueId}">
+      <section data-ui="hero">
+        <span data-ui="hero-kicker"><a href="/setup">Dashboard</a> / <a id="season-league-link" href="/setup">League</a> / Season</span>
+        <h1 id="season-title">${safeSeasonId || "Season"}</h1>
+        <p data-ui="hero-copy" id="season-subtitle">Loading season details...</p>
+        <div data-ui="button-row">${renderClientButton("Delete season", "danger", {
+          type: "button",
+          "data-action": "delete-season",
+          "data-testid": "delete-season",
+        })}</div>
+      </section>
+      <section data-ui="setup-flow" id="setup-flow-root" data-testid="setup-flow-root" data-page="season" data-api-base-url="${safeApiBaseUrl}" data-season-id="${safeSeasonId}" data-league-id="${safeLeagueId}">
+        <p data-ui="status-note" id="setup-status">Loading season data...</p>
+        <p data-ui="status-note" data-state="error" id="setup-error" hidden></p>
+        <section data-ui="panel-grid" data-testid="season-grid">
+          ${createGamePanel}
+          ${gamesPanel}
+        </section>
+      </section>
+    </main>`;
+
+    refreshShellReferences();
   }
 
   function createIdempotencyKey(prefix, stablePart) {
@@ -570,6 +738,27 @@
     }
 
     return result.body;
+  }
+
+  function isRouteUnavailable(error) {
+    return error instanceof Error && (error.statusCode === 404 || error.statusCode === 405);
+  }
+
+  async function requestJsonOrThrowWithFallback(primaryPath, fallbackPath, init = {}, validateFallback = null) {
+    try {
+      return await requestJsonOrThrow(primaryPath, init);
+    } catch (error) {
+      if (!fallbackPath || !isRouteUnavailable(error)) {
+        throw error;
+      }
+
+      const fallbackBody = await requestJsonOrThrow(fallbackPath, init);
+      if (typeof validateFallback === "function" && !validateFallback(fallbackBody)) {
+        throw error;
+      }
+
+      return fallbackBody;
+    }
   }
 
   async function currentAuthenticatedSession() {
@@ -1125,13 +1314,14 @@
       seasonsBody.innerHTML = seasons
         .map((season) => {
           const dateRange = `${season.startsOn ?? "-"} to ${season.endsOn ?? "-"}`;
+          const seasonPath = buildLeagueSeasonPath(leagueId, season.seasonId);
           return `<tr>
-            <td><a href="/seasons/${encodeURIComponent(season.seasonId)}">${escapeHtml(season.name)}</a></td>
+            <td><a href="${seasonPath}">${escapeHtml(season.name)}</a></td>
             <td>${escapeHtml(dateRange)}</td>
             <td><code>${escapeHtml(season.slug ?? "-")}</code></td>
             <td>
               <div data-ui="row-action-buttons">
-                <a href="/seasons/${encodeURIComponent(season.seasonId)}" data-ui="button-link" data-variant="secondary">View</a>
+                <a href="${seasonPath}" data-ui="button-link" data-variant="secondary">View</a>
                 <button data-ui="row-action" data-tone="danger" type="button" data-action="delete-season" data-season-id="${escapeHtml(season.seasonId)}">Delete</button>
               </div>
             </td>
@@ -1181,7 +1371,7 @@
           }),
         });
 
-        navigateTo(`/seasons/${encodeURIComponent(seasonId)}`);
+        navigateTo(buildLeagueSeasonPath(leagueId, seasonId));
       } catch (error) {
         const message = error instanceof Error ? error.message : "Could not create season.";
         showError(message);
@@ -1332,6 +1522,7 @@
     if (!seasonId) {
       return;
     }
+    const routeLeagueId = resolveRouteEntityId("data-league-id", "leagues");
 
     const seasonTitle = document.getElementById("season-title");
     const seasonSubtitle = document.getElementById("season-subtitle");
@@ -1359,7 +1550,7 @@
       return;
     }
 
-    let leagueId = "";
+    let leagueId = routeLeagueId ?? "";
     let gameIdNonce = randomSuffix(4);
 
     function updateDerivedGameId() {
@@ -1397,9 +1588,16 @@
     updateDerivedGameId();
 
     async function loadSeason() {
-      const season = await requestJsonOrThrow(`/v1/seasons/${encodeURIComponent(seasonId)}`, {
-        method: "GET",
-      });
+      const seasonPath = routeLeagueId
+        ? `/v1/leagues/${encodeURIComponent(routeLeagueId)}/seasons/${encodeURIComponent(seasonId)}`
+        : `/v1/seasons/${encodeURIComponent(seasonId)}`;
+      const legacySeasonPath = `/v1/seasons/${encodeURIComponent(seasonId)}`;
+      const season = await requestJsonOrThrowWithFallback(
+        seasonPath,
+        routeLeagueId ? legacySeasonPath : null,
+        { method: "GET" },
+        (fallbackSeason) => fallbackSeason?.leagueId === routeLeagueId,
+      );
 
       leagueId = season.leagueId;
       if (seasonTitle) {
@@ -1418,11 +1616,19 @@
     }
 
     async function renderGames() {
-      const payload = await requestJsonOrThrow(`/v1/seasons/${encodeURIComponent(seasonId)}/games`, {
-        method: "GET",
-      });
+      const gamesPath = leagueId
+        ? `/v1/leagues/${encodeURIComponent(leagueId)}/seasons/${encodeURIComponent(seasonId)}/games`
+        : `/v1/seasons/${encodeURIComponent(seasonId)}/games`;
+      const legacyGamesPath = `/v1/seasons/${encodeURIComponent(seasonId)}/games`;
+      const payload = await requestJsonOrThrowWithFallback(
+        gamesPath,
+        leagueId ? legacyGamesPath : null,
+        { method: "GET" },
+      );
 
-      const games = Array.isArray(payload?.games) ? payload.games : [];
+      const games = (Array.isArray(payload?.games) ? payload.games : []).filter(
+        (game) => !leagueId || (game.leagueId === leagueId && game.seasonId === seasonId),
+      );
       if (games.length === 0) {
         gamesBody.innerHTML = "";
         if (gamesTableWrap instanceof HTMLElement) {
@@ -1483,11 +1689,14 @@
       setStatus("Creating game…", "default");
 
       try {
-        await requestJsonOrThrow(`/v1/seasons/${encodeURIComponent(seasonId)}/sessions`, {
+        const createSessionPath = leagueId
+          ? `/v1/leagues/${encodeURIComponent(leagueId)}/seasons/${encodeURIComponent(seasonId)}/sessions`
+          : `/v1/seasons/${encodeURIComponent(seasonId)}/sessions`;
+        await requestJsonOrThrow(createSessionPath, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            "Idempotency-Key": createIdempotencyKey("create-session", `${seasonId}-${sessionId}`),
+            "Idempotency-Key": createIdempotencyKey("create-session", `${leagueId}-${seasonId}-${sessionId}`),
           },
           body: JSON.stringify({
             sessionId,
@@ -1495,7 +1704,10 @@
           }),
         });
 
-        await requestJsonOrThrow(`/v1/sessions/${encodeURIComponent(sessionId)}/games`, {
+        const createGamePath = leagueId
+          ? `/v1/leagues/${encodeURIComponent(leagueId)}/seasons/${encodeURIComponent(seasonId)}/sessions/${encodeURIComponent(sessionId)}/games`
+          : `/v1/sessions/${encodeURIComponent(sessionId)}/games`;
+        await requestJsonOrThrow(createGamePath, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -1568,7 +1780,10 @@
         setStatus(`Deleting season ${seasonId}…`, "default");
 
         try {
-          await requestJsonOrThrow(`/v1/seasons/${encodeURIComponent(seasonId)}`, {
+          const deleteSeasonPath = leagueId
+            ? `/v1/leagues/${encodeURIComponent(leagueId)}/seasons/${encodeURIComponent(seasonId)}`
+            : `/v1/seasons/${encodeURIComponent(seasonId)}`;
+          await requestJsonOrThrow(deleteSeasonPath, {
             method: "DELETE",
           });
           navigateTo(`/leagues/${encodeURIComponent(leagueId)}`);
@@ -3227,10 +3442,10 @@
         gameLeagueLink.href = `/leagues/${encodeURIComponent(game.leagueId)}`;
       }
       if (gameSeasonLink instanceof HTMLAnchorElement) {
-        gameSeasonLink.href = `/seasons/${encodeURIComponent(game.seasonId)}`;
+        gameSeasonLink.href = buildLeagueSeasonPath(game.leagueId, game.seasonId);
       }
       if (createAnotherLink instanceof HTMLAnchorElement) {
-        createAnotherLink.href = `/seasons/${encodeURIComponent(game.seasonId)}`;
+        createAnotherLink.href = buildLeagueSeasonPath(game.leagueId, game.seasonId);
       }
     }
 
@@ -3317,7 +3532,7 @@
         await requestJsonOrThrow(`/v1/games/${encodeURIComponent(gameId)}`, {
           method: "DELETE",
         });
-        navigateTo(`/seasons/${encodeURIComponent(currentSeasonId)}`);
+        navigateTo(buildLeagueSeasonPath(currentLeagueId, currentSeasonId));
       } catch (error) {
         const message = error instanceof Error ? error.message : "Could not delete game.";
         showError(message);
@@ -3844,9 +4059,10 @@
     syncGameModeState();
 
     try {
-      const season = await requestJsonOrThrow(`/v1/seasons/${encodeURIComponent(currentSeasonId)}`, {
-        method: "GET",
-      });
+      const seasonPath = currentLeagueId
+        ? `/v1/leagues/${encodeURIComponent(currentLeagueId)}/seasons/${encodeURIComponent(currentSeasonId)}`
+        : `/v1/seasons/${encodeURIComponent(currentSeasonId)}`;
+      const season = await requestJsonOrThrow(seasonPath, { method: "GET" });
       const previousLeagueId = currentLeagueId;
       currentLeagueId = season.leagueId;
       if (gameLeagueLink instanceof HTMLAnchorElement) {
@@ -4218,6 +4434,7 @@
   }
 
   async function initialize() {
+    mountSeasonShellForNestedLeagueRoute();
     clearError();
 
     if (page === "join") {

--- a/docs/dynamodb-single-table.md
+++ b/docs/dynamodb-single-table.md
@@ -21,12 +21,35 @@ This document defines the baseline key structure and access patterns for the
 - Season lookup mirror (for ACL scope resolution):
   - `pk=SEASON#{seasonId}`
   - `sk=METADATA`
-- Team:
+- Season team:
+  - `pk=LEAGUE#{leagueId}`
+  - `sk=SEASON#{seasonId}#TEAM#{teamId}`
+  - canonical scoped season team defaults used when creating games
+- Session:
+  - `pk=LEAGUE#{leagueId}`
+  - `sk=SEASON#{seasonId}#SESSION#{sessionId}`
+  - canonical scoped season session/day owned by the league season
+- Legacy season team template:
   - `pk=SEASON#{seasonId}`
   - `sk=TEAM#{teamId}`
-- Session:
+  - compatibility read/write path during the scoped-key migration
+  - scoped reads only accept templates with row-level `leagueId` provenance
+    after atomically validating the requested scoped season exists
+  - scoped season deletion removes owned legacy templates in the same
+    conditional cleanup transaction as the season mirror
+- Legacy session:
   - `pk=SEASON#{seasonId}`
   - `sk=SESSION#{sessionId}`
+  - compatibility read/write path during the scoped-key migration
+  - scoped reads accept row-attributed sessions, or provenance-less legacy
+    sessions only while the global season mirror still belongs to the requested
+    league
+  - scoped session creation writes rollback-compatible legacy rows under the
+    same mirror ownership rule and only when existing legacy rows are absent,
+    provenance-less under that mirror, or already carry matching row-level
+    `leagueId` provenance
+  - row-attributed legacy session rows remain cleanup targets for that league
+    even if another league later replaces the global season mirror
 - Session lookup mirror (for ACL scope resolution):
   - `pk=SESSION#{sessionId}`
   - `sk=METADATA`
@@ -103,8 +126,10 @@ without schema rewrites at this stage.
 
 - Create/read league metadata.
 - Create/list seasons for a league.
-- Create/list teams for a season.
-- Create/list sessions for a season.
+- Create/list scoped teams for a league season, with owned legacy template
+  compatibility during migration.
+- Create/list scoped sessions for a league season, with global-mirror-gated
+  legacy session compatibility during migration.
 - Create/read game metadata.
 - Resolve join code to game for player self-registration.
 - Create/accept reusable share organiser invites and one-time email organiser invites, then grant league admin ACL entries.

--- a/docs/openapi/v1-core-write.yaml
+++ b/docs/openapi/v1-core-write.yaml
@@ -231,6 +231,192 @@ paths:
           $ref: "#/components/responses/NotFound"
         "409":
           $ref: "#/components/responses/IdempotencyConflict"
+  /v1/leagues/{leagueId}/seasons/{seasonId}:
+    get:
+      summary: Get a league-scoped season
+      description: >-
+        Resolves a season within its league so reused season slugs or IDs in
+        another league cannot select the wrong season.
+      operationId: getLeagueSeason
+      parameters:
+        - name: leagueId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: seasonId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Season found within the league
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Season"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+    delete:
+      summary: Delete a league-scoped season
+      description: >-
+        Deletes the season only from the requested league. The season must have
+        no remaining scoped sessions or games.
+      operationId: deleteLeagueSeason
+      parameters:
+        - name: leagueId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: seasonId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: Season deleted
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/Conflict"
+  /v1/leagues/{leagueId}/seasons/{seasonId}/sessions:
+    post:
+      summary: Create a session for a league-scoped season
+      description: >-
+        Creates the session after resolving the season within the requested
+        league, avoiding global season ID ambiguity.
+      operationId: createLeagueSeasonSession
+      parameters:
+        - name: leagueId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: seasonId
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateSessionRequest"
+      responses:
+        "201":
+          description: Session created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Session"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/IdempotencyConflict"
+  /v1/leagues/{leagueId}/seasons/{seasonId}/games:
+    get:
+      summary: List games for a league-scoped season
+      description: >-
+        Lists games only when both the session index and loaded game metadata
+        belong to the requested league and season.
+      operationId: listLeagueSeasonGames
+      parameters:
+        - name: leagueId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: seasonId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: League-scoped season games
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - games
+                properties:
+                  games:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Game"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+  /v1/leagues/{leagueId}/seasons/{seasonId}/sessions/{sessionId}/games:
+    post:
+      summary: Create a game for a league-scoped season session
+      description: >-
+        Creates a game with explicit league, season, and session scope so reused
+        season IDs cannot attach the game to another league.
+      operationId: createLeagueSeasonSessionGame
+      parameters:
+        - name: leagueId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: seasonId
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateGameRequest"
+      responses:
+        "201":
+          description: Game created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Game"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "409":
+          $ref: "#/components/responses/CreateGameConflict"
   /v1/seasons/{seasonId}/sessions:
     post:
       summary: Create session

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -49,8 +49,21 @@ gameId.
 
 - League: PK=LEAGUE#{leagueId}  SK=METADATA
 - Season: PK=LEAGUE#{leagueId}  SK=SEASON#{seasonId}
-- Team: PK=SEASON#{seasonId}    SK=TEAM#{teamId}
-- Session/Day: PK=SEASON#{seasonId} SK=SESSION#{yyyymmdd}
+- Season team: PK=LEAGUE#{leagueId} SK=SEASON#{seasonId}#TEAM#{teamId}
+- Session/Day: PK=LEAGUE#{leagueId} SK=SEASON#{seasonId}#SESSION#{yyyymmdd}
+- Legacy season team template: PK=SEASON#{seasonId} SK=TEAM#{teamId}
+  (compatibility read/write path during scoped-key migration; scoped reads only
+  accept templates with row-level `leagueId` provenance for an atomically
+  validated scoped season).
+- Legacy session/day: PK=SEASON#{seasonId} SK=SESSION#{yyyymmdd}
+  (compatibility read/write path during scoped-key migration; scoped reads
+  accept row-attributed sessions and provenance-less legacy sessions only while
+  the global season mirror still belongs to the requested league. Scoped writes
+  preserve rollback-compatible legacy rows only under the same mirror ownership
+  rule and when existing legacy rows are absent, provenance-less under that
+  mirror, or carry matching row-level `leagueId` provenance. Row-attributed
+  legacy session rows remain owned cleanup targets even if the global mirror is
+  later replaced by another league).
 - Game (metadata): PK=GAME#{gameId} SK=METADATA (leagueId, seasonId, sessionId,
   date, location, thirdLength, status, finishedAt, result).
 - GoalEvent (timeline): PK=GAME#{gameId}
@@ -70,7 +83,7 @@ gameId.
 - League organiser share invite pointer: PK=LEAGUE#{leagueId}
   SK=INVITE#ORGANISER_SHARE (active reusable organiser share invite code).
   Deleting a league invalidates organiser invite records and removes this pointer.
-- Admin grants: PK=ACL#{scopeType}#{scopeId} SK=ADMIN#{cognitoSub}
+- League ACL grants: PK=LEAGUE#{leagueId} SK=ACL#USER#{userId}
 
 ### 5.2 GoalEvent fields
 
@@ -118,6 +131,11 @@ POST  /v1/auth/magic/complete
 Core (authed):
 POST  /v1/leagues
 POST  /v1/leagues/{leagueId}/seasons
+GET   /v1/leagues/{leagueId}/seasons/{seasonId}
+DELETE /v1/leagues/{leagueId}/seasons/{seasonId}
+GET   /v1/leagues/{leagueId}/seasons/{seasonId}/games
+POST  /v1/leagues/{leagueId}/seasons/{seasonId}/sessions
+POST  /v1/leagues/{leagueId}/seasons/{seasonId}/sessions/{sessionId}/games
 POST  /v1/seasons/{seasonId}/sessions
 POST  /v1/sessions/{sessionId}/games
 PATCH /v1/games/{gameId}

--- a/infra/application/cloudfront-site-router.js
+++ b/infra/application/cloudfront-site-router.js
@@ -23,12 +23,16 @@ function rewriteToShell(uri) {
     return "/ui/components/index.html";
   }
 
-  if (uri === "/leagues" || uri.indexOf("/leagues/") === 0) {
-    return "/leagues/index.html";
-  }
-
   if (uri === "/seasons" || uri.indexOf("/seasons/") === 0) {
     return "/seasons/index.html";
+  }
+
+  if (/^\/leagues\/[^/]+\/seasons(?:\/|$)/.test(uri)) {
+    return "/seasons/index.html";
+  }
+
+  if (uri === "/leagues" || uri.indexOf("/leagues/") === 0) {
+    return "/leagues/index.html";
   }
 
   if (uri === "/games" || uri.indexOf("/games/") === 0) {

--- a/serverless.api-core.yml
+++ b/serverless.api-core.yml
@@ -152,6 +152,33 @@ functions:
           path: /v1/leagues/{leagueId}/seasons
       - httpApi:
           method: GET
+          path: /v1/leagues/{leagueId}/seasons/{seasonId}
+      - httpApi:
+          method: DELETE
+          path: /v1/leagues/{leagueId}/seasons/{seasonId}
+      - httpApi:
+          method: OPTIONS
+          path: /v1/leagues/{leagueId}/seasons/{seasonId}
+      - httpApi:
+          method: GET
+          path: /v1/leagues/{leagueId}/seasons/{seasonId}/games
+      - httpApi:
+          method: OPTIONS
+          path: /v1/leagues/{leagueId}/seasons/{seasonId}/games
+      - httpApi:
+          method: POST
+          path: /v1/leagues/{leagueId}/seasons/{seasonId}/sessions
+      - httpApi:
+          method: OPTIONS
+          path: /v1/leagues/{leagueId}/seasons/{seasonId}/sessions
+      - httpApi:
+          method: POST
+          path: /v1/leagues/{leagueId}/seasons/{seasonId}/sessions/{sessionId}/games
+      - httpApi:
+          method: OPTIONS
+          path: /v1/leagues/{leagueId}/seasons/{seasonId}/sessions/{sessionId}/games
+      - httpApi:
+          method: GET
           path: /v1/seasons/{seasonId}
       - httpApi:
           method: DELETE


### PR DESCRIPTION
<!-- review-packet-version:1 -->

## Behavioural claim

Season pages reached from a league remain league-scoped end to end. The app links to `/leagues/{leagueId}/seasons/{seasonId}`, the API exposes scoped season routes, and scoped route guards resolve the requested season with a strongly consistent keyed read. Season game listings only return games whose loaded metadata matches the requested `(leagueId, seasonId)` pair, while still preserving owned pre-deployment legacy sessions that lack row-level `leagueId` when the global season mirror proves ownership.

Normal scoped game creation writes the game, join-code lookup, session-game index, and session metadata touch in one repository transaction, so a failed session link cannot leave a publicly addressable orphan game. Scoped create-game idempotency recovery now condition-checks that the recovered game still exists unchanged before linking it to a session, so retry recovery cannot recreate an index for a deleted game.

Scoped session creation writes rollback-compatible legacy session rows only when the global season mirror still belongs to the requested league and any existing legacy rows are absent, provenance-less under that mirror, or attributed to the same league. Legacy session and team cleanup uses row-level `leagueId` provenance where available, so mirror replacement by another league cannot claim or strand another league's compatibility rows. Scoped game cleanup removes owned compatibility rows once no remaining game belongs to the deleted game's league and season, even when another league shares the date-derived session index. Legacy season team writes are also serialized against the owned global season row, so a concurrent scoped season delete cannot be followed by an orphan legacy team template write.

## Specification and acceptance evidence

| Acceptance criterion | Evidence | Result |
| --- | --- | --- |
| Season game listings exclude same-season games from another league. | `npm test -w @3fc/api` (`core lambda scopes season game listings to the authorized season league`; `repository scopes season game listings by league when session indexes collide`) | PASS |
| League-scoped season routes resolve seasons and games without depending on the global season lookup. | `npm test -w @3fc/api` (`core lambda serves league-scoped season game listings without global season lookup`) | PASS |
| Scoped season route guards use strongly consistent keyed reads, avoiding transient misses after season creation. | `npm test -w @3fc/api` (`core lambda serves league-scoped season game listings without global season lookup`; `core lambda creates league-scoped games from sessions in the requested league`) | PASS |
| Owned pre-deployment legacy sessions without row-level `leagueId` still expose their in-scope games. | `npm test -w @3fc/api` (`repository scoped season game listings include owned provenance-less legacy sessions`) | PASS |
| Join-code repair cannot replace or mutate a scoped season-list item with a same-id game from another league. | `npm test -w @3fc/api` (`core lambda keeps scoped season listing when join-code refresh sees foreign game metadata`; `repository skips legacy game join-code repair when expected scope does not match`) | PASS |
| Scoped game creation validates the requested league session and links the session atomically with game creation. | `npm test -w @3fc/api` (`repository links scoped sessions atomically when creating games`; `repository rolls back scoped game creation when session linking loses a race`; create-game route recovery tests) | PASS |
| Duplicate-game retry recovery only links an unchanged existing game into the session index. | `npm test -w @3fc/api` (`repository recovery session linking rejects games deleted before commit`; `core lambda guards duplicate-game recovery session linking with the existing game`; local server create-game recovery assertion) | PASS |
| Scoped session creation preserves rollback-compatible legacy session rows only when legacy ownership is safe. | `npm test -w @3fc/api` (`repository scoped session creation touches season metadata to serialize deletion`; `repository scoped session creation skips legacy compatibility rows when global mirror belongs to another league`; `repository scoped session creation aborts compatibility writes if global mirror changes`; `repository scoped session creation leaves foreign legacy session compatibility rows untouched`) | PASS |
| Row-attributed legacy session rows are cleaned up by their owning scoped league even after global mirror replacement. | `npm test -w @3fc/api` (`repository scoped game cleanup leaves unowned legacy sessions untouched`; `repository scoped game cleanup deletes row-attributed legacy sessions after mirror replacement`) | PASS |
| Owned legacy session compatibility rows are cleaned up when only foreign games remain in the shared session index. | `npm test -w @3fc/api` (`repository scoped game cleanup deletes owned legacy sessions despite foreign games`) | PASS |
| Legacy season team templates are row-attributed to a league and are not claimed or deleted after another league replaces/deletes the global mirror. | `npm test -w @3fc/api` (`repository reads owned legacy season team templates for scoped season teams`; `repository does not treat another league's legacy templates as owned after mirror replacement`; `repository scoped season delete removes owned legacy season team templates`) | PASS |
| Legacy season team writes cannot recreate orphan templates after scoped season deletion. | `npm test -w @3fc/api` (`repository rejects legacy season team writes when the season is deleted before commit`; `repository create-only season teams do not replace concurrent teams`) | PASS |
| Scoped season deletion blocks owned provenance-less legacy session rows and removes row-attributed legacy team templates after mirror replacement. | `npm test -w @3fc/api` (`repository scoped season delete blocks owned provenance-less legacy sessions without games`; `repository scoped season delete removes row-attributed legacy templates after mirror replacement`) | PASS |
| Scoped cleanup uses strong descendant reads and conditional transactions before destructive decisions. | `npm test -w @3fc/api` (`repository strongly reads session-game index before scoped game cleanup`; `repository scoped season delete uses consistent descendant reads`; `repository scoped season delete rejects sessions created after descendant checks`) | PASS |
| League-scoped app writes/deletes fail closed instead of falling back to unscoped legacy mutation APIs. | `npm test -w @3fc/app` (`season page does not fall back to legacy create routes when scoped writes are unavailable`; `season page delete does not fall back to legacy API during site-first scoped rollout`) | PASS |
| Static and app routing send league season links through the scoped season page. | `npm test -w @3fc/app` (`setup happy path runs from sign-in to created game context`; `league static shell remounts nested league season routes as scoped season pages`; CloudFront router tests) | PASS |
| API, app, contracts, build, lint/typecheck, whitespace, and local review-gate remain green. | `npm test`; `npm run build`; `npm run lint`; `git diff --check` on commit `02f4c70` | PASS |
| QA reproduction no longer lists cross-league games on the invited league season page after this head is deployed. | QA deploy passed for commit `02f4c70`. Browser QA: `/leagues/codex-invite-qa-20260802-1204` links to `/leagues/codex-invite-qa-20260802-1204/seasons/codex-finished-join-season-1209`; `/leagues/codex-invite-qa-20260802-1204/seasons/winter-2026` fails closed as not found with no game links; `/games/game-20260802-1000-3ee7` opens without the previous access error. | PASS |

## Scope boundaries

Included:

- Add and use league-scoped season routes for season pages and season game listings.
- Add a strongly consistent scoped season read and use it for scoped season route guards.
- Scope repository season game expansion by both `leagueId` and `seasonId` after loading game metadata, while retaining owned provenance-less legacy sessions during migration.
- Add league-scoped create-session/create-game paths and keep mutation fallbacks fail-closed for scoped pages.
- Link scoped game creation to its session in the same transaction as game and join-code creation.
- Guard duplicate-game recovery session linking by condition-checking the recovered existing game row.
- Write rollback-compatible legacy session rows for new scoped sessions only when the global season mirror still belongs to the same league and existing legacy rows are safe to preserve or normalize.
- Clean up owned legacy session compatibility rows when no remaining game belongs to the deleted game's league and season, regardless of foreign games sharing the same session index.
- Stamp legacy team/session writes with row-level `leagueId` when the global season mirror can attribute the write.
- Serialize legacy season team writes against the owned global season row, including create-only concurrent replay handling.
- Read/delete legacy season team templates and session rows by row-level `leagueId` provenance against the scoped season, not by trusting the current global mirror owner.
- Use strong reads and conditional transactions for scoped game/session/season cleanup and concurrent child protection.
- Update OpenAPI/deploy route config, app routing, static router source, `docs/spec.md`, and `docs/dynamodb-single-table.md` for the scoped routes and compatibility rows.

Excluded:

- No DynamoDB key migration or destructive data cleanup.
- No removal of legacy `/seasons/{seasonId}` app/API routes.
- No duplicate-season-slug prevention across leagues.
- No change to invite semantics from PR #111.
- No Terraform apply or live CloudFront Function publish in this PR.

## Change classification

- Declared risk: `high`
- [ ] `documentation-only` - Documentation only
- [ ] `tests-only` - Tests only
- [x] `application-behaviour` - Application or API behaviour
- [ ] `backlog-maintenance` - Canonical backlog maintenance
- [ ] `dependency-tooling` - Dependency or tooling
- [x] `public-contract` - Public API or repository contract
- [ ] `data-migration` - Database schema or data migration
- [x] `permission-trust-boundary` - Permission or trust boundary
- [x] `durable-state-ownership` - Durable state or ownership
- [x] `destructive-behaviour` - Destructive or difficult-to-reverse behaviour
- [ ] `new-production-dependency` - New production dependency
- [x] `authentication-authorisation` - Authentication or authorisation
- [ ] `privacy-regulated-data` - Privacy or regulated data
- [x] `infrastructure-production-configuration` - Infrastructure or deployment control
- [ ] `review-policy` - Review policy, packet, or workflow

## Architecture and invariants

- [ ] `architecture:none`
- [x] `architecture:documented`
- [ ] `architecture:judgement-required`

### Affected invariants

| Invariant | How this PR affects it | Why it remains valid | Evidence |
| --- | --- | --- | --- |
| INV-002 | Protected season reads and child writes/deletes now have explicit league-scoped route variants. | Access checks still run before protected reads/writes/deletes, and scoped routes resolve the season inside the requested league before returning or mutating child state. | API scoped route tests; keyed scoped-season read assertions; app failed-closed mutation fallback tests |
| INV-003 | Scoped create-session/create-game paths add additional conditional writes, conflict mapping, and duplicate-game recovery checks. | Idempotency ownership remains in `executeIdempotentMutation`; session/game races return conflict or safe replay rather than partial state; recovery links only unchanged existing games. | Atomic create-game/session-link tests; idempotent recovery tests; guarded recovery-link tests |
| INV-004 | Season/session/team ownership now uses league-scoped keys, row-level provenance, global-mirror-gated compatibility writes, owned provenance-less legacy-session reads during migration, scoped compatibility cleanup by owning game scope, and conditional legacy-team writes. | Returned games must match loaded metadata; legacy team/session compatibility rows are accepted only with matching row-level `leagueId` or a currently matching mirror for provenance-less rows; destructive cleanup and legacy writes use strong reads and conditional transactions. | Cross-league listing tests; provenance-less legacy session listing/delete tests; legacy template mirror replacement tests; global-mirror-gated legacy session tests; cleanup serialization tests; shared-session cleanup test; legacy team write serialization tests |
| INV-009 | Static routing changes for nested league-season URLs. | Existing security headers/CSP/cookie behaviour is unchanged; the route target remains the existing season shell. | App route/remount/static-router tests |

### Architecture or decision record

No new ADR. This implements the documented model that season identity is `(leagueId, seasonId)` while keeping legacy routes and compatibility rows during rollout.

## Failure and rollback

### Failure behaviour

If scoped route handling is too loose, cross-league games could still appear and then fail on click with a league-access error. If it is too strict, valid games or legacy team templates may be hidden until re-saved under scoped keys. If the compatibility-row ownership checks are wrong, rollback legacy rows could be skipped for valid scoped sessions, foreign legacy rows could be overwritten, pre-deployment legacy sessions could disappear from scoped pages, row-attributed legacy rows could be stranded after mirror replacement or shared-session cleanup, duplicate-game recovery could expose deleted games through session indexes, or legacy season-team writes could recreate orphan templates. Scoped write/delete actions intentionally fail closed rather than retrying unscoped mutation APIs when scoped routes are unavailable.

### Rollback approach

Revert this PR to restore the previous unscoped season route behaviour. No destructive migration or cleanup is required. New scoped sessions may leave legacy compatibility rows with the same session payload plus `leagueId`; old code can ignore the extra field, and the rows preserve rollback visibility when the global season mirror remains with the same league.

### Rollback evidence

No destructive migration is included. Legacy app/API routes remain present, and repository tests cover rollback-compatible session rows, global-mirror-gated session compatibility, owned provenance-less legacy session listings and delete guards, preservation of foreign legacy rows, cleanup of row-attributed compatibility rows after mirror replacement and shared-session-index collisions, guarded duplicate-game recovery linking, and serialization of legacy season-team writes against concurrent scoped season deletion.

## Automated and agent review disposition

### Unresolved blocking findings

None.

### Resolved review findings

| Finding | Resolution | Evidence |
| --- | --- | --- |
| Preserve games attached to legacy sessions. | Scoped game listing now includes provenance-less legacy sessions only when the global season mirror currently proves the requested league; final session-game and game metadata filters still enforce `(leagueId, seasonId)`. | `repository scoped season game listings include owned provenance-less legacy sessions` |
| Read newly created scoped seasons consistently. | Scoped GET/list-games/create-session/create-game guards now use `getSeasonForLeague(..., { consistentRead: true })` instead of list-query existence checks. | `core lambda serves league-scoped season game listings without global season lookup`; `core lambda creates league-scoped games from sessions in the requested league` |
| Gate compatibility writes on the global season owner. | Scoped session creation now writes legacy compatibility rows only when the global season mirror belongs to the requested league, and condition-checks that mirror before dual-writing. | `repository scoped session creation skips legacy compatibility rows when global mirror belongs to another league`; `repository scoped session creation aborts compatibility writes if global mirror changes` |
| Clean up row-attributed sessions after mirror replacement. | Session cleanup now treats matching row-level `leagueId` provenance as ownership independent of the current global mirror, while provenance-less rows still require the current mirror owner. | `repository scoped game cleanup deletes row-attributed legacy sessions after mirror replacement`; `repository scoped game cleanup leaves unowned legacy sessions untouched` |
| Validate refreshed game scope before repairing it. | Legacy join-code repair now receives expected league/season scope and refuses to mutate refreshed games outside that scope. | `core lambda keeps scoped season listing when join-code refresh sees foreign game metadata`; `repository skips legacy game join-code repair when expected scope does not match` |
| Revalidate scope after refreshing each listed game. | Strong refresh results are discarded unless the refreshed game still matches the requested league and season. | `core lambda keeps scoped season listing when join-code refresh sees foreign game metadata` |
| Preserve legacy session lookups for rollback. | Scoped session creation now writes `SEASON#{seasonId}/SESSION#{sessionId}` and `SESSION#{sessionId}/METADATA` compatibility rows when the global mirror and existing rows are safely attributable, and skips unsafe foreign legacy rows. | `repository scoped session creation touches season metadata to serialize deletion`; global-mirror-gated legacy session tests |
| Attribute legacy templates independently of the global mirror. | Legacy templates carry row-level `leagueId`; scoped reads/deletes validate the scoped season and template provenance rather than trusting the current global mirror owner. | `repository reads owned legacy season team templates for scoped season teams`; `repository does not treat another league's legacy templates as owned after mirror replacement` |
| Keep season deletion in the league scope and protect concurrent descendants. | Added scoped delete paths with strong descendant reads and conditional deletes. | Scoped season delete tests |
| Validate the session against the requested league before scoped game creation. | Scoped create-game loads the requested scoped session before creating the game. | Scoped create-game route/repository tests |
| Scope default teams to the requested league while preserving valid legacy templates. | Default setup reads/writes scoped teams and merges newer valid legacy templates. | Legacy template and default-team tests |
| Distinguish route absence before mutating through legacy APIs. | Scoped app create/delete actions do not fall back to unscoped mutation routes. | App failed-closed fallback tests |
| Document the league-scoped keys and compatibility semantics. | Storage/spec docs now describe scoped team/session keys, row-provenance compatibility rows, global-mirror-gated session compatibility writes, and provenance-less legacy-session read handling. | `docs/spec.md`; `docs/dynamodb-single-table.md`; `git diff --check` |
| Serialize legacy team writes with season deletion. | Legacy season team writes now require the owned global season row to exist unchanged in the same transaction, and create-only replay only preserves an existing concurrent team when the parent season row is still unchanged. | `repository rejects legacy season team writes when the season is deleted before commit`; `repository create-only season teams do not replace concurrent teams` |
| Tie recovery linking to the existing game. | Duplicate-game recovery passes `requireExistingGame: true`; the repository rereads the matching game and condition-checks it in the session-game transaction before writing the recovery link. | `repository recovery session linking rejects games deleted before commit`; `core lambda guards duplicate-game recovery session linking with the existing game`; local server create-game recovery assertion |
| Query row-owned legacy templates before deletion. | Scoped season delete now reads owned legacy team templates by scoped season and row-level team provenance instead of requiring the current global mirror to belong to the deleting league. | `repository scoped season delete removes row-attributed legacy templates after mirror replacement` |
| Include owned provenance-less sessions in deletion guard. | Scoped season delete now includes provenance-less legacy sessions while the strongly read global season mirror still proves ownership by the requested league. | `repository scoped season delete blocks owned provenance-less legacy sessions without games` |
| Read the scoped season consistently before deleting. | Scoped season delete now strongly reads the keyed `LEAGUE#{leagueId}/SEASON#{seasonId}` row before deciding whether the season exists. | `repository scoped season delete uses consistent descendant reads` |
| Clean up owned legacy sessions despite foreign games. | Scoped game cleanup now deletes owned legacy session compatibility rows when no remaining game belongs to the deleted game's `(leagueId, seasonId)` scope, even if another league has games in the shared `SESSION#{sessionId}` index. | `repository scoped game cleanup deletes owned legacy sessions despite foreign games` |

### Rejected findings and evidence

None.

## Human judgement

- [ ] `human-judgement:none`
- [x] `human-judgement:required`

### Decision requiring judgement

Confirm that adding scoped app/API routes plus compatibility handling is the right milestone-sized fix, rather than migrating all season/session identity and removing legacy routes in this PR.

### Options considered

Add defensive filtering only; add scoped app/API routes now; publish a CloudFront Function update from this PR; add rollout-safe read fallbacks; or migrate all season/session keys and URLs immediately.

### Reason selected

Scoped routes fix the observed QA leak at the source for league-originated navigation and new game creation without a destructive DynamoDB migration. Read-only legacy fallback keeps site-first deploys usable, while scoped mutations fail closed because unscoped mutation fallback cannot be made ownership-atomic in the browser.

### Reversal cost

Low to medium. Revert the code/config/docs; legacy compatibility rows created by this PR can remain and preserve rollback visibility when the global mirror remains with the same league.

## Review focus

- `api/src/data/repository.ts` league-scoped season game listing, keyed scoped season reads, atomic scoped game/session linking, row-provenance legacy session/team compatibility, global-mirror-gated session compatibility writes, duplicate-game recovery linking, legacy team write serialization, and conditional cleanup.
- `api/src/lambda-core.ts`, `api/src/server.ts`, and `serverless.api-core.yml` scoped route handling/deploy declarations.
- `app/src/ui/setup-flow.js` scoped season links, read fallback, failed-closed scoped mutations, and nested-route remount fallback.
- `infra/application/cloudfront-site-router.js` nested season-shell routing source.
- `docs/spec.md` and `docs/dynamodb-single-table.md` scoped key and compatibility documentation.
