### PR TITLE
feat(app): streamline dashboard, league and season UX

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc -p tsconfig.json && mkdir -p dist/ui && cp src/ui/styles.css dist/ui/styles.css && cp src/ui/modal.js dist/ui/modal.js && cp src/ui/setup-flow.js dist/ui/setup-flow.js && cp src/ui/auth-flow.js dist/ui/auth-flow.js",
+    "build": "tsc -p tsconfig.json && mkdir -p dist/ui && cp src/ui/styles.css dist/ui/styles.css && cp src/ui/modal.js dist/ui/modal.js && cp src/ui/setup-flow.js dist/ui/setup-flow.js && cp src/ui/auth-flow.js dist/ui/auth-flow.js && node scripts/build-icons.mjs",
     "export:static": "node dist/static-export.js",
     "start": "node dist/server.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
@@ -16,5 +16,9 @@
   },
   "dependencies": {
     "@3fc/contracts": "0.1.0"
+  },
+  "devDependencies": {
+    "@iconify-json/lucide": "^1.2.123",
+    "@iconify/utils": "^3.1.4"
   }
 }

--- a/app/scripts/build-icons.mjs
+++ b/app/scripts/build-icons.mjs
@@ -1,0 +1,36 @@
+import { icons } from "@iconify-json/lucide";
+import { getIconData, getIconsCSS } from "@iconify/utils";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { ICON_NAMES } from "../dist/ui/icon-names.js";
+import { validateClientIconNames } from "./validate-client-icons.mjs";
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const outputPath = resolve(appRoot, "dist/ui/icons.css");
+const clientSourcePath = resolve(appRoot, "src/ui/setup-flow.js");
+const missingIcons = ICON_NAMES.filter((name) => getIconData(icons, name) === null);
+
+if (missingIcons.length > 0) {
+  throw new Error(`Lucide icons missing from @iconify-json/lucide: ${missingIcons.join(", ")}`);
+}
+
+validateClientIconNames(readFileSync(clientSourcePath, "utf8"), ICON_NAMES, clientSourcePath);
+
+const css = getIconsCSS(icons, [...ICON_NAMES], {
+  commonSelector: '[data-ui="icon"]',
+  iconSelector: '[data-icon="{name}"]',
+  format: "expanded",
+});
+
+if (!css.trim()) {
+  throw new Error("Iconify generated an empty icon stylesheet.");
+}
+
+mkdirSync(dirname(outputPath), { recursive: true });
+writeFileSync(
+  outputPath,
+  `/* Generated from @iconify-json/lucide. Do not edit by hand. */\n${css}`,
+  "utf8",
+);

--- a/app/scripts/validate-client-icons.mjs
+++ b/app/scripts/validate-client-icons.mjs
@@ -1,0 +1,99 @@
+import ts from "typescript";
+
+const CLIENT_ICON_RENDERERS = new Set([
+  "renderClientIcon",
+  "renderClientIconButton",
+  "renderClientIconLink",
+]);
+const CLIENT_ICON_WRAPPERS = new Set(["renderClientIconButton", "renderClientIconLink"]);
+
+function enclosingFunctionName(node) {
+  for (let current = node.parent; current; current = current.parent) {
+    if (ts.isFunctionDeclaration(current) && current.name) {
+      return current.name.text;
+    }
+  }
+  return null;
+}
+
+function resolveStringValues(node, declarations, seen = new Set()) {
+  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+    return [node.text];
+  }
+  if (ts.isParenthesizedExpression(node)) {
+    return resolveStringValues(node.expression, declarations, seen);
+  }
+  if (ts.isConditionalExpression(node)) {
+    const whenTrue = resolveStringValues(node.whenTrue, declarations, seen);
+    const whenFalse = resolveStringValues(node.whenFalse, declarations, seen);
+    return whenTrue && whenFalse ? [...whenTrue, ...whenFalse] : null;
+  }
+  if (ts.isIdentifier(node) && !seen.has(node.text)) {
+    const initializer = declarations.get(node.text);
+    if (!initializer) {
+      return null;
+    }
+    return resolveStringValues(initializer, declarations, new Set([...seen, node.text]));
+  }
+  return null;
+}
+
+export function collectClientIconNames(source, fileName = "setup-flow.js") {
+  const sourceFile = ts.createSourceFile(fileName, source, ts.ScriptTarget.ESNext, true, ts.ScriptKind.JS);
+  const declarations = new Map();
+  const names = new Set();
+
+  function collectDeclarations(node) {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      declarations.set(node.name.text, node.initializer);
+    }
+    ts.forEachChild(node, collectDeclarations);
+  }
+  collectDeclarations(sourceFile);
+
+  function collectCalls(node) {
+    if (ts.isCallExpression(node) && ts.isIdentifier(node.expression) && CLIENT_ICON_RENDERERS.has(node.expression.text)) {
+      const renderer = node.expression.text;
+      if (renderer === "renderClientIcon" && CLIENT_ICON_WRAPPERS.has(enclosingFunctionName(node))) {
+        ts.forEachChild(node, collectCalls);
+        return;
+      }
+
+      let iconExpression = node.arguments[0];
+      if (renderer !== "renderClientIcon") {
+        const input = node.arguments[0];
+        if (!input || !ts.isObjectLiteralExpression(input)) {
+          throw new Error(`${renderer} must receive an object literal so its icon can be validated at build time.`);
+        }
+        const iconProperty = input.properties.find(
+          (property) =>
+            ts.isPropertyAssignment(property) &&
+            ((ts.isIdentifier(property.name) && property.name.text === "icon") ||
+              (ts.isStringLiteral(property.name) && property.name.text === "icon")),
+        );
+        iconExpression = iconProperty?.initializer;
+      }
+
+      const resolved = iconExpression ? resolveStringValues(iconExpression, declarations) : null;
+      if (!resolved || resolved.length === 0) {
+        throw new Error(`${renderer} icon must resolve to string literals at build time.`);
+      }
+      for (const name of resolved) {
+        names.add(name);
+      }
+    }
+    ts.forEachChild(node, collectCalls);
+  }
+  collectCalls(sourceFile);
+  return [...names].sort();
+}
+
+export function validateClientIconNames(source, allowedNames, fileName = "setup-flow.js") {
+  const names = collectClientIconNames(source, fileName);
+  const allowed = new Set(allowedNames);
+  const unsupported = names.filter((name) => !allowed.has(name));
+  if (unsupported.length > 0) {
+    throw new Error(`Client icons are missing from the Lucide allow-list: ${unsupported.join(", ")}`);
+  }
+  return names;
+}

--- a/app/src/server.ts
+++ b/app/src/server.ts
@@ -24,6 +24,11 @@ const UI_STYLESHEET_PATHS = [
   resolve(process.cwd(), "src/ui/styles.css"),
   resolve(process.cwd(), "app/src/ui/styles.css"),
 ];
