### PR TITLE
fix(app): re-enable own goal scoring

### DIFF
--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -4642,6 +4642,62 @@ test("game page runs live goal scoring, corrections, undo, and delete", async ()
   assert.match(scoreboard.querySelector('[data-team-id="blue"]')?.textContent ?? "", /Conceded\s*0/);
 });
 
+test("game page enables and creates a fresh own goal after the timeline loads", async () => {
+  const apiState = createMockApiState();
+  const thirds = createDefaultThirdTimerSegments();
+  thirds[0] = {
+    ...thirds[0],
+    startedAt: "2026-03-28T11:00:10.000Z",
+  };
+  seedGoalScoringGame(apiState, {
+    gameId: "game-own-goal-create",
+    status: "live",
+    thirds,
+  });
+
+  const page = await bootPage({
+    html: renderGamePage("http://localhost:3001", { gameId: "game-own-goal-create" }),
+    url: "http://localhost:3000/games/game-own-goal-create",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+
+  const ownGoalInput = page.document.getElementById("goal-own-goal");
+  const scoringTeamInput = page.document.getElementById("goal-scoring-team");
+  const concedingTeamInput = page.document.getElementById("goal-conceding-team");
+  const scorerInput = page.document.getElementById("goal-scorer");
+  const saveGoalButton = page.document.querySelector('[data-action="save-goal"]');
+  const scoreboard = page.document.getElementById("live-scoreboard");
+  assert(ownGoalInput instanceof page.window.HTMLInputElement);
+  assert(scoringTeamInput instanceof page.window.HTMLSelectElement);
+  assert(concedingTeamInput instanceof page.window.HTMLSelectElement);
+  assert(scorerInput instanceof page.window.HTMLSelectElement);
+  assert(saveGoalButton instanceof page.window.HTMLButtonElement);
+  assert(scoreboard instanceof page.window.HTMLElement);
+
+  assert.equal(ownGoalInput.disabled, false);
+  ownGoalInput.click();
+  assert.equal(ownGoalInput.checked, true);
+  assert.equal(scoringTeamInput.disabled, true);
+  assert.equal(scoringTeamInput.value, "");
+
+  concedingTeamInput.value = "blue";
+  concedingTeamInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+  scorerInput.value = "player-cy";
+  scorerInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+  dispatchClick(saveGoalButton);
+  await flushAsync();
+
+  const goal = apiState.goalEvents.get("goal-1");
+  assert(goal);
+  assert.equal(goal.ownGoal, true);
+  assert.equal(goal.scoringTeamId, null);
+  assert.equal(goal.concedingTeamId, "blue");
+  assert.equal(goal.scorerPlayerId, "player-cy");
+  assert.match(scoreboard.querySelector('[data-team-id="blue"]')?.textContent ?? "", /Conceded\s*1/);
+  assert.match(scoreboard.querySelector('[data-team-id="blue"]')?.textContent ?? "", /Scored\s*0/);
+});
+
 test("setup smoke completes live game through finish", async () => {
   const apiState = createMockApiState();
   apiState.session = {

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -2711,6 +2711,7 @@
         return;
       }
 
+      goalOwnGoalInput.disabled = false;
       saveGoalButton.disabled = false;
 
       if (rosterTeams.length < 2) {


### PR DESCRIPTION
<!-- review-packet-version:1 -->

## Behavioural claim

After the goal timeline loads, scorekeepers can select Own goal and create an event with no scoring team, increasing only the selected conceding team's conceded tally.

## Specification and acceptance evidence

| Acceptance criterion | Evidence | Result |
| --- | --- | --- |
| Own-goal control is enabled after the timeline loading state resolves | `npm test` — `game page enables and creates a fresh own goal after the timeline loads` | PASS |
| Own-goal creation sends `scoringTeamId: null` and preserves scored/conceded separation | `npm test` — fresh own-goal regression assertions and repository scoring tests | PASS |
| Repository types remain valid | `npm run typecheck` | PASS |

## Scope boundaries

Included:

- Live scoring UI control-state recovery after goal timeline loading.
- Regression coverage for creating a fresh own goal through the UI.

Excluded:

- API contracts, scoring engine rules, data model, and existing goal correction behavior.
- Production deployment.

## Change classification

- Declared risk: `medium`
- [ ] `documentation-only` — Documentation only
- [ ] `tests-only` — Tests only
- [x] `application-behaviour` — Application or API behaviour
- [ ] `backlog-maintenance` — Canonical backlog maintenance
- [ ] `dependency-tooling` — Dependency or tooling
- [ ] `public-contract` — Public API or repository contract
- [ ] `data-migration` — Database schema or data migration
- [ ] `permission-trust-boundary` — Permission or trust boundary
- [ ] `durable-state-ownership` — Durable state or ownership
- [ ] `destructive-behaviour` — Destructive or difficult-to-reverse behaviour
- [ ] `new-production-dependency` — New production dependency
- [ ] `authentication-authorisation` — Authentication or authorisation
- [ ] `privacy-regulated-data` — Privacy or regulated data
- [ ] `infrastructure-production-configuration` — Infrastructure or deployment control
- [ ] `review-policy` — Review policy, packet, or workflow

## Architecture and invariants

- [x] `architecture:none`
- [ ] `architecture:documented`
- [ ] `architecture:judgement-required`

### Affected invariants

| Invariant | How this PR affects it | Why it remains valid | Evidence |
| --- | --- | --- | --- |
| INV-005 | Restores the UI path for own-goal event creation. | The request uses a null scoring team and the conceding team's scored tally remains unchanged. | Fresh own-goal UI test plus existing API scoring tests in `npm test`. |

### Architecture or decision record

No architecture boundary or decision record changes; this resets one existing form control after asynchronous loading.

## Failure and rollback

### Failure behaviour

If the state reset regresses, the Own goal checkbox remains disabled after load and scorekeepers cannot create own goals from the UI.

### Rollback approach

Revert commit `b078342` and redeploy the previous site artifact.

### Rollback evidence

The change is isolated to one UI state assignment and its regression test; `git revert b078342` cleanly removes it.

## Automated and agent review disposition

### Unresolved blocking findings

None.

### Rejected findings and evidence

None.

## Human judgement

- [x] `human-judgement:none`
- [ ] `human-judgement:required`

### Decision requiring judgement

None.

### Options considered

None.

### Reason selected

None.

### Reversal cost

Low; one isolated state reset can be reverted without data changes.

## Review focus

Confirm the checkbox is re-enabled only after the goal timeline becomes usable and that finished-game permission behavior remains unchanged.