+const UI_ICON_STYLESHEET_PATHS = [
+  fileURLToPath(new URL("./ui/icons.css", import.meta.url)),
+  resolve(process.cwd(), "dist/ui/icons.css"),
+  resolve(process.cwd(), "app/dist/ui/icons.css"),
+];
 const UI_MODAL_SCRIPT_PATHS = [
   fileURLToPath(new URL("./ui/modal.js", import.meta.url)),
   resolve(process.cwd(), "src/ui/modal.js"),
@@ -40,6 +45,7 @@ const UI_AUTH_FLOW_SCRIPT_PATHS = [
   resolve(process.cwd(), "app/src/ui/auth-flow.js"),
 ];
 const UI_STYLESHEET = loadUiStylesheet();
+const UI_ICON_STYLESHEET = loadUiIconStylesheet();
 const UI_MODAL_SCRIPT = loadUiModalScript();
 const UI_SETUP_FLOW_SCRIPT = loadUiSetupFlowScript();
 const UI_AUTH_FLOW_SCRIPT = loadUiAuthFlowScript();
@@ -54,6 +60,18 @@ function loadUiStylesheet(): string {
   }
 
   return "/* ui stylesheet unavailable */";
+}
+
+function loadUiIconStylesheet(): string {
+  for (const stylesheetPath of UI_ICON_STYLESHEET_PATHS) {
+    try {
+      return readFileSync(stylesheetPath, "utf8");
+    } catch {
+      // Continue until a readable generated icon stylesheet is found.
+    }
+  }
+
+  throw new Error("Generated Iconify stylesheet unavailable. Run the app build first.");
 }
 
 function loadUiModalScript(): string {
@@ -177,6 +195,11 @@ export function createAppRequestHandler(apiBaseUrl: string) {
 
     if (method === "GET" && route === "/ui/styles.css") {
       sendCss(response, securityHeaders, 200, UI_STYLESHEET);
+      return;
+    }
+
+    if (method === "GET" && route === "/ui/icons.css") {
+      sendCss(response, securityHeaders, 200, UI_ICON_STYLESHEET);
       return;
     }
 

--- a/app/src/static-export.ts
+++ b/app/src/static-export.ts
@@ -31,6 +31,14 @@ interface StaticAsset {
 
 const STATIC_ASSETS: StaticAsset[] = [
   {
+    outputPath: "ui/icons.css",
+    candidateSources: [
+      fileURLToPath(new URL("./ui/icons.css", import.meta.url)),
+      resolve(process.cwd(), "dist/ui/icons.css"),
+      resolve(process.cwd(), "app/dist/ui/icons.css"),
+    ],
+  },
+  {
     outputPath: "ui/styles.css",
     candidateSources: [
       fileURLToPath(new URL("./ui/styles.css", import.meta.url)),

--- a/app/src/tests/icon-assets.test.ts
+++ b/app/src/tests/icon-assets.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+import lucidePackage from "@iconify-json/lucide/package.json" with { type: "json" };
+import iconifyUtilsPackage from "@iconify/utils/package.json" with { type: "json" };
+
+import { ICON_NAMES } from "../ui/icon-names.js";
+
+test("generated Lucide asset contains exactly the local allow-list", () => {
+  const css = readFileSync(resolve(process.cwd(), "dist/ui/icons.css"), "utf8");
+  const generatedNames = Array.from(css.matchAll(/\[data-icon="([^"]+)"\]/g), (match) => match[1]);
+
+  assert.deepEqual(generatedNames, [...ICON_NAMES]);
+  assert.match(css, /data:image\/svg\+xml/);
+  assert.doesNotMatch(css, /url\(["']?https?:\/\//);
+});
+
+test("Lucide dependency provenance and licence stay explicit", () => {
+  assert.equal(lucidePackage.name, "@iconify-json/lucide");
+  assert.equal(lucidePackage.license, "ISC");
+  assert.equal(iconifyUtilsPackage.name, "@iconify/utils");
+  assert.equal(iconifyUtilsPackage.license, "MIT");
+});
+
+test("client icon validation rejects names outside the generated allow-list", async () => {
+  // The validator is a build-time JavaScript module rather than application code.
+  // @ts-expect-error No declaration file is needed for the build script module.
+  const { validateClientIconNames } = await import("../../../scripts/validate-client-icons.mjs") as {
+    validateClientIconNames: (source: string, names: readonly string[]) => string[];
+  };
+
+  assert.deepEqual(
+    validateClientIconNames('renderClientIconButton({ icon: "eye", label: "View" });', ICON_NAMES),
+    ["eye"],
+  );
+  assert.throws(
+    () => validateClientIconNames('renderClientIconButton({ icon: "missing-icon", label: "Broken" });', ICON_NAMES),
+    /missing from the Lucide allow-list: missing-icon/,
+  );
+});

--- a/app/src/tests/server.test.ts
+++ b/app/src/tests/server.test.ts
@@ -96,7 +96,22 @@ test("stylesheet route serves external UI css", () => {
   assert.equal(response.headers["Content-Type"], "text/css; charset=utf-8");
   assert.match(response.body, /\[data-ui="button"]/);
   assert.match(response.body, /\[data-ui="nav"]/);
+  assert.match(response.body, /\[data-testid="dashboard-leagues-table"\]/);
+  assert.match(response.body, /\[data-testid="league-seasons-table"\]/);
+  assert.match(response.body, /\[data-testid="season-games-table"\]/);
   assert.match(response.body, /&:hover/);
+});
+
+test("generated icon stylesheet is local, allow-listed, and CSP compatible", () => {
+  const response = executeRoute("GET", "/ui/icons.css");
+
+  assert.equal(response.statusCode, 200);
+  assertSecurityHeaders(response.headers);
+  assert.equal(response.headers["Content-Type"], "text/css; charset=utf-8");
+  assert.match(response.body, /Generated from @iconify-json\/lucide/);
+  assert.match(response.body, /\[data-icon="trash-2"\]/);
+  assert.match(response.body, /data:image\/svg\+xml/);
+  assert.doesNotMatch(response.body, /url\(["']?https?:\/\//);
 });
 
 test("modal behavior script route serves external javascript", () => {

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -2026,7 +2026,7 @@ test("setup flow shows inline validation for blank required fields", async () =>
   assert.equal(dashboard.document.getElementById("dashboard-welcome")?.textContent, "Welcome Organizer");
   assert.equal(createLeagueToggle.getAttribute("aria-expanded"), "true");
   assert.equal(createLeagueRegion.hidden, false);
-  assert.equal(dashboard.document.activeElement?.id, "league-name");
+  assert.notEqual(dashboard.document.activeElement?.id, "league-name");
   dispatchClick(createLeagueButton);
   await flushAsync();
   assert.equal(leagueNameNotice.textContent, "League name is required.");
@@ -2156,6 +2156,59 @@ test("populated dashboard keeps league creation disclosed on demand and handles 
 
   assert.equal(confirmations, 1);
   assert.equal(apiState.leagues.has("autumn-league"), false);
+});
+
+test("empty dashboard does not reopen creation after a slow response overrides user choice", async () => {
+  const apiState = createMockApiState();
+  apiState.session = {
+    sessionId: "session-1",
+    email: "organizer@3fc.football",
+    createdAt: "2026-03-28T11:00:00.000Z",
+    expiresAt: "2026-03-29T11:00:00.000Z",
+  };
+  apiState.cookieJar = "threefc_session=session-1";
+  const defaultFetch = createMockFetch(apiState);
+  let resolveLeagues: ((response: Response) => void) | undefined;
+  const delayedFetch: typeof fetch = async (input, init = {}) => {
+    const target =
+      typeof input === "string" || input instanceof URL
+        ? new URL(String(input))
+        : new URL(input.url);
+    if ((init.method ?? "GET").toUpperCase() === "GET" && target.pathname === "/v1/leagues") {
+      return new Promise<Response>((resolve) => {
+        resolveLeagues = resolve;
+      });
+    }
+    return defaultFetch(input, init);
+  };
+
+  const page = await bootPage({
+    html: renderSetupHomePage("http://localhost:3001"),
+    url: "http://localhost:3000/setup",
+    scriptFile: "setup-flow.js",
+    apiState,
+    fetch: delayedFetch,
+    flushOnBoot: false,
+  });
+  await flushAsync();
+
+  const toggle = page.document.querySelector('[data-testid="toggle-create-league"]');
+  const region = page.document.getElementById("dashboard-create-league-region");
+  assert(toggle instanceof page.window.HTMLButtonElement);
+  assert(region instanceof page.window.HTMLElement);
+  dispatchClick(toggle);
+  assert.equal(toggle.getAttribute("aria-expanded"), "true");
+  dispatchClick(toggle);
+  assert.equal(toggle.getAttribute("aria-expanded"), "false");
+  assert.equal(page.document.activeElement, toggle);
+
+  assert(resolveLeagues);
+  resolveLeagues(createJsonResponse(200, { leagues: [] }));
+  await flushAsync();
+
+  assert.equal(toggle.getAttribute("aria-expanded"), "false");
+  assert.equal(region.hidden, true);
+  assert.equal(page.document.activeElement, toggle);
 });
 
 test("dashboard greeting falls back to the full email when no local-part token exists", async () => {

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -2529,9 +2529,16 @@ test("league page shows manual invite link when organiser email delivery is unco
   );
   assert.equal(
     leaguePage.document.getElementById("organiser-invite-email-status")?.textContent,
-    "Delivery unconfirmed. Use the reusable link above.",
+    "Delivery unconfirmed. Open the email-restricted recovery link.",
   );
+  const recoveryLink = leaguePage.document.querySelector(
+    "#organiser-invite-email-status .inline-recovery-link",
+  );
+  assert(recoveryLink instanceof leaguePage.window.HTMLAnchorElement);
+  assert.equal(recoveryLink.href, "http://localhost:3000/invites?code=UNKN2345");
   assert.equal(leaguePage.document.getElementById("organiser-email-invite-code"), null);
+  assert.equal(leaguePage.document.getElementById("organiser-email-invite-link"), null);
+  assert.equal(leaguePage.document.getElementById("organiser-email-invite-result"), null);
   assert.equal(
     apiState.storage.has("threefc-idempotency:organiser-invite:autumn-league-coach%40example.com"),
     false,

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -2016,9 +2016,17 @@ test("setup flow shows inline validation for blank required fields", async () =>
   });
 
   const createLeagueButton = dashboard.document.querySelector('[data-action="create-league"]');
+  const createLeagueToggle = dashboard.document.querySelector('[data-action="toggle-create-league"]');
+  const createLeagueRegion = dashboard.document.getElementById("dashboard-create-league-region");
   const leagueNameNotice = dashboard.document.getElementById("league-name-notice");
   assert(createLeagueButton instanceof dashboard.window.HTMLButtonElement);
+  assert(createLeagueToggle instanceof dashboard.window.HTMLButtonElement);
+  assert(createLeagueRegion instanceof dashboard.window.HTMLElement);
   assert(leagueNameNotice instanceof dashboard.window.HTMLElement);
+  assert.equal(dashboard.document.getElementById("dashboard-welcome")?.textContent, "Welcome Organizer");
+  assert.equal(createLeagueToggle.getAttribute("aria-expanded"), "true");
+  assert.equal(createLeagueRegion.hidden, false);
+  assert.equal(dashboard.document.activeElement?.id, "league-name");
   dispatchClick(createLeagueButton);
   await flushAsync();
   assert.equal(leagueNameNotice.textContent, "League name is required.");
@@ -2092,6 +2100,84 @@ test("setup flow shows inline validation for blank required fields", async () =>
   assert.equal(gameKickoffNotice.textContent, "Kickoff time must be valid.");
 });
 
+test("populated dashboard keeps league creation disclosed on demand and handles icon-child actions", async () => {
+  const apiState = createMockApiState();
+  apiState.session = {
+    sessionId: "session-1",
+    email: "AJ.FISHER@3fc.football",
+    createdAt: "2026-03-28T11:00:00.000Z",
+    expiresAt: "2026-03-29T11:00:00.000Z",
+  };
+  apiState.cookieJar = "threefc_session=session-1";
+  apiState.leagues.set("autumn-league", {
+    leagueId: "autumn-league",
+    name: "Autumn League",
+    slug: "autumn-league",
+    createdByUserId: apiState.session.email,
+    createdAt: "2026-03-28T11:00:00.000Z",
+    updatedAt: "2026-03-28T11:00:00.000Z",
+  });
+  grantMockLeagueAccess(apiState, "autumn-league", apiState.session.email, "admin");
+
+  const page = await bootPage({
+    html: renderSetupHomePage("http://localhost:3001"),
+    url: "http://localhost:3000/setup",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+
+  const toggle = page.document.querySelector('[data-testid="toggle-create-league"]');
+  const region = page.document.getElementById("dashboard-create-league-region");
+  assert(toggle instanceof page.window.HTMLButtonElement);
+  assert(region instanceof page.window.HTMLElement);
+  assert.equal(page.document.getElementById("dashboard-welcome")?.textContent, "Welcome Aj");
+  assert.equal(toggle.getAttribute("aria-expanded"), "false");
+  assert.equal(region.hidden, true);
+
+  dispatchClick(toggle);
+  assert.equal(toggle.getAttribute("aria-expanded"), "true");
+  assert.equal(region.hidden, false);
+  assert.equal(page.document.activeElement?.id, "league-name");
+
+  let confirmations = 0;
+  Object.defineProperty(page.window, "confirm", {
+    value: () => {
+      confirmations += 1;
+      return true;
+    },
+    configurable: true,
+  });
+  const deleteIcon = page.document.querySelector(
+    '[data-action="delete-league"][data-league-id="autumn-league"] [data-icon="trash-2"]',
+  );
+  assert(deleteIcon instanceof page.window.HTMLElement);
+  dispatchClick(deleteIcon);
+  await flushAsync();
+
+  assert.equal(confirmations, 1);
+  assert.equal(apiState.leagues.has("autumn-league"), false);
+});
+
+test("dashboard greeting falls back to the full email when no local-part token exists", async () => {
+  const apiState = createMockApiState();
+  apiState.session = {
+    sessionId: "session-1",
+    email: "...@example.com",
+    createdAt: "2026-03-28T11:00:00.000Z",
+    expiresAt: "2026-03-29T11:00:00.000Z",
+  };
+  apiState.cookieJar = "threefc_session=session-1";
+
+  const page = await bootPage({
+    html: renderSetupHomePage("http://localhost:3001"),
+    url: "http://localhost:3000/setup",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+
+  assert.equal(page.document.getElementById("dashboard-welcome")?.textContent, "Welcome ...@example.com");
+});
+
 test("league page loads reusable organiser share invites and sends direct email invites", async () => {
   const apiState = createMockApiState();
   apiState.session = {
@@ -2119,29 +2205,57 @@ test("league page loads reusable organiser share invites and sends direct email 
   });
 
   const createInviteButton = leaguePage.document.querySelector('[data-testid="create-organiser-invite"]');
+  const createSeasonToggle = leaguePage.document.querySelector('[data-testid="toggle-create-season"]');
+  const createSeasonRegion = leaguePage.document.getElementById("league-create-season-region");
+  const inviteToggle = leaguePage.document.querySelector('[data-testid="toggle-organiser-invite"]');
+  const inviteRegion = leaguePage.document.getElementById("league-organiser-invite-region");
   const inviteEmailInput = leaguePage.document.getElementById("organiser-invite-email");
   assert(createInviteButton instanceof leaguePage.window.HTMLButtonElement);
+  assert(createSeasonToggle instanceof leaguePage.window.HTMLButtonElement);
+  assert(createSeasonRegion instanceof leaguePage.window.HTMLElement);
+  assert(inviteToggle instanceof leaguePage.window.HTMLButtonElement);
+  assert(inviteRegion instanceof leaguePage.window.HTMLElement);
   assert(inviteEmailInput instanceof leaguePage.window.HTMLInputElement);
 
-  assert.equal(apiState.lastOrganiserInviteRequest?.leagueId, "autumn-league");
-  assert.deepEqual(apiState.lastOrganiserInviteRequest?.body, { email: null });
+  assert.equal(apiState.lastOrganiserInviteRequest, null);
+  assert.equal(inviteRegion.hidden, true);
+  dispatchClick(createSeasonToggle);
+  assert.equal(createSeasonRegion.hidden, false);
+  assert.equal(leaguePage.document.activeElement?.id, "season-name");
+  dispatchClick(inviteToggle);
+  await flushAsync();
+
+  assert.equal(inviteToggle.getAttribute("aria-expanded"), "true");
+  assert.equal(inviteRegion.hidden, false);
+  assert.equal(createSeasonToggle.getAttribute("aria-expanded"), "false");
+  assert.equal(createSeasonRegion.hidden, true);
+  assert.equal(leaguePage.document.activeElement, inviteEmailInput);
+  const shareRequest = apiState.lastOrganiserInviteRequest as unknown as Exclude<
+    MockApiState["lastOrganiserInviteRequest"],
+    null
+  >;
+  assert.equal(shareRequest.leagueId, "autumn-league");
+  assert.deepEqual(shareRequest.body, { email: null });
   assert.equal(
-    apiState.lastOrganiserInviteRequest?.idempotencyKey,
+    shareRequest.idempotencyKey,
     "organiser-share-invite-autumn-league",
   );
   assert.equal(
     apiState.storage.has("threefc-idempotency:organiser-invite:autumn-league-link"),
     false,
   );
-  assert.equal(
-    leaguePage.document.getElementById("organiser-share-invite-status")?.textContent,
-    "Share invite ready.",
-  );
+  assert.equal(leaguePage.document.getElementById("organiser-share-invite-status")?.textContent, "");
   assert.equal(leaguePage.document.getElementById("organiser-share-invite-code")?.textContent, "ABCD2345");
   const inviteLink = leaguePage.document.getElementById("organiser-share-invite-link");
   assert(inviteLink instanceof leaguePage.window.HTMLAnchorElement);
   assert.equal(inviteLink.href, "http://localhost:3000/invites?code=ABCD2345");
-  assert.equal(leaguePage.document.getElementById("organiser-email-invite-result")?.hidden, true);
+  dispatchClick(inviteToggle);
+  assert.equal(inviteRegion.hidden, true);
+  assert.equal(leaguePage.document.activeElement, inviteToggle);
+  dispatchClick(inviteToggle);
+  await flushAsync();
+  assert.deepEqual(shareRequest.body, { email: null });
+  assert.equal(leaguePage.document.getElementById("organiser-email-invite-result"), null);
   assert.equal(leaguePage.document.getElementById("organiser-invite-email-status")?.textContent, "");
 
   inviteEmailInput.value = "Coach@Example.COM";
@@ -2149,13 +2263,15 @@ test("league page loads reusable organiser share invites and sends direct email 
   dispatchClick(createInviteButton);
   await flushAsync();
 
-  assert.deepEqual(apiState.lastOrganiserInviteRequest?.body, { email: "Coach@Example.COM" });
+  const emailRequest = apiState.lastOrganiserInviteRequest as unknown as Exclude<
+    MockApiState["lastOrganiserInviteRequest"],
+    null
+  >;
+  assert.deepEqual(emailRequest.body, { email: "Coach@Example.COM" });
   assert.equal(leaguePage.document.getElementById("organiser-share-invite-code")?.textContent, "ABCD2345");
-  assert.equal(leaguePage.document.getElementById("organiser-email-invite-result")?.hidden, false);
-  assert.equal(leaguePage.document.getElementById("organiser-email-invite-code")?.textContent, "EFGH2345");
-  const emailInviteLink = leaguePage.document.getElementById("organiser-email-invite-link");
-  assert(emailInviteLink instanceof leaguePage.window.HTMLAnchorElement);
-  assert.equal(emailInviteLink.href, "http://localhost:3000/invites?code=EFGH2345");
+  assert.equal(leaguePage.document.getElementById("organiser-email-invite-result"), null);
+  assert.equal(leaguePage.document.getElementById("organiser-email-invite-code"), null);
+  assert.equal(leaguePage.document.getElementById("organiser-email-invite-link"), null);
   assert.equal(
     leaguePage.document.getElementById("organiser-invite-email-status")?.textContent,
     "Sent to coach@example.com.",
@@ -2234,6 +2350,10 @@ test("league page reuses organiser invite idempotency key until a retry succeeds
 
   assert.equal(leaguePage.document.getElementById("setup-status")?.textContent, "Organiser invite failed.");
   assert.equal(
+    leaguePage.document.getElementById("organiser-invite-email-status")?.textContent,
+    "Invite failed: Temporary failure.",
+  );
+  assert.equal(
     apiState.storage.get("threefc-idempotency:organiser-invite:autumn-league-coach%40example.com"),
     requestedKeys[0],
   );
@@ -2248,6 +2368,71 @@ test("league page reuses organiser invite idempotency key until a retry succeeds
     false,
   );
   assert.equal(leaguePage.document.getElementById("setup-status")?.textContent, "Organiser invite sent.");
+  assert.equal(
+    leaguePage.document.getElementById("organiser-invite-email-status")?.textContent,
+    "Sent to coach@example.com.",
+  );
+});
+
+test("league page retries a failed reusable invite when its disclosure is reopened", async () => {
+  const apiState = createMockApiState();
+  apiState.session = {
+    sessionId: "session-admin",
+    email: "organizer@3fc.football",
+    createdAt: "2026-03-28T11:00:00.000Z",
+    expiresAt: "2026-03-29T11:00:00.000Z",
+  };
+  apiState.cookieJar = "threefc_session=session-admin";
+  apiState.leagues.set("autumn-league", {
+    leagueId: "autumn-league",
+    name: "Autumn League",
+    slug: "autumn-league",
+    createdByUserId: apiState.session.email,
+    createdAt: "2026-03-28T11:00:00.000Z",
+    updatedAt: "2026-03-28T11:00:00.000Z",
+  });
+  grantMockLeagueAccess(apiState, "autumn-league", apiState.session.email, "admin");
+
+  const defaultFetch = createMockFetch(apiState);
+  let shareAttempts = 0;
+  const retryFetch: ReturnType<typeof createMockFetch> = async (input, init = {}) => {
+    const target = typeof input === "string" || input instanceof URL ? new URL(String(input)) : new URL(input.url);
+    const method = (init.method ?? "GET").toUpperCase();
+    if (method === "POST" && target.pathname === "/v1/leagues/autumn-league/organiser-invites") {
+      const body = typeof init.body === "string" ? (JSON.parse(init.body) as Record<string, unknown>) : {};
+      if (body.email === null) {
+        shareAttempts += 1;
+        if (shareAttempts === 1) {
+          return createJsonResponse(503, { error: "temporary_failure", message: "Temporary failure." });
+        }
+      }
+    }
+    return defaultFetch(input, init);
+  };
+
+  const page = await bootPage({
+    html: renderLeaguePage("http://localhost:3001", "autumn-league"),
+    url: "http://localhost:3000/leagues/autumn-league",
+    scriptFile: "setup-flow.js",
+    apiState,
+    fetch: retryFetch,
+  });
+  const toggle = page.document.querySelector('[data-testid="toggle-organiser-invite"]');
+  assert(toggle instanceof page.window.HTMLButtonElement);
+
+  dispatchClick(toggle);
+  await flushAsync();
+  assert.equal(shareAttempts, 1);
+  assert.equal(
+    page.document.getElementById("organiser-share-invite-status")?.textContent,
+    "Share invite unavailable. Close and reopen to try again.",
+  );
+
+  dispatchClick(toggle);
+  dispatchClick(toggle);
+  await flushAsync();
+  assert.equal(shareAttempts, 2);
+  assert.equal(page.document.getElementById("organiser-share-invite-code")?.textContent, "ABCD2345");
 });
 
 test("league page shows manual invite link when organiser email delivery is unconfirmed", async () => {
@@ -2270,6 +2455,7 @@ test("league page shows manual invite link when organiser email delivery is unco
   grantMockLeagueAccess(apiState, "autumn-league", "organizer@3fc.football", "admin");
 
   const defaultFetch = createMockFetch(apiState);
+  const uncertainKeys: string[] = [];
   const uncertainFetch: ReturnType<typeof createMockFetch> = async (input, init = {}) => {
     const target =
       typeof input === "string" || input instanceof URL
@@ -2284,6 +2470,11 @@ test("league page shows manual invite link when organiser email delivery is unco
           : {};
       if (typeof body.email !== "string" || body.email.trim().length === 0) {
         return defaultFetch(input, init);
+      }
+
+      const idempotencyKey = readInitHeader(init, "idempotency-key");
+      if (idempotencyKey) {
+        uncertainKeys.push(idempotencyKey);
       }
 
       return createJsonResponse(202, {
@@ -2338,9 +2529,14 @@ test("league page shows manual invite link when organiser email delivery is unco
   );
   assert.equal(
     leaguePage.document.getElementById("organiser-invite-email-status")?.textContent,
-    "Delivery unconfirmed. Share the invite link manually.",
+    "Delivery unconfirmed. Use the reusable link above.",
   );
-  assert.equal(leaguePage.document.getElementById("organiser-email-invite-code")?.textContent, "UNKN2345");
+  assert.equal(leaguePage.document.getElementById("organiser-email-invite-code"), null);
+  assert.equal(
+    apiState.storage.has("threefc-idempotency:organiser-invite:autumn-league-coach%40example.com"),
+    false,
+  );
+  assert.equal(uncertainKeys.length, 1);
 });
 
 test("invite page accepts organiser codes after confirmation and grants league admin access", async () => {
@@ -2413,6 +2609,20 @@ test("season page renders game kickoff times in the user local timezone", async 
   seedGoalScoringGame(apiState, {
     gameId: "game-season-local-time",
   });
+  const scheduledGame = apiState.games.get("game-season-local-time");
+  assert(scheduledGame);
+  apiState.games.set("game-season-live", {
+    ...scheduledGame,
+    gameId: "game-season-live",
+    status: "live",
+    gameStartTs: "2026-03-28T10:05:00.000Z",
+  });
+  apiState.games.set("game-season-finished", {
+    ...scheduledGame,
+    gameId: "game-season-finished",
+    status: "finished",
+    gameStartTs: "2026-03-28T10:10:00.000Z",
+  });
 
   const page = await bootPage({
     html: renderSeasonPage("http://localhost:3001", "autumn-cup"),
@@ -2426,7 +2636,49 @@ test("season page renders game kickoff times in the user local timezone", async 
   assert(gamesBody instanceof page.window.HTMLElement);
   assert(game);
   assert.match(gamesBody.textContent ?? "", new RegExp(expectedLocalTimestamp(game.gameStartTs)));
+  assert.doesNotMatch(gamesBody.textContent ?? "", /game-season-local-time/);
   assert.doesNotMatch(gamesBody.textContent ?? "", /Z\b|UTC/);
+  const kickoffLink = gamesBody.querySelector('a[href="/games/game-season-local-time"]');
+  assert(kickoffLink instanceof page.window.HTMLAnchorElement);
+  assert.equal(kickoffLink.textContent, expectedLocalTimestamp(game.gameStartTs));
+  const statusChip = gamesBody.querySelector('[data-ui="status-chip"][data-status="scheduled"]');
+  assert(statusChip instanceof page.window.HTMLElement);
+  assert.match(statusChip.textContent ?? "", /Scheduled/);
+  assert(statusChip.querySelector('[data-icon="calendar-clock"]'));
+  assert(gamesBody.querySelector('[aria-label^="View game at"] [data-icon="eye"]'));
+  assert(gamesBody.querySelector('[aria-label^="Delete game at"] [data-icon="trash-2"]'));
+  assert(gamesBody.querySelector('[data-status="live"] [data-icon="activity"]'));
+  assert(gamesBody.querySelector('[data-status="finished"] [data-icon="circle-check"]'));
+});
+
+test("season kickoff links use the next local calendar date across a UTC boundary", async () => {
+  const previousTimezone = process.env.TZ;
+  process.env.TZ = "Australia/Melbourne";
+
+  try {
+    const apiState = createMockApiState();
+    seedGoalScoringGame(apiState, { gameId: "game-date-boundary" });
+    const game = apiState.games.get("game-date-boundary");
+    assert(game);
+    game.gameStartTs = "2026-03-28T16:30:00.000Z";
+
+    const page = await bootPage({
+      html: renderSeasonPage("http://localhost:3001", "autumn-cup"),
+      url: "http://localhost:3000/seasons/autumn-cup",
+      scriptFile: "setup-flow.js",
+      apiState,
+    });
+
+    const kickoffLink = page.document.querySelector('a[href="/games/game-date-boundary"]');
+    assert(kickoffLink instanceof page.window.HTMLAnchorElement);
+    assert.equal(kickoffLink.textContent, "2026-03-29 03:30");
+  } finally {
+    if (previousTimezone === undefined) {
+      delete process.env.TZ;
+    } else {
+      process.env.TZ = previousTimezone;
+    }
+  }
 });
 
 test("league static shell remounts nested league season routes as scoped season pages", async () => {
@@ -2453,7 +2705,8 @@ test("league static shell remounts nested league season routes as scoped season 
   assert.equal(root?.getAttribute("data-season-id"), "autumn-cup");
   assert.equal(page.document.getElementById("season-title")?.textContent, "Autumn Cup");
   assert(gamesBody instanceof page.window.HTMLElement);
-  assert.match(gamesBody.textContent ?? "", /game-season-static-fallback/);
+  assert(gamesBody.querySelector('a[href="/games/game-season-static-fallback"]'));
+  assert.doesNotMatch(gamesBody.textContent ?? "", /game-season-static-fallback/);
 });
 
 test("season page falls back to legacy season APIs during site-first scoped rollout", async () => {
@@ -2525,8 +2778,9 @@ test("season page falls back to legacy season APIs during site-first scoped roll
   const gamesBody = page.document.getElementById("season-games-body");
   assert(gamesBody instanceof page.window.HTMLElement);
   assert.equal(page.document.getElementById("season-title")?.textContent, "Winter 2026");
-  assert.match(gamesBody.textContent ?? "", /game-visible/);
-  assert.doesNotMatch(gamesBody.textContent ?? "", /game-foreign/);
+  assert(gamesBody.querySelector('a[href="/games/game-visible"]'));
+  assert.equal(gamesBody.querySelector('a[href="/games/game-foreign"]'), null);
+  assert.doesNotMatch(gamesBody.textContent ?? "", /game-visible|game-foreign/);
 });
 
 test("setup happy path runs from sign-in to created game context", async () => {
@@ -2623,26 +2877,24 @@ test("setup happy path runs from sign-in to created game context", async () => {
 
   const gameDateInput = seasonPage.document.getElementById("game-date");
   const gameKickoffInput = seasonPage.document.getElementById("game-kickoff");
-  const gameIdDisplay = seasonPage.document.getElementById("game-id-display");
   const createGameButton = seasonPage.document.querySelector('[data-action="create-game"]');
   assert(gameDateInput instanceof seasonPage.window.HTMLInputElement);
   assert(gameKickoffInput instanceof seasonPage.window.HTMLInputElement);
-  assert(gameIdDisplay instanceof seasonPage.window.HTMLElement);
+  assert.equal(seasonPage.document.getElementById("game-id-display"), null);
   assert(createGameButton instanceof seasonPage.window.HTMLButtonElement);
 
   gameDateInput.value = "2026-03-28";
   gameDateInput.dispatchEvent(new seasonPage.window.Event("change", { bubbles: true }));
   gameKickoffInput.value = "2026-03-28T10:00";
   gameKickoffInput.dispatchEvent(new seasonPage.window.Event("change", { bubbles: true }));
-  const gameId = gameIdDisplay.textContent ?? "";
   dispatchClick(createGameButton);
   await flushAsync();
 
-  const createdGame = apiState.games.get(gameId);
-  assert(createdGame);
-
   const gameNavigation = seasonPage.navigations.at(-1);
   assert(gameNavigation);
+  const gameId = decodeURIComponent(gameNavigation.url.split("/").at(-1) ?? "");
+  const createdGame = apiState.games.get(gameId);
+  assert(createdGame);
   assert.equal(gameNavigation.url, `/games/${gameId}`);
 
   const gamePage = await bootPage({
@@ -2665,8 +2917,28 @@ test("setup happy path runs from sign-in to created game context", async () => {
   assert.equal(seasonId?.textContent, "autumn-cup");
   assert.equal(
     createAnotherLink?.getAttribute("href"),
-    "/leagues/three-sided-football-club/seasons/autumn-cup",
+    "/leagues/three-sided-football-club/seasons/autumn-cup#create-game",
   );
+});
+
+test("season create-game hash opens and focuses the hidden form", async () => {
+  const apiState = createMockApiState();
+  seedGoalScoringGame(apiState, { gameId: "existing-game" });
+
+  const page = await bootPage({
+    html: renderSeasonPage("http://localhost:3001", "autumn-cup", "three-sided-football-club"),
+    url: "http://localhost:3000/leagues/three-sided-football-club/seasons/autumn-cup#create-game",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+
+  const toggle = page.document.querySelector('[data-testid="toggle-create-game"]');
+  const region = page.document.getElementById("season-create-game-region");
+  assert(toggle instanceof page.window.HTMLButtonElement);
+  assert(region instanceof page.window.HTMLElement);
+  assert.equal(toggle.getAttribute("aria-expanded"), "true");
+  assert.equal(region.hidden, false);
+  assert.equal(page.document.activeElement?.id, "game-date");
 });
 
 test("season page does not fall back to legacy create routes when scoped writes are unavailable", async () => {

--- a/app/src/tests/static-export.test.ts
+++ b/app/src/tests/static-export.test.ts
@@ -44,6 +44,7 @@ test("buildStaticSite exports static route shells and ui assets", () => {
     assert.equal(existsSync(resolve(outputDir, "join/index.html")), true);
     assert.equal(existsSync(resolve(outputDir, "invites/index.html")), true);
     assert.equal(existsSync(resolve(outputDir, "ui/styles.css")), true);
+    assert.equal(existsSync(resolve(outputDir, "ui/icons.css")), true);
     assert.equal(existsSync(resolve(outputDir, "ui/setup-flow.js")), true);
     assert.equal(existsSync(resolve(outputDir, "ui/auth-flow.js")), true);
 

--- a/app/src/tests/ui-layout.test.ts
+++ b/app/src/tests/ui-layout.test.ts
@@ -110,6 +110,8 @@ test("setup home page includes stepwise setup panels and setup-flow script", () 
   assert.match(html, /aria-controls="dashboard-create-league-region"/);
   assert.match(html, /id="dashboard-create-league-region" data-ui="disclosure-panel" hidden/);
   assert.ok(html.indexOf('data-testid="panel-dashboard-leagues"') < html.indexOf('data-testid="panel-dashboard-create-league"'));
+  assert.ok(html.indexOf('data-testid="panel-dashboard-leagues"') < html.indexOf('data-testid="toggle-create-league"'));
+  assert.ok(html.indexOf('data-testid="toggle-create-league"') < html.indexOf('data-testid="panel-dashboard-create-league"'));
   assert.match(html, /dashboard-leagues-body/);
   assert.match(html, /data-testid="create-league"/);
   assert.match(html, /id="league-id-display"/);

--- a/app/src/tests/ui-layout.test.ts
+++ b/app/src/tests/ui-layout.test.ts
@@ -14,6 +14,9 @@ import {
 import {
   renderButton,
   renderDataTable,
+  renderIcon,
+  renderIconButton,
+  renderIconLink,
   renderInputField,
   renderModalPrompt,
   renderNavigation,
@@ -60,6 +63,9 @@ test("primitives render expected semantic and data-ui hooks", () => {
     cancelLabel: "Cancel",
   });
   const panel = renderPanel("League setup", "Description", field, button);
+  const icon = renderIcon("circle-plus");
+  const iconButton = renderIconButton({ icon: "trash-2", label: "Delete league" });
+  const iconLink = renderIconLink({ href: "/leagues/league-1", icon: "eye", label: "View league" });
 
   assert.match(button, /data-ui="button"/);
   assert.match(button, /data-variant="danger"/);
@@ -80,6 +86,12 @@ test("primitives render expected semantic and data-ui hooks", () => {
   assert.match(modal, /data-modal-open="delete-game"/);
   assert.match(modal, /data-ui="prompt-overlay"/);
   assert.match(panel, /data-ui="panel"/);
+  assert.match(icon, /data-icon="circle-plus"/);
+  assert.match(icon, /aria-hidden="true"/);
+  assert.match(iconButton, /aria-label="Delete league"/);
+  assert.match(iconButton, /title="Delete league"/);
+  assert.match(iconLink, /aria-label="View league"/);
+  assert.throws(() => renderIcon("missing-icon" as never), /Unsupported icon/);
 });
 
 test("setup home page includes stepwise setup panels and setup-flow script", () => {
@@ -89,11 +101,20 @@ test("setup home page includes stepwise setup panels and setup-flow script", () 
   assert.match(html, /data-page="dashboard"/);
   assert.match(html, /data-testid="panel-dashboard-create-league"/);
   assert.match(html, /data-testid="panel-dashboard-leagues"/);
-  assert.match(html, /League friendly URL/);
+  assert.match(html, /id="dashboard-welcome">Welcome</);
+  assert.match(html, /id="setup-status" role="status" aria-live="polite"/);
+  assert.match(html, /id="setup-error" role="status" aria-live="polite" hidden/);
+  assert.doesNotMatch(html, /API target/);
+  assert.doesNotMatch(html, /3FC ORGANIZER/i);
+  assert.match(html, /data-testid="toggle-create-league"/);
+  assert.match(html, /aria-controls="dashboard-create-league-region"/);
+  assert.match(html, /id="dashboard-create-league-region" data-ui="disclosure-panel" hidden/);
+  assert.ok(html.indexOf('data-testid="panel-dashboard-leagues"') < html.indexOf('data-testid="panel-dashboard-create-league"'));
   assert.match(html, /dashboard-leagues-body/);
   assert.match(html, /data-testid="create-league"/);
   assert.match(html, /id="league-id-display"/);
   assert.match(html, /rel="stylesheet" href="\/ui\/styles\.css"/);
+  assert.match(html, /rel="stylesheet" href="\/ui\/icons\.css"/);
   assert.match(html, /data-testid="setup-shell"/);
   assert.match(html, /<script src="\/ui\/setup-flow\.js" defer><\/script>/);
   assert.match(html, /https:\/\/qa-api\.3fc\.football/);
@@ -109,6 +130,7 @@ test("setup pages can version UI asset URLs for deployments", () => {
     const componentHtml = renderComponentShowcasePage("https://qa-api.3fc.football");
 
     assert.match(setupHtml, /href="\/ui\/styles\.css\?v=abc1234"/);
+    assert.match(setupHtml, /href="\/ui\/icons\.css\?v=abc1234"/);
     assert.match(setupHtml, /<script src="\/ui\/setup-flow\.js\?v=abc1234" defer><\/script>/);
     assert.match(signInHtml, /<script src="\/ui\/auth-flow\.js\?v=abc1234" defer><\/script>/);
     assert.match(componentHtml, /<script src="\/ui\/modal\.js\?v=abc1234" defer><\/script>/);
@@ -127,7 +149,14 @@ test("league page includes season create form and seasons table", () => {
   assert.match(html, /data-testid="league-shell"/);
   assert.match(html, /data-page="league"/);
   assert.match(html, /data-league-id="league-1"/);
-  assert.match(html, /Season friendly URL/);
+  assert.match(html, /id="league-reference">League ID: league-1/);
+  assert.match(html, /data-testid="toggle-create-season"/);
+  assert.match(html, /data-ui="header-actions" role="toolbar" aria-label="League actions"/);
+  assert.match(html, /data-testid="toggle-organiser-invite"/);
+  assert.match(html, /aria-controls="league-create-season-region"/);
+  assert.match(html, /id="league-create-season-region" data-ui="disclosure-panel" hidden/);
+  assert.match(html, /Share the link or code below or send an invite via email/);
+  assert.doesNotMatch(html, /Share invite ready/);
   assert.match(html, /league-seasons-body/);
   assert.match(html, /data-testid="create-season"/);
   assert.match(html, /data-testid="delete-league"/);
@@ -139,6 +168,12 @@ test("season page includes game create form and games table", () => {
   assert.match(html, /data-testid="season-shell"/);
   assert.match(html, /data-page="season"/);
   assert.match(html, /data-season-id="season-1"/);
+  assert.match(html, /id="season-reference">Season ID: season-1/);
+  assert.match(html, /data-testid="toggle-create-game"/);
+  assert.match(html, /data-ui="header-actions" role="toolbar" aria-label="Season actions"/);
+  assert.match(html, /aria-controls="season-create-game-region"/);
+  assert.match(html, /id="season-create-game-region" data-ui="disclosure-panel" hidden/);
+  assert.doesNotMatch(html, /game-id-display/);
   assert.match(html, /Game date/);
   assert.match(html, /data-testid="game-third-length"/);
   assert.match(html, /season-games-body/);

--- a/app/src/ui/icon-names.ts
+++ b/app/src/ui/icon-names.ts
@@ -1,0 +1,28 @@
+export const ICON_NAMES = [
+  "activity",
+  "arrow-left-right",
+  "arrow-right",
+  "calendar-clock",
+  "calendar-plus",
+  "chevron-down",
+  "circle-check",
+  "circle-plus",
+  "circle-user-round",
+  "eye",
+  "pencil",
+  "rotate-ccw",
+  "save",
+  "trash-2",
+  "user-round-check",
+  "user-round-plus",
+  "users",
+  "x",
+] as const;
+
+export type IconName = (typeof ICON_NAMES)[number];
+
+const ICON_NAME_SET = new Set<string>(ICON_NAMES);
+
+export function isIconName(value: string): value is IconName {
+  return ICON_NAME_SET.has(value);
+}

--- a/app/src/ui/layout.ts
+++ b/app/src/ui/layout.ts
@@ -211,24 +211,24 @@ export function renderSetupHomePage(apiBaseUrl: string): string {
     <main data-ui="app-shell" data-testid="setup-shell" data-api-base-url="${escapeHtml(apiBaseUrl)}">
       ${renderDashboardHero()}
       <section data-ui="setup-flow" id="setup-flow-root" data-testid="setup-flow-root" data-page="dashboard" data-api-base-url="${escapeHtml(apiBaseUrl)}">
-        <div data-ui="page-toolbar" role="toolbar" aria-label="Dashboard actions">
-          ${renderIconButton({
-            icon: "circle-plus",
-            label: "Create a new league",
-            text: "Create a new league",
-            variant: "primary",
-            attributes: {
-              "data-action": "toggle-create-league",
-              "data-testid": "toggle-create-league",
-              "aria-controls": "dashboard-create-league-region",
-              "aria-expanded": "false",
-            },
-          })}
-        </div>
         <p data-ui="status-note" id="setup-status" role="status" aria-live="polite">Checking sign-in state…</p>
         <p data-ui="status-note" data-state="error" id="setup-error" role="status" aria-live="polite" hidden></p>
         <section data-ui="panel-stack" data-testid="dashboard-grid">
           ${leaguesPanel}
+          <div data-ui="page-toolbar" role="toolbar" aria-label="Dashboard actions">
+            ${renderIconButton({
+              icon: "circle-plus",
+              label: "Create a new league",
+              text: "Create a new league",
+              variant: "primary",
+              attributes: {
+                "data-action": "toggle-create-league",
+                "data-testid": "toggle-create-league",
+                "aria-controls": "dashboard-create-league-region",
+                "aria-expanded": "false",
+              },
+            })}
+          </div>
           <section id="dashboard-create-league-region" data-ui="disclosure-panel" hidden>
             ${createLeaguePanel}
           </section>

--- a/app/src/ui/layout.ts
+++ b/app/src/ui/layout.ts
@@ -2,6 +2,7 @@ import {
   renderButton,
   renderDataTable,
   renderInputField,
+  renderIconButton,
   renderModalPrompt,
   renderNavigation,
   renderPanel,
@@ -29,7 +30,8 @@ function renderAssetPath(path: string): string {
 }
 
 function renderStylesheetLink(): string {
-  return `<link rel="stylesheet" href="${escapeHtml(renderAssetPath("/ui/styles.css"))}" />`;
+  return `<link rel="stylesheet" href="${escapeHtml(renderAssetPath("/ui/styles.css"))}" />
+  <link rel="stylesheet" href="${escapeHtml(renderAssetPath("/ui/icons.css"))}" />`;
 }
 
 function renderModalScriptTag(): string {
@@ -154,11 +156,9 @@ function renderTableShell(input: {
   </div>`;
 }
 
-function renderDashboardHero(apiBaseUrl: string): string {
-  return `<section data-ui="hero">
-    <span data-ui="hero-kicker">3FC Organizer</span>
-    <h1>Dashboard</h1>
-    <p data-ui="hero-copy">Create leagues, then drill into seasons and games. API target: <code>${escapeHtml(apiBaseUrl)}</code></p>
+function renderDashboardHero(): string {
+  return `<section data-ui="hero" data-layout="dashboard">
+    <h1 id="dashboard-welcome">Welcome</h1>
   </section>`;
 }
 
@@ -193,7 +193,7 @@ export function renderSetupHomePage(apiBaseUrl: string): string {
       bodyId: "dashboard-leagues-body",
       emptyId: "dashboard-leagues-empty",
       emptyText: "No leagues yet. Create your first league to begin.",
-      headers: ["League", "Friendly URL", "Actions"],
+      headers: ["League", "Actions"],
     }),
     "",
     "panel-dashboard-leagues",
@@ -209,13 +209,29 @@ export function renderSetupHomePage(apiBaseUrl: string): string {
   </head>
   <body data-api-base-url="${escapeHtml(apiBaseUrl)}">
     <main data-ui="app-shell" data-testid="setup-shell" data-api-base-url="${escapeHtml(apiBaseUrl)}">
-      ${renderDashboardHero(apiBaseUrl)}
+      ${renderDashboardHero()}
       <section data-ui="setup-flow" id="setup-flow-root" data-testid="setup-flow-root" data-page="dashboard" data-api-base-url="${escapeHtml(apiBaseUrl)}">
-        <p data-ui="status-note" id="setup-status">Checking sign-in state…</p>
-        <p data-ui="status-note" data-state="error" id="setup-error" hidden></p>
-        <section data-ui="panel-grid" data-testid="dashboard-grid">
-          ${createLeaguePanel}
+        <div data-ui="page-toolbar" role="toolbar" aria-label="Dashboard actions">
+          ${renderIconButton({
+            icon: "circle-plus",
+            label: "Create a new league",
+            text: "Create a new league",
+            variant: "primary",
+            attributes: {
+              "data-action": "toggle-create-league",
+              "data-testid": "toggle-create-league",
+              "aria-controls": "dashboard-create-league-region",
+              "aria-expanded": "false",
+            },
+          })}
+        </div>
+        <p data-ui="status-note" id="setup-status" role="status" aria-live="polite">Checking sign-in state…</p>
+        <p data-ui="status-note" data-state="error" id="setup-error" role="status" aria-live="polite" hidden></p>
+        <section data-ui="panel-stack" data-testid="dashboard-grid">
           ${leaguesPanel}
+          <section id="dashboard-create-league-region" data-ui="disclosure-panel" hidden>
+            ${createLeaguePanel}
+          </section>
         </section>
       </section>
     </main>
@@ -235,11 +251,6 @@ export function renderLeaguePage(apiBaseUrl: string, leagueId: string): string {
       label: "Season name",
       placeholder: "2026 Season",
       required: true,
-    })}${renderValidatedField({
-      id: "season-friendly-url",
-      label: "Season friendly URL",
-      placeholder: "2026-season",
-      hint: "Auto-filled from season name. Editable.",
     })}${renderInputField({
       id: "season-start",
       label: "Season start date",
@@ -248,6 +259,11 @@ export function renderLeaguePage(apiBaseUrl: string, leagueId: string): string {
       id: "season-end",
       label: "Season end date",
       type: "date",
+    })}${renderValidatedField({
+      id: "season-friendly-url",
+      label: "Season friendly URL",
+      placeholder: "2026-season",
+      hint: "Auto-filled from season name. Editable.",
     })}<dl data-ui="id-preview"><div><dt>Season ID</dt><dd id="season-id-display">Not generated yet</dd></div></dl>`,
     `<div data-ui="button-row">${renderButton("Create season", "primary", {
       type: "button",
@@ -265,7 +281,7 @@ export function renderLeaguePage(apiBaseUrl: string, leagueId: string): string {
       bodyId: "league-seasons-body",
       emptyId: "league-seasons-empty",
       emptyText: "No seasons yet. Create one to add games.",
-      headers: ["Season", "Dates", "Friendly URL", "Actions"],
+      headers: ["Season", "Dates", "Actions"],
     }),
     "",
     "panel-league-seasons",
@@ -273,14 +289,13 @@ export function renderLeaguePage(apiBaseUrl: string, leagueId: string): string {
 
   const organiserInvitePanel = renderPanel(
     "Invite organiser",
-    "Share a reusable league code or send a direct email invite.",
+    "Share the link or code below or send an invite via email.",
     `<section data-ui="section-stack" aria-labelledby="organiser-share-invite-heading">
       <h3 id="organiser-share-invite-heading">Share code/link</h3>
-      <p data-ui="status-note" id="organiser-share-invite-status">Loading share invite…</p>
-      <p data-ui="field-hint">Reusable league organiser code. Anyone signed in with this code or link can join as organiser.</p>
+      <p data-ui="status-note" id="organiser-share-invite-status" aria-live="polite"></p>
       <dl data-ui="id-preview" data-testid="organiser-share-invite-result" id="organiser-share-invite-result">
-        <div><dt>Invite code</dt><dd id="organiser-share-invite-code">Loading…</dd></div>
-        <div><dt>Invite link</dt><dd><a id="organiser-share-invite-link">Loading…</a></dd></div>
+        <div><dt>Invite code</dt><dd id="organiser-share-invite-code">Open this panel to load</dd></div>
+        <div><dt>Invite link</dt><dd><a id="organiser-share-invite-link">Open this panel to load</a></dd></div>
       </dl>
     </section>
     <section data-ui="section-stack" aria-labelledby="organiser-email-invite-heading">
@@ -292,11 +307,7 @@ export function renderLeaguePage(apiBaseUrl: string, leagueId: string): string {
         placeholder: "coach@example.com",
         hint: "Sends a one-time invite restricted to this email.",
       })}
-      <dl data-ui="id-preview" data-testid="organiser-email-invite-result" id="organiser-email-invite-result" hidden>
-        <div><dt>Invite code</dt><dd id="organiser-email-invite-code"></dd></div>
-        <div><dt>Invite link</dt><dd><a id="organiser-email-invite-link"></a></dd></div>
-        <div><dt>Email</dt><dd id="organiser-invite-email-status"></dd></div>
-      </dl>
+      <p data-ui="status-note" id="organiser-invite-email-status" aria-live="polite"></p>
     </section>`,
     `<div data-ui="button-row">${renderButton("Send email invite", "primary", {
       type: "button",
@@ -318,21 +329,53 @@ export function renderLeaguePage(apiBaseUrl: string, leagueId: string): string {
     <main data-ui="app-shell" data-testid="league-shell" data-api-base-url="${escapeHtml(apiBaseUrl)}">
       <section data-ui="hero">
         <span data-ui="hero-kicker"><a href="/setup">Dashboard</a> / League</span>
-        <h1 id="league-title">${leagueHeading}</h1>
-        <p data-ui="hero-copy" id="league-subtitle">Loading league details…</p>
-        <div data-ui="button-row">${renderButton("Delete league", "danger", {
-          type: "button",
-          "data-action": "delete-league",
-          "data-testid": "delete-league",
-        })}</div>
+        <div data-ui="hero-title-row">
+          <h1 id="league-title">${leagueHeading}</h1>
+          <small data-ui="reference-id" id="league-reference">League ID: ${safeLeagueId || "Loading…"}</small>
+        </div>
+        <div data-ui="header-actions" role="toolbar" aria-label="League actions">
+          ${renderIconButton({
+            icon: "calendar-plus",
+            label: "Create season",
+            attributes: {
+              "data-action": "toggle-create-season",
+              "data-testid": "toggle-create-season",
+              "aria-controls": "league-create-season-region",
+              "aria-expanded": "false",
+            },
+          })}
+          ${renderIconButton({
+            icon: "user-round-plus",
+            label: "Invite organiser",
+            attributes: {
+              "data-action": "toggle-organiser-invite",
+              "data-testid": "toggle-organiser-invite",
+              "aria-controls": "league-organiser-invite-region",
+              "aria-expanded": "false",
+            },
+          })}
+          ${renderIconButton({
+            icon: "trash-2",
+            label: "Delete league",
+            variant: "danger",
+            attributes: {
+              "data-action": "delete-league",
+              "data-testid": "delete-league",
+            },
+          })}
+        </div>
       </section>
       <section data-ui="setup-flow" id="setup-flow-root" data-testid="setup-flow-root" data-page="league" data-api-base-url="${escapeHtml(apiBaseUrl)}" data-league-id="${safeLeagueId}">
-        <p data-ui="status-note" id="setup-status">Loading league data…</p>
-        <p data-ui="status-note" data-state="error" id="setup-error" hidden></p>
-        <section data-ui="panel-grid" data-testid="league-grid">
-          ${createSeasonPanel}
-          ${organiserInvitePanel}
+        <p data-ui="status-note" id="setup-status" role="status" aria-live="polite">Loading league data…</p>
+        <p data-ui="status-note" data-state="error" id="setup-error" role="status" aria-live="polite" hidden></p>
+        <section data-ui="panel-stack" data-testid="league-grid">
           ${seasonsPanel}
+          <section id="league-create-season-region" data-ui="disclosure-panel" hidden>
+            ${createSeasonPanel}
+          </section>
+          <section id="league-organiser-invite-region" data-ui="disclosure-panel" hidden>
+            ${organiserInvitePanel}
+          </section>
         </section>
       </section>
     </main>
@@ -362,8 +405,8 @@ export function renderInvitePage(apiBaseUrl: string, inviteCode: string): string
         <p data-ui="hero-copy">Code <code>${inviteHeading}</code></p>
       </section>
       <section data-ui="setup-flow" id="setup-flow-root" data-testid="setup-flow-root" data-page="invite" data-api-base-url="${escapeHtml(apiBaseUrl)}" data-invite-code="${safeInviteCode}">
-        <p data-ui="status-note" id="setup-status">Checking sign-in state…</p>
-        <p data-ui="status-note" data-state="error" id="setup-error" hidden></p>
+        <p data-ui="status-note" id="setup-status" role="status" aria-live="polite">Checking sign-in state…</p>
+        <p data-ui="status-note" data-state="error" id="setup-error" role="status" aria-live="polite" hidden></p>
         <section data-ui="panel-grid" data-testid="invite-grid">
           ${renderPanel(
             "Accept invite",
@@ -431,8 +474,7 @@ export function renderSeasonPage(apiBaseUrl: string, seasonId: string, leagueId 
         <option value="25">25 minutes</option>
         <option value="30">30 minutes</option>
       </select>
-    </div>
-    <dl data-ui="id-preview"><div><dt>Game ID</dt><dd id="game-id-display">Not generated yet</dd></div></dl>`,
+    </div>`,
     `<div data-ui="button-row">${renderButton("Create game", "primary", {
       type: "button",
       "data-action": "create-game",
@@ -449,7 +491,7 @@ export function renderSeasonPage(apiBaseUrl: string, seasonId: string, leagueId 
       bodyId: "season-games-body",
       emptyId: "season-games-empty",
       emptyText: "No games yet. Create your first game.",
-      headers: ["Game", "Kickoff", "Status", "Actions"],
+      headers: ["Kickoff", "Status", "Actions"],
     }),
     "",
     "panel-season-games",
@@ -467,20 +509,40 @@ export function renderSeasonPage(apiBaseUrl: string, seasonId: string, leagueId 
     <main data-ui="app-shell" data-testid="season-shell" data-api-base-url="${escapeHtml(apiBaseUrl)}" data-season-id="${safeSeasonId}" data-league-id="${safeLeagueId}">
       <section data-ui="hero">
         <span data-ui="hero-kicker"><a href="/setup">Dashboard</a> / <a id="season-league-link" href="/setup">League</a> / Season</span>
-        <h1 id="season-title">${seasonHeading}</h1>
-        <p data-ui="hero-copy" id="season-subtitle">Loading season details…</p>
-        <div data-ui="button-row">${renderButton("Delete season", "danger", {
-          type: "button",
-          "data-action": "delete-season",
-          "data-testid": "delete-season",
-        })}</div>
+        <div data-ui="hero-title-row">
+          <h1 id="season-title">${seasonHeading}</h1>
+          <small data-ui="reference-id" id="season-reference">Season ID: ${safeSeasonId || "Loading…"}</small>
+        </div>
+        <div data-ui="header-actions" role="toolbar" aria-label="Season actions">
+          ${renderIconButton({
+            icon: "calendar-plus",
+            label: "Create game",
+            attributes: {
+              "data-action": "toggle-create-game",
+              "data-testid": "toggle-create-game",
+              "aria-controls": "season-create-game-region",
+              "aria-expanded": "false",
+            },
+          })}
+          ${renderIconButton({
+            icon: "trash-2",
+            label: "Delete season",
+            variant: "danger",
+            attributes: {
+              "data-action": "delete-season",
+              "data-testid": "delete-season",
+            },
+          })}
+        </div>
       </section>
       <section data-ui="setup-flow" id="setup-flow-root" data-testid="setup-flow-root" data-page="season" data-api-base-url="${escapeHtml(apiBaseUrl)}" data-season-id="${safeSeasonId}" data-league-id="${safeLeagueId}">
-        <p data-ui="status-note" id="setup-status">Loading season data…</p>
-        <p data-ui="status-note" data-state="error" id="setup-error" hidden></p>
-        <section data-ui="panel-grid" data-testid="season-grid">
-          ${createGamePanel}
+        <p data-ui="status-note" id="setup-status" role="status" aria-live="polite">Loading season data…</p>
+        <p data-ui="status-note" data-state="error" id="setup-error" role="status" aria-live="polite" hidden></p>
+        <section data-ui="panel-stack" data-testid="season-grid">
           ${gamesPanel}
+          <section id="season-create-game-region" data-ui="disclosure-panel" hidden>
+            ${createGamePanel}
+          </section>
         </section>
       </section>
     </main>
@@ -677,7 +739,7 @@ export function renderComponentShowcasePage(apiBaseUrl: string): string {
   </head>
   <body>
     <main data-ui="app-shell" data-testid="component-showcase">
-      ${renderDashboardHero(apiBaseUrl)}
+      ${renderDashboardHero()}
       <div data-ui="section-stack">
         ${navigationPanel}
         <section data-ui="panel-grid" data-testid="component-grid">
@@ -773,8 +835,8 @@ export function renderJoinPage(apiBaseUrl: string, joinCode: string): string {
         <p data-ui="hero-copy">Code <code>${joinHeading}</code></p>
       </section>
       <section data-ui="setup-flow" id="setup-flow-root" data-testid="setup-flow-root" data-page="join" data-api-base-url="${escapeHtml(apiBaseUrl)}" data-join-code="${safeJoinCode}">
-        <p data-ui="status-note" id="setup-status">Ready.</p>
-        <p data-ui="status-note" data-state="error" id="setup-error" hidden></p>
+        <p data-ui="status-note" id="setup-status" role="status" aria-live="polite">Ready.</p>
+        <p data-ui="status-note" data-state="error" id="setup-error" role="status" aria-live="polite" hidden></p>
         <section data-ui="panel-grid" data-testid="join-grid">
           ${renderPanel(
             "Player registration",
@@ -1089,8 +1151,8 @@ export function renderGamePage(apiBaseUrl: string, input: GameContextPageInput):
         <p data-ui="hero-copy" id="game-subtitle">Loading game details…</p>
       </section>
       <section data-ui="setup-flow" id="setup-flow-root" data-testid="setup-flow-root" data-page="game" data-api-base-url="${escapeHtml(apiBaseUrl)}" data-game-id="${gameId}">
-        <p data-ui="status-note" id="setup-status">Loading game data…</p>
-        <p data-ui="status-note" data-state="error" id="setup-error" hidden></p>
+        <p data-ui="status-note" id="setup-status" role="status" aria-live="polite">Loading game data…</p>
+        <p data-ui="status-note" data-state="error" id="setup-error" role="status" aria-live="polite" hidden></p>
         <nav data-ui="game-mode-nav" data-testid="game-mode-nav" aria-label="Game workflow">
           <div data-ui="game-mode-tabs" aria-label="Game workflow modes">
             ${renderGameModeTab({ mode: "structure", label: "Game", meta: "Setup", active: true })}

--- a/app/src/ui/primitives.ts
+++ b/app/src/ui/primitives.ts
@@ -1,3 +1,5 @@
+import { isIconName, type IconName } from "./icon-names.js";
+
 export type ButtonVariant = "primary" | "secondary" | "ghost" | "danger";
 
 export interface StepChipInput {
@@ -94,6 +96,62 @@ export function renderButton(
     .join(" ");
 
   return `<button ${htmlAttributes}>${escapeHtml(label)}</button>`;
+}
+
+export function renderIcon(name: IconName): string {
+  if (!isIconName(name)) {
+    throw new Error(`Unsupported icon: ${name}`);
+  }
+
+  return `<span data-ui="icon" data-icon="${escapeHtml(name)}" aria-hidden="true"></span>`;
+}
+
+export function renderIconButton(input: {
+  icon: IconName;
+  label: string;
+  variant?: ButtonVariant;
+  text?: string;
+  attributes?: Record<string, string>;
+}): string {
+  const variant = input.variant ?? "secondary";
+  const attributes = {
+    ...(input.attributes ?? {}),
+    type: "button",
+    "aria-label": input.label,
+    title: input.label,
+    "data-ui": "icon-button",
+    "data-variant": variant,
+  };
+  const htmlAttributes = Object.entries(attributes)
+    .map(([name, value]) => `${name}="${escapeHtml(value)}"`)
+    .join(" ");
+  const text = input.text ? `<span data-ui="button-text">${escapeHtml(input.text)}</span>` : "";
+
+  return `<button ${htmlAttributes}>${renderIcon(input.icon)}${text}</button>`;
+}
+
+export function renderIconLink(input: {
+  href: string;
+  icon: IconName;
+  label: string;
+  text?: string;
+  variant?: "secondary" | "ghost";
+  attributes?: Record<string, string>;
+}): string {
+  const attributes = {
+    ...(input.attributes ?? {}),
+    href: input.href,
+    "aria-label": input.label,
+    title: input.label,
+    "data-ui": "icon-link",
+    "data-variant": input.variant ?? "secondary",
+  };
+  const htmlAttributes = Object.entries(attributes)
+    .map(([name, value]) => `${name}="${escapeHtml(value)}"`)
+    .join(" ");
+  const text = input.text ? `<span data-ui="button-text">${escapeHtml(input.text)}</span>` : "";
+
+  return `<a ${htmlAttributes}>${renderIcon(input.icon)}${text}</a>`;
 }
 
 export function renderStepChip(input: StepChipInput): string {

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -84,6 +84,7 @@
     }
 
     statusElement.textContent = text;
+    statusElement.hidden = text.length === 0;
     if (state === "default") {
       statusElement.removeAttribute("data-state");
       return;
@@ -257,6 +258,82 @@
     return `<button data-ui="button" data-variant="${escapeHtml(variant)}" ${renderedAttributes}>${escapeHtml(label)}</button>`;
   }
 
+  function renderClientIcon(name) {
+    return `<span data-ui="icon" data-icon="${escapeHtml(name)}" aria-hidden="true"></span>`;
+  }
+
+  function renderClientIconButton({ icon, label, variant = "secondary", attributes = {} }) {
+    const renderedAttributes = Object.entries({
+      ...attributes,
+      type: "button",
+      "aria-label": label,
+      title: label,
+    })
+      .map(([name, value]) => `${name}="${escapeHtml(String(value))}"`)
+      .join(" ");
+    return `<button data-ui="icon-button" data-variant="${escapeHtml(variant)}" ${renderedAttributes}>${renderClientIcon(icon)}</button>`;
+  }
+
+  function renderClientIconLink({ href, icon, label, attributes = {} }) {
+    const renderedAttributes = Object.entries({
+      ...attributes,
+      href,
+      "aria-label": label,
+      title: label,
+    })
+      .map(([name, value]) => `${name}="${escapeHtml(String(value))}"`)
+      .join(" ");
+    return `<a data-ui="icon-link" data-variant="secondary" ${renderedAttributes}>${renderClientIcon(icon)}</a>`;
+  }
+
+  function setDisclosureState(trigger, panel, open, options = {}) {
+    if (!(trigger instanceof HTMLButtonElement) || !(panel instanceof HTMLElement)) {
+      return;
+    }
+
+    const focusWasInside = panel.contains(document.activeElement);
+    trigger.setAttribute("aria-expanded", open ? "true" : "false");
+    panel.hidden = !open;
+    if (open && options.focus !== false) {
+      const focusTarget = panel.querySelector("input, select, button, [tabindex]");
+      if (focusTarget instanceof HTMLElement) {
+        focusTarget.focus();
+      }
+      return;
+    }
+    if (!open && options.restoreFocus !== false && focusWasInside) {
+      trigger.focus();
+    }
+  }
+
+  function closeOtherDisclosures(activeTrigger) {
+    for (const trigger of document.querySelectorAll('button[aria-controls][aria-expanded="true"]')) {
+      if (!(trigger instanceof HTMLButtonElement) || trigger === activeTrigger) {
+        continue;
+      }
+      const panelId = trigger.getAttribute("aria-controls");
+      const panel = panelId ? document.getElementById(panelId) : null;
+      setDisclosureState(trigger, panel, false, { restoreFocus: false });
+    }
+  }
+
+  function attachDisclosure(trigger, panel, options = {}) {
+    if (!(trigger instanceof HTMLButtonElement) || !(panel instanceof HTMLElement)) {
+      return;
+    }
+
+    trigger.addEventListener("click", () => {
+      const open = trigger.getAttribute("aria-expanded") !== "true";
+      if (open) {
+        closeOtherDisclosures(trigger);
+      }
+      setDisclosureState(trigger, panel, open);
+      if (open && typeof options.onOpen === "function") {
+        options.onOpen();
+      }
+    });
+  }
+
   function renderClientTableShell({ tableTestId, bodyId, emptyId, emptyText, headers }) {
     return `<div data-ui="table-wrap" data-testid="${escapeHtml(tableTestId)}" hidden>
       <table>
@@ -304,7 +381,7 @@
           <option value="30">30 minutes</option>
         </select>
       </div>
-      <dl data-ui="id-preview"><div><dt>Game ID</dt><dd id="game-id-display">Not generated yet</dd></div></dl>`,
+      `,
       `<div data-ui="button-row">${renderClientButton("Create game", "primary", {
         type: "button",
         "data-action": "create-game",
@@ -320,7 +397,7 @@
         bodyId: "season-games-body",
         emptyId: "season-games-empty",
         emptyText: "No games yet. Create your first game.",
-        headers: ["Game", "Kickoff", "Status", "Actions"],
+        headers: ["Kickoff", "Status", "Actions"],
       }),
       "",
       "panel-season-games",
@@ -331,20 +408,40 @@
     document.body.innerHTML = `<main data-ui="app-shell" data-testid="season-shell" data-api-base-url="${safeApiBaseUrl}" data-season-id="${safeSeasonId}" data-league-id="${safeLeagueId}">
       <section data-ui="hero">
         <span data-ui="hero-kicker"><a href="/setup">Dashboard</a> / <a id="season-league-link" href="/setup">League</a> / Season</span>
-        <h1 id="season-title">${safeSeasonId || "Season"}</h1>
-        <p data-ui="hero-copy" id="season-subtitle">Loading season details...</p>
-        <div data-ui="button-row">${renderClientButton("Delete season", "danger", {
-          type: "button",
-          "data-action": "delete-season",
-          "data-testid": "delete-season",
-        })}</div>
+        <div data-ui="hero-title-row">
+          <h1 id="season-title">${safeSeasonId || "Season"}</h1>
+          <small data-ui="reference-id" id="season-reference">Season ID: ${safeSeasonId || "Loading..."}</small>
+        </div>
+        <div data-ui="header-actions" role="toolbar" aria-label="Season actions">
+          ${renderClientIconButton({
+            icon: "calendar-plus",
+            label: "Create game",
+            attributes: {
+              "data-action": "toggle-create-game",
+              "data-testid": "toggle-create-game",
+              "aria-controls": "season-create-game-region",
+              "aria-expanded": "false",
+            },
+          })}
+          ${renderClientIconButton({
+            icon: "trash-2",
+            label: "Delete season",
+            variant: "danger",
+            attributes: {
+              "data-action": "delete-season",
+              "data-testid": "delete-season",
+            },
+          })}
+        </div>
       </section>
       <section data-ui="setup-flow" id="setup-flow-root" data-testid="setup-flow-root" data-page="season" data-api-base-url="${safeApiBaseUrl}" data-season-id="${safeSeasonId}" data-league-id="${safeLeagueId}">
-        <p data-ui="status-note" id="setup-status">Loading season data...</p>
-        <p data-ui="status-note" data-state="error" id="setup-error" hidden></p>
-        <section data-ui="panel-grid" data-testid="season-grid">
-          ${createGamePanel}
+        <p data-ui="status-note" id="setup-status" role="status" aria-live="polite">Loading season data...</p>
+        <p data-ui="status-note" data-state="error" id="setup-error" role="status" aria-live="polite" hidden></p>
+        <section data-ui="panel-stack" data-testid="season-grid">
           ${gamesPanel}
+          <section id="season-create-game-region" data-ui="disclosure-panel" hidden>
+            ${createGamePanel}
+          </section>
         </section>
       </section>
     </main>`;
@@ -992,11 +1089,25 @@
     updateDerivedId();
   }
 
-  async function initDashboardPage() {
+  function dashboardNameFromSession(session) {
+    const email = typeof session?.email === "string" ? session.email.trim() : "";
+    const localPart = email.split("@")[0] ?? "";
+    const token = localPart.split(/[._-]+/).find((part) => part.length > 0) ?? "";
+    if (!token) {
+      return email || "there";
+    }
+
+    return `${token.charAt(0).toUpperCase()}${token.slice(1).toLowerCase()}`;
+  }
+
+  async function initDashboardPage(session) {
     const leagueNameInput = document.getElementById("league-name");
     const leagueFriendlyUrlInput = document.getElementById("league-friendly-url");
     const leagueIdDisplay = document.getElementById("league-id-display");
     const createLeagueButton = root.querySelector('[data-action="create-league"]');
+    const toggleCreateLeagueButton = root.querySelector('[data-action="toggle-create-league"]');
+    const createLeagueRegion = document.getElementById("dashboard-create-league-region");
+    const welcomeHeading = document.getElementById("dashboard-welcome");
 
     const leaguesBody = document.getElementById("dashboard-leagues-body");
     const leaguesTableWrap = document.querySelector('[data-testid="dashboard-leagues-table"]');
@@ -1006,12 +1117,18 @@
       !(leagueNameInput instanceof HTMLInputElement) ||
       !(leagueFriendlyUrlInput instanceof HTMLInputElement) ||
       !(createLeagueButton instanceof HTMLButtonElement) ||
+      !(toggleCreateLeagueButton instanceof HTMLButtonElement) ||
+      !(createLeagueRegion instanceof HTMLElement) ||
       !(leaguesBody instanceof HTMLElement)
     ) {
       return;
     }
 
     attachSlugAutoFill(leagueNameInput, leagueFriendlyUrlInput, leagueIdDisplay, "league");
+    attachDisclosure(toggleCreateLeagueButton, createLeagueRegion);
+    if (welcomeHeading instanceof HTMLElement) {
+      welcomeHeading.textContent = `Welcome ${dashboardNameFromSession(session)}`;
+    }
     leagueNameInput.addEventListener("input", () => {
       setFieldMessage("league-name");
     });
@@ -1031,20 +1148,31 @@
         if (leaguesEmpty instanceof HTMLElement) {
           leaguesEmpty.hidden = false;
         }
-        setStatus("No leagues found. Create your first league.", "default");
+        setDisclosureState(toggleCreateLeagueButton, createLeagueRegion, true);
+        setStatus("");
         return;
       }
 
       const rows = leagues
         .map((league) => {
-          const friendlyUrl = league.slug ?? "-";
           return `<tr>
-            <td><a href="/leagues/${encodeURIComponent(league.leagueId)}">${escapeHtml(league.name)}</a></td>
-            <td><code>${escapeHtml(friendlyUrl)}</code></td>
-            <td>
+            <td data-label="League"><a href="/leagues/${encodeURIComponent(league.leagueId)}">${escapeHtml(league.name)}</a></td>
+            <td data-label="Actions">
               <div data-ui="row-action-buttons">
-                <a href="/leagues/${encodeURIComponent(league.leagueId)}" data-ui="button-link" data-variant="secondary">View</a>
-                <button data-ui="row-action" data-tone="danger" type="button" data-action="delete-league" data-league-id="${escapeHtml(league.leagueId)}">Delete</button>
+                ${renderClientIconLink({
+                  href: `/leagues/${encodeURIComponent(league.leagueId)}`,
+                  icon: "eye",
+                  label: `View ${league.name}`,
+                })}
+                ${renderClientIconButton({
+                  icon: "trash-2",
+                  label: `Delete ${league.name}`,
+                  variant: "danger",
+                  attributes: {
+                    "data-action": "delete-league",
+                    "data-league-id": league.leagueId,
+                  },
+                })}
               </div>
             </td>
           </tr>`;
@@ -1058,7 +1186,7 @@
       if (leaguesEmpty instanceof HTMLElement) {
         leaguesEmpty.hidden = true;
       }
-      setStatus(`Loaded ${leagues.length} league${leagues.length === 1 ? "" : "s"}.`, "success");
+      setStatus("");
     }
 
     createLeagueButton.addEventListener("click", async () => {
@@ -1104,12 +1232,9 @@
     });
 
     leaguesBody.addEventListener("click", async (event) => {
-      const target = event.target;
+      const eventTarget = event.target;
+      const target = eventTarget instanceof Element ? eventTarget.closest('[data-action="delete-league"]') : null;
       if (!(target instanceof HTMLElement)) {
-        return;
-      }
-
-      if (target.getAttribute("data-action") !== "delete-league") {
         return;
       }
 
@@ -1150,8 +1275,12 @@
     }
 
     const title = document.getElementById("league-title");
-    const subtitle = document.getElementById("league-subtitle");
+    const leagueReference = document.getElementById("league-reference");
     const deleteLeagueButton = document.querySelector('[data-testid="delete-league"]');
+    const toggleCreateSeasonButton = document.querySelector('[data-action="toggle-create-season"]');
+    const toggleOrganiserInviteButton = document.querySelector('[data-action="toggle-organiser-invite"]');
+    const createSeasonRegion = document.getElementById("league-create-season-region");
+    const organiserInviteRegion = document.getElementById("league-organiser-invite-region");
 
     const seasonNameInput = document.getElementById("season-name");
     const seasonFriendlyUrlInput = document.getElementById("season-friendly-url");
@@ -1163,9 +1292,6 @@
     const organiserShareInviteResult = document.getElementById("organiser-share-invite-result");
     const organiserShareInviteCode = document.getElementById("organiser-share-invite-code");
     const organiserShareInviteLink = document.getElementById("organiser-share-invite-link");
-    const organiserEmailInviteResult = document.getElementById("organiser-email-invite-result");
-    const organiserEmailInviteCode = document.getElementById("organiser-email-invite-code");
-    const organiserEmailInviteLink = document.getElementById("organiser-email-invite-link");
     const organiserInviteEmailStatus = document.getElementById("organiser-invite-email-status");
 
     const seasonsBody = document.getElementById("league-seasons-body");
@@ -1176,6 +1302,10 @@
       !(seasonNameInput instanceof HTMLInputElement) ||
       !(seasonFriendlyUrlInput instanceof HTMLInputElement) ||
       !(createSeasonButton instanceof HTMLButtonElement) ||
+      !(toggleCreateSeasonButton instanceof HTMLButtonElement) ||
+      !(toggleOrganiserInviteButton instanceof HTMLButtonElement) ||
+      !(createSeasonRegion instanceof HTMLElement) ||
+      !(organiserInviteRegion instanceof HTMLElement) ||
       !(organiserInviteEmailInput instanceof HTMLInputElement) ||
       !(createOrganiserInviteButton instanceof HTMLButtonElement) ||
       !(seasonsBody instanceof HTMLElement)
@@ -1194,12 +1324,30 @@
       setFieldMessage("organiser-invite-email");
     });
 
+    let shareInviteLoaded = false;
+    let shareInvitePromise = null;
+    attachDisclosure(toggleCreateSeasonButton, createSeasonRegion);
+    attachDisclosure(toggleOrganiserInviteButton, organiserInviteRegion, {
+      onOpen: () => {
+        if (!shareInviteLoaded && !shareInvitePromise) {
+          shareInvitePromise = ensureShareInvite()
+            .then((loaded) => {
+              shareInviteLoaded = loaded;
+            })
+            .finally(() => {
+              shareInvitePromise = null;
+            });
+        }
+      },
+    });
+
     function setLocalStatus(element, text, state = "default") {
       if (!(element instanceof HTMLElement)) {
         return;
       }
 
       element.textContent = text;
+      element.hidden = text.length === 0;
       if (state === "default") {
         element.removeAttribute("data-state");
         return;
@@ -1264,7 +1412,8 @@
           organiserShareInviteLink,
           payload,
         );
-        setLocalStatus(organiserShareInviteStatus, "Share invite ready.", "success");
+        setLocalStatus(organiserShareInviteStatus, "", "default");
+        return true;
       } catch {
         if (organiserShareInviteCode instanceof HTMLElement) {
           organiserShareInviteCode.textContent = "Unavailable";
@@ -1273,7 +1422,8 @@
           organiserShareInviteLink.removeAttribute("href");
           organiserShareInviteLink.textContent = "Unavailable";
         }
-        setLocalStatus(organiserShareInviteStatus, "Share invite unavailable. Reload to try again.", "error");
+        setLocalStatus(organiserShareInviteStatus, "Share invite unavailable. Close and reopen to try again.", "error");
+        return false;
       }
     }
 
@@ -1286,10 +1436,8 @@
         title.textContent = league.name;
       }
 
-      if (subtitle) {
-        subtitle.innerHTML = `League ID: <code>${escapeHtml(league.leagueId)}</code> | Friendly URL: <code>${escapeHtml(
-          league.slug ?? "-",
-        )}</code>`;
+      if (leagueReference) {
+        leagueReference.textContent = `League ID: ${league.leagueId}`;
       }
     }
 
@@ -1316,13 +1464,17 @@
           const dateRange = `${season.startsOn ?? "-"} to ${season.endsOn ?? "-"}`;
           const seasonPath = buildLeagueSeasonPath(leagueId, season.seasonId);
           return `<tr>
-            <td><a href="${seasonPath}">${escapeHtml(season.name)}</a></td>
-            <td>${escapeHtml(dateRange)}</td>
-            <td><code>${escapeHtml(season.slug ?? "-")}</code></td>
-            <td>
+            <td data-label="Season"><a href="${seasonPath}">${escapeHtml(season.name)}</a></td>
+            <td data-label="Dates">${escapeHtml(dateRange)}</td>
+            <td data-label="Actions">
               <div data-ui="row-action-buttons">
-                <a href="${seasonPath}" data-ui="button-link" data-variant="secondary">View</a>
-                <button data-ui="row-action" data-tone="danger" type="button" data-action="delete-season" data-season-id="${escapeHtml(season.seasonId)}">Delete</button>
+                ${renderClientIconLink({ href: seasonPath, icon: "eye", label: `View ${season.name}` })}
+                ${renderClientIconButton({
+                  icon: "trash-2",
+                  label: `Delete ${season.name}`,
+                  variant: "danger",
+                  attributes: { "data-action": "delete-season", "data-season-id": season.seasonId },
+                })}
               </div>
             </td>
           </tr>`;
@@ -1398,6 +1550,7 @@
 
       setFieldMessage("organiser-invite-email");
       createOrganiserInviteButton.disabled = true;
+      setLocalStatus(organiserInviteEmailStatus, "Sending invite…", "default");
       setStatus("Sending organiser invite…", "default");
       const idempotencyKey = idempotencyKeyForOrganiserInvite(leagueId, rawEmail);
 
@@ -1416,20 +1569,16 @@
           },
         );
 
-        renderInviteCodeLink(
-          organiserEmailInviteResult,
-          organiserEmailInviteCode,
-          organiserEmailInviteLink,
-          payload,
-        );
-        if (organiserInviteEmailStatus instanceof HTMLElement) {
-          if (payload.emailDelivery?.status === "sent") {
-            organiserInviteEmailStatus.textContent = `Sent to ${payload.emailDelivery.email}.`;
-          } else if (payload.emailDelivery?.status === "unknown") {
-            organiserInviteEmailStatus.textContent = "Delivery unconfirmed. Share the invite link manually.";
-          } else {
-            organiserInviteEmailStatus.textContent = "";
-          }
+        if (payload.emailDelivery?.status === "sent") {
+          setLocalStatus(organiserInviteEmailStatus, `Sent to ${payload.emailDelivery.email}.`, "success");
+        } else if (payload.emailDelivery?.status === "unknown") {
+          setLocalStatus(
+            organiserInviteEmailStatus,
+            "Delivery unconfirmed. Use the reusable link above.",
+            "error",
+          );
+        } else {
+          setLocalStatus(organiserInviteEmailStatus, "Invite created.", "success");
         }
 
         organiserInviteEmailInput.value = "";
@@ -1442,6 +1591,7 @@
         );
       } catch (error) {
         const message = error instanceof Error ? error.message : "Could not create organiser invite.";
+        setLocalStatus(organiserInviteEmailStatus, `Invite failed: ${message}`, "error");
         showError(message);
         setStatus("Organiser invite failed.", "error");
       } finally {
@@ -1450,12 +1600,9 @@
     });
 
     seasonsBody.addEventListener("click", async (event) => {
-      const target = event.target;
+      const eventTarget = event.target;
+      const target = eventTarget instanceof Element ? eventTarget.closest('[data-action="delete-season"]') : null;
       if (!(target instanceof HTMLElement)) {
-        return;
-      }
-
-      if (target.getAttribute("data-action") !== "delete-season") {
         return;
       }
 
@@ -1513,8 +1660,8 @@
     }
 
     await loadLeague();
-    await Promise.all([renderSeasons(), ensureShareInvite()]);
-    setStatus("League page ready.", "success");
+    await renderSeasons();
+    setStatus("");
   }
 
   async function initSeasonPage() {
@@ -1525,14 +1672,15 @@
     const routeLeagueId = resolveRouteEntityId("data-league-id", "leagues");
 
     const seasonTitle = document.getElementById("season-title");
-    const seasonSubtitle = document.getElementById("season-subtitle");
+    const seasonReference = document.getElementById("season-reference");
     const seasonLeagueLink = document.getElementById("season-league-link");
 
     const gameDateInput = document.getElementById("game-date");
     const gameKickoffInput = document.getElementById("game-kickoff");
     const gameThirdLengthInput = document.getElementById("game-third-length");
-    const gameIdDisplay = document.getElementById("game-id-display");
     const createGameButton = root.querySelector('[data-action="create-game"]');
+    const toggleCreateGameButton = document.querySelector('[data-action="toggle-create-game"]');
+    const createGameRegion = document.getElementById("season-create-game-region");
 
     const deleteSeasonButton = document.querySelector('[data-testid="delete-season"]');
 
@@ -1545,6 +1693,8 @@
       !(gameKickoffInput instanceof HTMLInputElement) ||
       !(gameThirdLengthInput instanceof HTMLSelectElement) ||
       !(createGameButton instanceof HTMLButtonElement) ||
+      !(toggleCreateGameButton instanceof HTMLButtonElement) ||
+      !(createGameRegion instanceof HTMLElement) ||
       !(gamesBody instanceof HTMLElement)
     ) {
       return;
@@ -1552,14 +1702,15 @@
 
     let leagueId = routeLeagueId ?? "";
     let gameIdNonce = randomSuffix(4);
+    let derivedGameId = "";
+
+    attachDisclosure(toggleCreateGameButton, createGameRegion);
 
     function updateDerivedGameId() {
       const sessionId = gameDateInput.value.trim() ? gameDateInput.value.trim().replaceAll("-", "") : `session-${randomSuffix(6)}`;
       const kickoff = gameKickoffInput.value.trim();
       const kickoffPart = kickoff.includes("T") ? kickoff.split("T")[1].replace(":", "") : "0000";
-      if (gameIdDisplay) {
-        gameIdDisplay.textContent = `game-${sessionId}-${kickoffPart}-${gameIdNonce}`;
-      }
+      derivedGameId = `game-${sessionId}-${kickoffPart}-${gameIdNonce}`;
     }
 
     gameDateInput.addEventListener("change", () => {
@@ -1604,10 +1755,8 @@
         seasonTitle.textContent = season.name;
       }
 
-      if (seasonSubtitle) {
-        seasonSubtitle.innerHTML = `Season ID: <code>${escapeHtml(season.seasonId)}</code> | Friendly URL: <code>${escapeHtml(
-          season.slug ?? "-",
-        )}</code>`;
+      if (seasonReference) {
+        seasonReference.textContent = `Season ID: ${season.seasonId}`;
       }
 
       if (seasonLeagueLink instanceof HTMLAnchorElement) {
@@ -1641,17 +1790,27 @@
       }
 
       gamesBody.innerHTML = games
-        .map((game) => `<tr>
-          <td><a href="/games/${encodeURIComponent(game.gameId)}">${escapeHtml(game.gameId)}</a></td>
-          <td>${escapeHtml(formatLocalTimestamp(game.gameStartTs))}</td>
-          <td>${escapeHtml(game.status)}</td>
-          <td>
+        .map((game) => {
+          const status = ["scheduled", "live", "finished"].includes(game.status) ? game.status : "scheduled";
+          const statusIcon = status === "live" ? "activity" : status === "finished" ? "circle-check" : "calendar-clock";
+          const statusLabel = status.charAt(0).toUpperCase() + status.slice(1);
+          const gamePath = `/games/${encodeURIComponent(game.gameId)}`;
+          return `<tr>
+          <td data-label="Kickoff"><a href="${gamePath}">${escapeHtml(formatLocalTimestamp(game.gameStartTs))}</a></td>
+          <td data-label="Status"><span data-ui="status-chip" data-status="${escapeHtml(status)}">${renderClientIcon(statusIcon)}<span>${escapeHtml(statusLabel)}</span></span></td>
+          <td data-label="Actions">
             <div data-ui="row-action-buttons">
-              <a href="/games/${encodeURIComponent(game.gameId)}" data-ui="button-link" data-variant="secondary">View</a>
-              <button data-ui="row-action" data-tone="danger" type="button" data-action="delete-game" data-game-id="${escapeHtml(game.gameId)}">Delete</button>
+              ${renderClientIconLink({ href: gamePath, icon: "eye", label: `View game at ${formatLocalTimestamp(game.gameStartTs)}` })}
+              ${renderClientIconButton({
+                icon: "trash-2",
+                label: `Delete game at ${formatLocalTimestamp(game.gameStartTs)}`,
+                variant: "danger",
+                attributes: { "data-action": "delete-game", "data-game-id": game.gameId },
+              })}
             </div>
           </td>
-        </tr>`)
+        </tr>`;
+        })
         .join("");
 
       if (gamesTableWrap instanceof HTMLElement) {
@@ -1683,7 +1842,7 @@
       setFieldMessage("game-kickoff");
 
       const sessionId = gameDate.replaceAll("-", "");
-      const gameId = (gameIdDisplay?.textContent ?? "").trim() || `game-${sessionId}-${randomSuffix(6)}`;
+      const gameId = derivedGameId || `game-${sessionId}-${randomSuffix(6)}`;
 
       createGameButton.disabled = true;
       setStatus("Creating game…", "default");
@@ -1732,12 +1891,9 @@
     });
 
     gamesBody.addEventListener("click", async (event) => {
-      const target = event.target;
+      const eventTarget = event.target;
+      const target = eventTarget instanceof Element ? eventTarget.closest('[data-action="delete-game"]') : null;
       if (!(target instanceof HTMLElement)) {
-        return;
-      }
-
-      if (target.getAttribute("data-action") !== "delete-game") {
         return;
       }
 
@@ -1799,7 +1955,10 @@
 
     await loadSeason();
     await renderGames();
-    setStatus("Season page ready.", "success");
+    if (window.location.hash === "#create-game") {
+      setDisclosureState(toggleCreateGameButton, createGameRegion, true);
+    }
+    setStatus("");
   }
 
   async function initGamePage() {
@@ -3446,7 +3605,7 @@
         gameSeasonLink.href = buildLeagueSeasonPath(game.leagueId, game.seasonId);
       }
       if (createAnotherLink instanceof HTMLAnchorElement) {
-        createAnotherLink.href = buildLeagueSeasonPath(game.leagueId, game.seasonId);
+        createAnotherLink.href = `${buildLeagueSeasonPath(game.leagueId, game.seasonId)}#create-game`;
       }
     }
 
@@ -3741,7 +3900,8 @@
       });
 
       root.addEventListener("click", async (event) => {
-        const target = event.target;
+        const eventTarget = event.target;
+        const target = eventTarget instanceof Element ? eventTarget.closest("button[data-action]") : null;
         if (!(target instanceof HTMLButtonElement)) {
           return;
         }
@@ -3978,7 +4138,8 @@
       });
 
       root.addEventListener("click", async (event) => {
-        const target = event.target;
+        const eventTarget = event.target;
+        const target = eventTarget instanceof Element ? eventTarget.closest("button[data-action]") : null;
         if (!(target instanceof HTMLButtonElement)) {
           return;
         }
@@ -4449,8 +4610,9 @@
       return;
     }
 
+    let authenticatedSession = null;
     try {
-      await ensureAuthenticatedSession();
+      authenticatedSession = await ensureAuthenticatedSession();
     } catch (error) {
       if (error instanceof Error && error.message === "redirecting_to_sign_in") {
         return;
@@ -4463,7 +4625,7 @@
 
     try {
       if (page === "dashboard") {
-        await initDashboardPage();
+        await initDashboardPage(authenticatedSession);
         return;
       }
 

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -1124,7 +1124,11 @@
       return;
     }
 
+    let createLeagueDisclosureTouched = false;
     attachSlugAutoFill(leagueNameInput, leagueFriendlyUrlInput, leagueIdDisplay, "league");
+    toggleCreateLeagueButton.addEventListener("click", () => {
+      createLeagueDisclosureTouched = true;
+    });
     attachDisclosure(toggleCreateLeagueButton, createLeagueRegion);
     if (welcomeHeading instanceof HTMLElement) {
       welcomeHeading.textContent = `Welcome ${dashboardNameFromSession(session)}`;
@@ -1148,7 +1152,9 @@
         if (leaguesEmpty instanceof HTMLElement) {
           leaguesEmpty.hidden = false;
         }
-        setDisclosureState(toggleCreateLeagueButton, createLeagueRegion, true);
+        if (!createLeagueDisclosureTouched) {
+          setDisclosureState(toggleCreateLeagueButton, createLeagueRegion, true, { focus: false });
+        }
         setStatus("");
         return;
       }

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -1572,11 +1572,15 @@
         if (payload.emailDelivery?.status === "sent") {
           setLocalStatus(organiserInviteEmailStatus, `Sent to ${payload.emailDelivery.email}.`, "success");
         } else if (payload.emailDelivery?.status === "unknown") {
-          setLocalStatus(
-            organiserInviteEmailStatus,
-            "Delivery unconfirmed. Use the reusable link above.",
-            "error",
-          );
+          const recoveryLink = typeof payload.inviteLink === "string" ? payload.inviteLink : "";
+          setLocalStatus(organiserInviteEmailStatus, "Delivery unconfirmed.", "error");
+          if (recoveryLink) {
+            const recoveryAnchor = document.createElement("a");
+            recoveryAnchor.href = recoveryLink;
+            recoveryAnchor.textContent = "Open the email-restricted recovery link";
+            recoveryAnchor.className = "inline-recovery-link";
+            organiserInviteEmailStatus.append(" ", recoveryAnchor, ".");
+          }
         } else {
           setLocalStatus(organiserInviteEmailStatus, "Invite created.", "success");
         }

--- a/app/src/ui/styles.css
+++ b/app/src/ui/styles.css
@@ -79,6 +79,47 @@ body {
     color: var(--ink-soft);
     max-width: 56ch;
   }
+
+  &[data-layout="dashboard"] h1 {
+    margin-bottom: 0;
+  }
+}
+
+[data-ui="hero-title-row"] {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.45rem 1rem;
+
+  h1 {
+    min-width: 0;
+  }
+}
+
+[data-ui="reference-id"] {
+  color: var(--ink-soft);
+  font-family: "SF Mono", "Menlo", "Monaco", monospace;
+  font-size: 0.72rem;
+  overflow-wrap: anywhere;
+}
+
+[data-ui="page-toolbar"],
+[data-ui="header-actions"] {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+[data-ui="page-toolbar"] {
+  justify-content: flex-end;
+  margin-top: 0.8rem;
+}
+
+[data-ui="header-actions"] {
+  justify-content: flex-end;
+  margin-top: 0.75rem;
 }
 
 [data-ui="section-stack"] {
@@ -123,6 +164,15 @@ body {
 [data-ui="panel-grid"] {
   display: grid;
   gap: 0.85rem;
+}
+
+[data-ui="panel-stack"] {
+  display: grid;
+  gap: 0.85rem;
+}
+
+[data-ui="disclosure-panel"][hidden] {
+  display: none;
 }
 
 [data-ui="panel"] {
@@ -340,6 +390,99 @@ body {
     cursor: not-allowed;
     opacity: 0.55;
     transform: none;
+  }
+}
+
+[data-ui="icon-button"],
+[data-ui="icon-link"] {
+  min-width: 2.75rem;
+  min-height: 2.75rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.45rem;
+  padding: 0.62rem;
+  color: var(--ink-strong);
+  background: #f1f7f4;
+  border-color: #b7d2c7;
+  font: inherit;
+  font-weight: 750;
+  line-height: 1;
+  text-decoration: none;
+  cursor: pointer;
+  transition: transform 140ms ease, background-color 140ms ease, border-color 140ms ease,
+    color 140ms ease;
+
+  [data-ui="icon"] {
+    flex: 0 0 auto;
+    width: 1.15rem;
+    height: 1.15rem;
+  }
+
+  [data-ui="button-text"] {
+    line-height: 1.15;
+  }
+
+  &:hover {
+    transform: translateY(-1px);
+    border-color: var(--accent);
+  }
+
+  &:focus-visible {
+    outline: 2px solid #5eb6aa73;
+    outline-offset: 2px;
+  }
+
+  &[data-variant="primary"] {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: #f6fdfb;
+  }
+
+  &[data-variant="danger"] {
+    background: var(--danger-soft);
+    border-color: #df9b92;
+    color: var(--danger);
+  }
+
+  &:disabled,
+  &[aria-disabled="true"] {
+    cursor: not-allowed;
+    opacity: 0.5;
+    transform: none;
+  }
+}
+
+[data-ui="status-chip"] {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.32rem;
+  width: fit-content;
+  border: 1px solid #bfd3cc;
+  border-radius: 999px;
+  padding: 0.22rem 0.5rem;
+  background: #f1f7f4;
+  color: #294f49;
+  font-size: 0.78rem;
+  font-weight: 800;
+
+  [data-ui="icon"] {
+    width: 0.9rem;
+    height: 0.9rem;
+  }
+
+  &[data-status="live"] {
+    border-color: #d7983c;
+    background: #fff4dd;
+    color: #744412;
+  }
+
+  &[data-status="finished"] {
+    border-color: #9fb7c5;
+    background: #eef5f8;
+    color: #27495a;
   }
 }
 
@@ -1239,6 +1382,69 @@ body {
   th {
     background: #f1f8f5;
     color: #2a4f49;
+  }
+}
+
+@media (max-width: 767px) {
+  :is(
+    [data-testid="dashboard-leagues-table"],
+    [data-testid="league-seasons-table"],
+    [data-testid="season-games-table"]
+  ) {
+    overflow: visible;
+    border: 0;
+
+    table {
+      min-width: 0;
+      display: block;
+
+      thead {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
+      }
+
+      tbody,
+      tr,
+      td {
+        display: block;
+        width: 100%;
+      }
+
+      tbody {
+        display: grid;
+        gap: 0.65rem;
+      }
+
+      tr {
+        border: 1px solid #cadcd6;
+        border-radius: 10px;
+        padding: 0.65rem;
+        background: #fff;
+      }
+
+      td {
+        border: 0;
+        padding: 0.3rem 0;
+
+        &::before {
+          content: attr(data-label);
+          display: block;
+          margin-bottom: 0.16rem;
+          color: var(--ink-soft);
+          font-size: 0.7rem;
+          font-weight: 800;
+          text-transform: uppercase;
+          letter-spacing: 0.04em;
+        }
+      }
+    }
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,10 @@
       "version": "0.1.0",
       "dependencies": {
         "@3fc/contracts": "0.1.0"
+      },
+      "devDependencies": {
+        "@iconify-json/lucide": "^1.2.123",
+        "@iconify/utils": "^3.1.4"
       }
     },
     "node_modules/@3fc/api": {
@@ -55,6 +59,20 @@
     "node_modules/@3fc/contracts": {
       "resolved": "packages/contracts",
       "link": true
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
     },
     "node_modules/@asamuzakjp/css-color": {
       "version": "5.0.1",
@@ -1660,6 +1678,35 @@
         "@noble/hashes": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@iconify-json/lucide": {
+      "version": "1.2.123",
+      "resolved": "https://registry.npmjs.org/@iconify-json/lucide/-/lucide-1.2.123.tgz",
+      "integrity": "sha512-0CozmpKXEOEEhltrfT2zt+/t1hez67Y+hM2VJWoIcBKdBrb83VYuKf+b5A0QU9HfQm+RNn2GjFWlTOwi+Ss6IA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.4.tgz",
+      "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "import-meta-resolve": "^4.2.0"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -4004,6 +4051,17 @@
         "node": ">= 4"
       }
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
@@ -4531,6 +4589,13 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/package-manager-detector": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
+      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "8.0.0",
@@ -5207,6 +5272,16 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tldts": {


### PR DESCRIPTION
<!-- review-packet-version:1 -->

## Behavioural claim

Signed-in organisers see a personalised, league-first dashboard and compact, accessible league/season management actions whose transient forms open only on request; Lucide icons are generated locally from an allow-list with no runtime network dependency.

## Specification and acceptance evidence

| Acceptance criterion | Evidence | Result |
| --- | --- | --- |
| Dashboard greeting, empty/populated league states, league-list → create-action → form hierarchy, hidden create form, icon-child deletion | `ui-layout.test.ts` ordering plus `setup-flow-e2e.test.ts` dashboard scenarios; `npm test` | PASS |
| League action disclosures, focus restoration, lazy share invite retry, direct invite success/failure/unconfirmed recovery link behavior | focused JSDOM scenarios plus final UX/engineering/quality re-audits | PASS |
| Season kickoff links, three status chips, hidden generated game ID, scoped/legacy routes, `#create-game` focus | season JSDOM scenarios including Australia/Melbourne UTC rollover; `npm test` | PASS |
| Icon allow-list, build failure for invalid client references, local/offline asset, CSP/static export | `icon-assets.test.ts`, `server.test.ts`, `static-export.test.ts`; `npm test` | PASS |
| Full repository compatibility | `npm run lint`; `npm test` (269 API, 80 app, 57 review-gate tests); `npm run contracts:check` | PASS |
| Independent local review | UX, engineering, and quality read-only final re-audits reported no material remaining issues | PASS |

## Scope boundaries

Included:

- Dashboard, league, and season shell hierarchy, disclosures, compact action controls, responsive management cards, invite presentation, and focused tests.
- Build-only `@iconify-json/lucide` and `@iconify/utils` dependencies, allow-list, generator, static client-reference validator, local generated CSS serving/export.
- Existing game “Create another” link now targets the supported season `#create-game` disclosure.

Excluded:

- Game setup/roster UI beyond the hash link.
- Live scoring and final summary UX.
- REST/OpenAPI/authentication/DynamoDB/deployment contract changes.

## Change classification

- Declared risk: `high`
- [ ] `documentation-only` — Documentation only
- [ ] `tests-only` — Tests only
- [x] `application-behaviour` — Application or API behaviour
- [ ] `backlog-maintenance` — Canonical backlog maintenance
- [x] `dependency-tooling` — Dependency or tooling
- [ ] `public-contract` — Public API or repository contract
- [ ] `data-migration` — Database schema or data migration
- [ ] `permission-trust-boundary` — Permission or trust boundary
- [ ] `durable-state-ownership` — Durable state or ownership
- [ ] `destructive-behaviour` — Destructive or difficult-to-reverse behaviour
- [ ] `new-production-dependency` — New production dependency
- [ ] `authentication-authorisation` — Authentication or authorisation
- [ ] `privacy-regulated-data` — Privacy or regulated data
- [ ] `infrastructure-production-configuration` — Infrastructure or deployment control
- [ ] `review-policy` — Review policy, packet, or workflow

## Architecture and invariants

- [ ] `architecture:none`
- [x] `architecture:documented`
- [ ] `architecture:judgement-required`

### Affected invariants

None.

### Architecture or decision record

No ADR is required. The architecture-sensitive change is isolated to the app build boundary: two development-only Iconify packages generate a committed-manifest, local CSS asset. The browser receives self-hosted CSS/data URIs only; no runtime package, web component, API, CDN, REST contract, or data owner is introduced.

## Failure and rollback

### Failure behaviour

A missing Lucide icon, non-static client icon reference, or generated empty stylesheet fails the app build. Runtime invite/network failures retain existing retry behavior and surface polite local/global feedback. If the local icon CSS were unavailable, the server fails at startup rather than rendering unnamed empty controls.

### Rollback approach

Revert the four commits on PR head `7bea4e00ee253d73319c586a63674f3764a4f2de`. There are no migrations, durable-data rewrites, public contracts, or runtime third-party services to unwind.

### Rollback evidence

The work is four isolated commits on `codex/ux-shell-actions`; the diff contains app UI/build/test files plus the lockfile only. Existing full repository tests pass on the proposed head, and reverting both commits restores the prior build script and removes the generated asset route atomically.

## Automated and agent review disposition

### Unresolved blocking findings

None.

### Addressed findings and evidence

- Independent Codex review found that uncertain direct-email delivery must retain the safer one-time, email-restricted recovery link instead of directing the organiser to the reusable credential. Fixed in `7218f4a`: the exceptional live status renders only the API-returned recovery link; invite code, email echo, raw legacy link field, and result table remain absent. Focused tests assert the exact recovery href and those absences.\n- Independent Codex review found a delayed empty-league response could reopen a form the user had deliberately closed and steal focus. Fixed in `7bea4e0`: untouched empty state auto-opens without focus, while any user-touched state wins. A held-response regression test proves the close state and focus survive the late response.

### Rejected findings and evidence

- A literal nested SVG/path click test is not applicable because generated Lucide artwork is a CSS data-URI mask on an `aria-hidden` span. The actual icon child is clicked in JSDOM, and delegated handlers use `closest("[data-action]")`.

## Human judgement

- [x] `human-judgement:none`
- [ ] `human-judgement:required`

### Decision requiring judgement

None.

### Options considered

None.

### Reason selected

None.

### Reversal cost

None.

## Review focus

Please challenge the Iconify client-reference validator and offline/CSP guarantees, disclosure focus and event delegation, invite idempotency/error recovery, mobile card scoping, timezone rendering, and nested scoped-season compatibility. Dependency provenance: `@iconify-json/lucide@1.2.123` is ISC; `@iconify/utils@3.1.4` is MIT; both are lockfile-pinned development dependencies.
