### PR TITLE
feat(app): improve live scoring and match summary

### DIFF
--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -5181,6 +5181,182 @@ test("game page invalidates current goals when correction replay refresh fails",
   assert.equal(undoLastGoalButton.disabled, true);
 });
 
+test("game page refreshes the finished result when a committed edit timeline reload fails", async () => {
+  const apiState = createMockApiState();
+  const finishedThirds = createDefaultThirdTimerSegments().map((third) => ({
+    ...third,
+    startedAt: `2026-03-28T11:00:0${third.third}.000Z`,
+    finishedAt: `2026-03-28T11:00:1${third.third}.000Z`,
+  }));
+  seedGoalScoringGame(apiState, {
+    gameId: "game-finished-timeline-refresh-fail",
+    status: "finished",
+    thirds: finishedThirds,
+    role: "admin",
+    sessionEmail: "admin@3fc.football",
+  });
+  apiState.goalEvents.set("goal-1", {
+    gameId: "game-finished-timeline-refresh-fail",
+    eventId: "goal-1",
+    third: 1,
+    thirdMinute: 1,
+    gameMinute: 1,
+    elapsedSeconds: 30,
+    stoppageMinute: null,
+    displayTime: "1'",
+    scoringTeamId: "red",
+    concedingTeamId: "blue",
+    scorerPlayerId: "player-ari",
+    assistPlayerIds: [],
+    ownGoal: false,
+    createdAt: "2026-03-28T11:01:01.000Z",
+    updatedAt: "2026-03-28T11:01:01.000Z",
+  });
+  const seededGame = apiState.games.get("game-finished-timeline-refresh-fail");
+  assert(seededGame);
+  refreshMockFinishedResult(apiState, seededGame, "2026-03-28T11:02:00.000Z");
+
+  const defaultFetch = createMockFetch(apiState);
+  let correctionCommitted = false;
+  let failedGoalRefreshes = 0;
+  let successfulGameRefreshes = 0;
+  let resolveGameRefresh: ((response: Response) => void) | undefined;
+  const partialRefreshFetch: ReturnType<typeof createMockFetch> = async (input, init = {}) => {
+    const target =
+      typeof input === "string" || input instanceof URL
+        ? new URL(String(input))
+        : new URL(input.url);
+    const method = (init.method ?? "GET").toUpperCase();
+
+    if (
+      method === "PATCH" &&
+      target.pathname === "/v1/games/game-finished-timeline-refresh-fail/goals/goal-1"
+    ) {
+      const response = await defaultFetch(input, init);
+      correctionCommitted = true;
+      return response;
+    }
+
+    if (
+      correctionCommitted &&
+      method === "GET" &&
+      target.pathname === "/v1/games/game-finished-timeline-refresh-fail/goals"
+    ) {
+      failedGoalRefreshes += 1;
+      return createJsonResponse(503, {
+        error: "unavailable",
+        message: "Goal timeline could not be refreshed.",
+      });
+    }
+
+    if (
+      correctionCommitted &&
+      method === "GET" &&
+      target.pathname === "/v1/games/game-finished-timeline-refresh-fail"
+    ) {
+      successfulGameRefreshes += 1;
+      return new Promise<Response>((resolve) => {
+        resolveGameRefresh = resolve;
+      });
+    }
+
+    return defaultFetch(input, init);
+  };
+
+  const page = await bootPage({
+    html: renderGamePage("http://localhost:3001", {
+      gameId: "game-finished-timeline-refresh-fail",
+    }),
+    url: "http://localhost:3000/games/game-finished-timeline-refresh-fail",
+    scriptFile: "setup-flow.js",
+    apiState,
+    fetch: partialRefreshFetch,
+  });
+
+  const editGoalButton = page.document.querySelector(
+    '[data-action="edit-goal"][data-event-id="goal-1"]',
+  );
+  const scoringTeamInput = page.document.getElementById("goal-scoring-team");
+  const concedingTeamInput = page.document.getElementById("goal-conceding-team");
+  const scorerInput = page.document.getElementById("goal-scorer");
+  const saveGoalButton = page.document.querySelector('[data-action="save-goal"]');
+  const timeline = page.document.getElementById("goal-timeline");
+  const status = page.document.getElementById("setup-status");
+  const error = page.document.getElementById("setup-error");
+  const resultSummary = page.document.getElementById("game-result-summary");
+  assert(editGoalButton instanceof page.window.HTMLButtonElement);
+  assert(scoringTeamInput instanceof page.window.HTMLSelectElement);
+  assert(concedingTeamInput instanceof page.window.HTMLSelectElement);
+  assert(scorerInput instanceof page.window.HTMLSelectElement);
+  assert(saveGoalButton instanceof page.window.HTMLButtonElement);
+  assert(timeline instanceof page.window.HTMLElement);
+  assert(status instanceof page.window.HTMLElement);
+  assert(error instanceof page.window.HTMLElement);
+  assert(resultSummary instanceof page.window.HTMLElement);
+  assert.match(resultSummary.textContent ?? "", /Red win/);
+
+  dispatchClick(editGoalButton);
+  await flushAsync();
+  scoringTeamInput.value = "blue";
+  scoringTeamInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+  concedingTeamInput.value = "red";
+  concedingTeamInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+  scorerInput.value = "player-cy";
+  scorerInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+  dispatchClick(saveGoalButton);
+  await flushAsync();
+
+  assert.equal(apiState.goalEvents.get("goal-1")?.scoringTeamId, "blue");
+  assert.equal(apiState.goalEvents.get("goal-1")?.concedingTeamId, "red");
+  assert.equal(apiState.goalEvents.get("goal-1")?.scorerPlayerId, "player-cy");
+  assert.equal(apiState.games.get("game-finished-timeline-refresh-fail")?.result?.winnerTeamId, "blue");
+  assert.equal(failedGoalRefreshes, 1);
+  assert.equal(successfulGameRefreshes, 1);
+  assert(resolveGameRefresh);
+  assert.equal(saveGoalButton.disabled, true);
+
+  const refreshedGame = apiState.games.get("game-finished-timeline-refresh-fail");
+  assert(refreshedGame);
+  resolveGameRefresh(createJsonResponse(200, refreshedGame));
+  await flushAsync();
+
+  assert.equal(failedGoalRefreshes, 1);
+  assert.equal(successfulGameRefreshes, 1);
+  assert.match(status.textContent ?? "", /Goal updated\. Match Summary refreshed; goal timeline unavailable/);
+  assert.match(error.textContent ?? "", /Goal details could not be loaded\. Reload to try again/);
+  assert.match(timeline.textContent ?? "", /Goal timeline unavailable/);
+  assert.equal(resultSummary.hidden, false);
+  assert.equal(
+    resultSummary.querySelector('[data-testid="game-result-outcome"]')?.textContent,
+    "Blue win",
+  );
+  assert.doesNotMatch(resultSummary.textContent ?? "", /Result refresh required/);
+  const blueTeam = resultSummary.querySelector('[data-ui="result-team"][data-team-id="blue"]');
+  const redTeam = resultSummary.querySelector('[data-ui="result-team"][data-team-id="red"]');
+  assert(blueTeam instanceof page.window.HTMLElement);
+  assert(redTeam instanceof page.window.HTMLElement);
+  assert.deepEqual(
+    [...blueTeam.querySelectorAll("dl div")].map((row) => row.textContent?.replace(/\s/g, "")),
+    ["Conceded0", "Scored1"],
+  );
+  assert.deepEqual(
+    [...redTeam.querySelectorAll("dl div")].map((row) => row.textContent?.replace(/\s/g, "")),
+    ["Conceded1", "Scored0"],
+  );
+  assert(resultSummary.querySelector('[data-testid="final-team-log-unavailable-blue"]'));
+  assert(resultSummary.querySelector('[data-testid="final-goal-summary-unavailable"]'));
+  assert.equal(resultSummary.querySelector('[data-testid="final-full-goal-log"]'), null);
+  assert.equal(scoringTeamInput.disabled, true);
+  assert.equal(concedingTeamInput.disabled, true);
+  assert.equal(scorerInput.disabled, true);
+  assert.equal(saveGoalButton.disabled, true);
+  const undoLastGoalButton = page.document.querySelector('[data-action="undo-last-goal"]');
+  assert(undoLastGoalButton instanceof page.window.HTMLButtonElement);
+  assert.equal(undoLastGoalButton.disabled, true);
+  assert.equal(timeline.querySelector('[data-action="edit-goal"]'), null);
+  assert.equal(timeline.querySelector('[data-action="delete-goal"]'), null);
+});
+
 test("game page renders malformed result data without crashing", async () => {
   const apiState = createMockApiState();
   apiState.session = {

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -4280,6 +4280,14 @@ test("game page renders final team logs and aggregate player stats", async () =>
   assert(
     fullGoalLog.querySelector('[data-ui="third-indicator"][data-third="3"][aria-label="Third 3 of 3"]'),
   );
+  assert.equal(
+    fullGoalLog.querySelector('[data-event-id="goal-1"] [data-ui="goal-team-semantics"]')?.textContent,
+    "Scoring team: Red. Conceding team: Blue.",
+  );
+  assert.equal(
+    fullGoalLog.querySelector('[data-event-id="goal-3"] [data-ui="goal-team-semantics"]')?.textContent,
+    "Own goal. No scoring team. Conceding team: Red.",
+  );
 });
 
 test("game page converts partial goal times into full-match football notation", async () => {
@@ -5277,6 +5285,30 @@ test("game page renders malformed goal identity values without crashing", async 
   const malformedRedTeam = apiState.gameTeams.get("game-malformed-goal:red");
   assert(malformedRedTeam);
   malformedRedTeam.name = 123 as unknown as string;
+  for (const player of [
+    { playerId: "99", nickname: "Valid 99" },
+    { playerId: "17", nickname: "Valid 17" },
+  ]) {
+    apiState.players.set(player.playerId, {
+      ...player,
+      claimedByUserId: null,
+      createdAt: "2026-03-28T11:00:07.000Z",
+      updatedAt: "2026-03-28T11:00:07.000Z",
+    });
+    apiState.gamePlayers.set(`game-malformed-goal:${player.playerId}`, {
+      gameId: "game-malformed-goal",
+      playerId: player.playerId,
+      createdAt: "2026-03-28T11:00:08.000Z",
+      updatedAt: "2026-03-28T11:00:08.000Z",
+    });
+    apiState.roster.set(`game-malformed-goal:${player.playerId}`, {
+      gameId: "game-malformed-goal",
+      playerId: player.playerId,
+      teamId: "red",
+      createdAt: "2026-03-28T11:00:08.000Z",
+      updatedAt: "2026-03-28T11:00:08.000Z",
+    });
+  }
   apiState.goalEvents.set("malformed-goal", {
     gameId: "game-malformed-goal",
     eventId: 123,
@@ -5294,6 +5326,25 @@ test("game page renders malformed goal identity values without crashing", async 
     createdAt: "2026-03-28T11:01:01.000Z",
     updatedAt: "2026-03-28T11:01:01.000Z",
   } as unknown as MockGoalEvent);
+  for (const [index, eventId] of ["valid-goal-1", "valid-goal-2"].entries()) {
+    apiState.goalEvents.set(eventId, {
+      gameId: "game-malformed-goal",
+      eventId,
+      third: 1,
+      thirdMinute: 2 + index,
+      gameMinute: 2 + index,
+      elapsedSeconds: 60 + index * 30,
+      stoppageMinute: null,
+      displayTime: `${2 + index}'`,
+      scoringTeamId: "red",
+      concedingTeamId: "blue",
+      scorerPlayerId: "99",
+      assistPlayerIds: ["17"],
+      ownGoal: false,
+      createdAt: `2026-03-28T11:01:0${2 + index}.000Z`,
+      updatedAt: `2026-03-28T11:01:0${2 + index}.000Z`,
+    });
+  }
   refreshMockFinishedResult(apiState, seededGame, "2026-03-28T11:02:00.000Z");
 
   const page = await bootPage({
@@ -5306,16 +5357,22 @@ test("game page renders malformed goal identity values without crashing", async 
   const goal = page.document.querySelector('[data-ui="goal-event"][data-event-id="123"]');
   const fullGoalLog = page.document.querySelector('[data-testid="final-full-goal-log"]');
   const scorerStats = page.document.querySelector('[data-testid="final-scorer-stats"]');
+  const assistStats = page.document.querySelector('[data-testid="final-assist-stats"]');
   assert(goal instanceof page.window.HTMLElement);
   assert(fullGoalLog instanceof page.window.HTMLElement);
   assert(scorerStats instanceof page.window.HTMLElement);
-  assert.match(goal.textContent ?? "", /99\s*red\s*→\s*42/);
-  assert.match(goal.textContent ?? "", /Assists: 17/);
+  assert(assistStats instanceof page.window.HTMLElement);
+  assert.match(goal.textContent ?? "", /Unknown player \(invalid ID: 99\)\s*red\s*→\s*42/);
+  assert.match(goal.textContent ?? "", /Assists: Unknown player \(invalid ID: 17\)/);
   assert(goal.querySelector('[data-ui="goal-team-chip"][data-team-id="red"]'));
   assert(goal.querySelector('[data-ui="goal-team-chip"][data-team-id="42"]'));
   assert.doesNotMatch(goal.innerHTML, /undefined|null/);
-  assert.match(fullGoalLog.textContent ?? "", /99/);
-  assert.match(scorerStats.textContent ?? "", /99\s*1/);
+  assert.match(fullGoalLog.textContent ?? "", /Unknown player \(invalid ID: 99\)/);
+  assert.match(scorerStats.textContent ?? "", /Valid 99\s*2/);
+  assert.match(scorerStats.textContent ?? "", /Unknown player \(invalid ID: 99\)\s*1/);
+  assert.doesNotMatch(scorerStats.textContent ?? "", /Valid 99\s*3/);
+  assert.match(assistStats.textContent ?? "", /Valid 17\s*2/);
+  assert.match(assistStats.textContent ?? "", /Unknown player \(invalid ID: 17\)\s*1/);
   assert.doesNotMatch(fullGoalLog.innerHTML, /undefined|null/);
 });
 
@@ -5453,9 +5510,17 @@ test("game page runs live goal scoring, corrections, undo, and delete", async ()
   assert.equal(assistsElement.querySelectorAll('input[type="checkbox"]:checked').length, 0);
   const firstGoal = timeline.querySelector('[data-ui="goal-event"][data-event-id="goal-1"]');
   assert(firstGoal instanceof gamePage.window.HTMLElement);
-  assert(firstGoal.querySelector('[data-ui="goal-team-chip"][data-team-id="red"]'));
+  assert(
+    firstGoal.querySelector(
+      '[data-ui="goal-team-chip"][role="img"][data-team-id="red"][aria-label="Scoring team: Red"]',
+    ),
+  );
   assert(firstGoal.querySelector('[data-ui="goal-team-arrow"]'));
-  assert(firstGoal.querySelector('[data-ui="goal-team-chip"][data-team-id="blue"]'));
+  assert(
+    firstGoal.querySelector(
+      '[data-ui="goal-team-chip"][role="img"][data-team-id="blue"][aria-label="Conceding team: Blue"]',
+    ),
+  );
   assert(firstGoal.querySelector('[data-ui="third-indicator"][data-third="1"][aria-label="Third 1 of 3"]'));
   assert(firstGoal.querySelector('[data-action="edit-goal"] [data-icon="pencil"]'));
   assert(firstGoal.querySelector('[data-action="delete-goal"] [data-icon="trash-2"]'));
@@ -5508,7 +5573,11 @@ test("game page runs live goal scoring, corrections, undo, and delete", async ()
   assert(ownGoalEvent instanceof gamePage.window.HTMLElement);
   assert(ownGoalEvent.querySelector('[data-ui="own-goal-marker"][aria-label="Own goal"]'));
   assert.equal(ownGoalEvent.querySelectorAll('[data-ui="goal-team-chip"]').length, 1);
-  assert(ownGoalEvent.querySelector('[data-ui="goal-team-chip"][data-team-id="blue"]'));
+  assert(
+    ownGoalEvent.querySelector(
+      '[data-ui="goal-team-chip"][role="img"][data-team-id="blue"][aria-label="Conceding team: Blue"]',
+    ),
+  );
 
   ownGoalInput.checked = false;
   ownGoalInput.dispatchEvent(new gamePage.window.Event("change", { bubbles: true }));
@@ -6003,6 +6072,127 @@ test("game page allows admins to correct finished goals and refresh result", asy
   assert.equal(scoringTeamInput.value, "");
   assert.equal(concedingTeamInput.value, "");
   assert.equal(scorerInput.value, "");
+});
+
+test("game page serializes goal corrections through the finished-result refresh", async () => {
+  const apiState = createMockApiState();
+  const finishedThirds = createDefaultThirdTimerSegments().map((third) => ({
+    ...third,
+    startedAt: `2026-03-28T11:00:0${third.third}.000Z`,
+    finishedAt: `2026-03-28T11:00:1${third.third}.000Z`,
+  }));
+  seedGoalScoringGame(apiState, {
+    gameId: "game-correction-serialized",
+    status: "finished",
+    thirds: finishedThirds,
+    role: "admin",
+    sessionEmail: "admin@3fc.football",
+  });
+  const seededGame = apiState.games.get("game-correction-serialized");
+  assert(seededGame);
+  refreshMockFinishedResult(apiState, seededGame, "2026-03-28T11:00:12.000Z");
+
+  const defaultFetch = createMockFetch(apiState);
+  let goalMutationRequests = 0;
+  let goalCommitted = false;
+  let resolveFinishedGameRefresh: ((response: Response) => void) | undefined;
+  const serializedFetch: ReturnType<typeof createMockFetch> = async (input, init = {}) => {
+    const target =
+      typeof input === "string" || input instanceof URL
+        ? new URL(String(input))
+        : new URL(input.url);
+    const method = (init.method ?? "GET").toUpperCase();
+    const isGoalMutation = method !== "GET" && target.pathname.includes("/goals");
+    if (isGoalMutation) {
+      goalMutationRequests += 1;
+    }
+
+    if (method === "POST" && target.pathname === "/v1/games/game-correction-serialized/goals") {
+      const response = await defaultFetch(input, init);
+      goalCommitted = true;
+      return response;
+    }
+
+    if (
+      goalCommitted &&
+      method === "GET" &&
+      target.pathname === "/v1/games/game-correction-serialized"
+    ) {
+      return new Promise<Response>((resolve) => {
+        resolveFinishedGameRefresh = resolve;
+      });
+    }
+
+    return defaultFetch(input, init);
+  };
+
+  const page = await bootPage({
+    html: renderGamePage("http://localhost:3001", { gameId: "game-correction-serialized" }),
+    url: "http://localhost:3000/games/game-correction-serialized",
+    scriptFile: "setup-flow.js",
+    apiState,
+    fetch: serializedFetch,
+  });
+
+  const scoringTeamInput = page.document.getElementById("goal-scoring-team");
+  const concedingTeamInput = page.document.getElementById("goal-conceding-team");
+  const scorerInput = page.document.getElementById("goal-scorer");
+  const saveGoalButton = page.document.querySelector('[data-action="save-goal"]');
+  assert(scoringTeamInput instanceof page.window.HTMLSelectElement);
+  assert(concedingTeamInput instanceof page.window.HTMLSelectElement);
+  assert(scorerInput instanceof page.window.HTMLSelectElement);
+  assert(saveGoalButton instanceof page.window.HTMLButtonElement);
+
+  scoringTeamInput.value = "red";
+  scoringTeamInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+  concedingTeamInput.value = "blue";
+  concedingTeamInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+  scorerInput.value = "player-ari";
+  scorerInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+  dispatchClick(saveGoalButton);
+  await flushAsync();
+
+  assert.equal(goalMutationRequests, 1);
+  assert(resolveFinishedGameRefresh);
+  assert.equal(scoringTeamInput.disabled, true);
+  assert.equal(concedingTeamInput.disabled, true);
+  assert.equal(scorerInput.disabled, true);
+  assert.equal(saveGoalButton.disabled, true);
+  assert.match(page.document.getElementById("goal-form-note")?.textContent ?? "", /Saving goal change/);
+
+  const pendingUndo = page.document.querySelector('[data-action="undo-last-goal"]');
+  const pendingEdit = page.document.querySelector('[data-action="edit-goal"][data-event-id="goal-1"]');
+  const pendingDelete = page.document.querySelector('[data-action="delete-goal"][data-event-id="goal-1"]');
+  assert(pendingUndo instanceof page.window.HTMLButtonElement);
+  assert(pendingEdit instanceof page.window.HTMLButtonElement);
+  assert(pendingDelete instanceof page.window.HTMLButtonElement);
+  assert.equal(pendingUndo.disabled, true);
+  assert.equal(pendingEdit.disabled, true);
+  assert.equal(pendingDelete.disabled, true);
+
+  dispatchClick(pendingUndo);
+  dispatchClick(pendingEdit);
+  dispatchClick(pendingDelete);
+  await flushAsync();
+  assert.equal(goalMutationRequests, 1);
+  assert.equal(page.document.querySelector('[data-action="cancel-goal-edit"]')?.hasAttribute("hidden"), true);
+
+  const refreshedGame = apiState.games.get("game-correction-serialized");
+  assert(refreshedGame);
+  resolveFinishedGameRefresh(createJsonResponse(200, refreshedGame));
+  await flushAsync();
+
+  const restoredUndo = page.document.querySelector('[data-action="undo-last-goal"]');
+  const restoredEdit = page.document.querySelector('[data-action="edit-goal"][data-event-id="goal-1"]');
+  const restoredDelete = page.document.querySelector('[data-action="delete-goal"][data-event-id="goal-1"]');
+  assert(restoredUndo instanceof page.window.HTMLButtonElement);
+  assert(restoredEdit instanceof page.window.HTMLButtonElement);
+  assert(restoredDelete instanceof page.window.HTMLButtonElement);
+  assert.equal(scoringTeamInput.disabled, false);
+  assert.equal(restoredUndo.disabled, false);
+  assert.equal(restoredEdit.disabled, false);
+  assert.equal(restoredDelete.disabled, false);
+  assert.equal(page.document.getElementById("setup-status")?.textContent, "Goal added.");
 });
 
 test("game page clears a committed finished-goal draft when result refresh fails", async () => {

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -3278,6 +3278,8 @@ test("game page quick-creates and assigns roster players", async () => {
   const quickCreateButton = gamePage.document.querySelector('[data-action="quick-create-player"]');
   const playerPool = gamePage.document.getElementById("player-pool");
   const rosterTeams = gamePage.document.getElementById("roster-teams");
+  const scoringTeamInput = gamePage.document.getElementById("goal-scoring-team");
+  const concedingTeamInput = gamePage.document.getElementById("goal-conceding-team");
   const scorerInput = gamePage.document.getElementById("goal-scorer");
   const saveGoalButton = gamePage.document.querySelector('[data-action="save-goal"]');
   const goalFormNote = gamePage.document.getElementById("goal-form-note");
@@ -3292,6 +3294,8 @@ test("game page quick-creates and assigns roster players", async () => {
   assert(quickCreateButton instanceof gamePage.window.HTMLButtonElement);
   assert(playerPool instanceof gamePage.window.HTMLElement);
   assert(rosterTeams instanceof gamePage.window.HTMLElement);
+  assert(scoringTeamInput instanceof gamePage.window.HTMLSelectElement);
+  assert(concedingTeamInput instanceof gamePage.window.HTMLSelectElement);
   assert(scorerInput instanceof gamePage.window.HTMLSelectElement);
   assert(saveGoalButton instanceof gamePage.window.HTMLButtonElement);
   assert(goalFormNote instanceof gamePage.window.HTMLElement);
@@ -3351,10 +3355,14 @@ test("game page quick-creates and assigns roster players", async () => {
   assert.equal(activeRedChip.getAttribute("aria-pressed"), "true");
   assert.match(activeRedChip.getAttribute("style") ?? "", /--team-color: #d83b36/);
   assert(activeRedChip.querySelector('[data-icon="circle-check"]'));
-  assert.equal(scorerInput.value, createdPlayer.playerId);
-  assert.match(scorerInput.textContent ?? "", /Ari/);
+  assert.equal(scoringTeamInput.value, "");
+  assert.equal(concedingTeamInput.value, "");
+  assert.equal(concedingTeamInput.disabled, true);
+  assert.equal(scorerInput.value, "");
+  assert.equal(scorerInput.disabled, true);
+  assert.equal(scorerInput.textContent, "Assign players first");
   assert.equal(saveGoalButton.disabled, true);
-  assert.match(goalFormNote.textContent ?? "", /Start a third/);
+  assert.match(goalFormNote.textContent ?? "", /Choose a scoring team/);
 
   const redRoster = rosterTeams.querySelector('[data-ui="roster-team"][data-team-id="red"]');
   let transferButton = redRoster?.querySelector(
@@ -3411,6 +3419,12 @@ test("game page quick-creates and assigns roster players", async () => {
   await flushAsync();
   assert.equal(apiState.roster.get(`game-1:${createdPlayer.playerId}`)?.teamId, "red");
 
+  scoringTeamInput.value = "red";
+  scoringTeamInput.dispatchEvent(new gamePage.window.Event("change", { bubbles: true }));
+  concedingTeamInput.value = "blue";
+  concedingTeamInput.dispatchEvent(new gamePage.window.Event("change", { bubbles: true }));
+  scorerInput.value = createdPlayer.playerId;
+  scorerInput.dispatchEvent(new gamePage.window.Event("change", { bubbles: true }));
   dispatchClick(startThirdButton);
   await flushAsync();
   assert.equal(apiState.games.get("game-1")?.thirds[1].startedAt, "2026-03-28T11:00:10.000Z");
@@ -3876,7 +3890,7 @@ test("game page mode panels advance from setup to run and finalisation", async (
   const finishGameButton = page.document.querySelector('[data-action="finish-game"]');
   const timerDisplay = page.document.getElementById("timer-display");
   const resultSummary = page.document.getElementById("game-result-summary");
-  const finalReadiness = page.document.getElementById("final-game-readiness");
+  const finalStatus = page.document.getElementById("final-game-status");
   const thirdStatusList = page.document.getElementById("third-status-list");
 
   assert(structureMode instanceof page.window.HTMLElement);
@@ -3891,7 +3905,7 @@ test("game page mode panels advance from setup to run and finalisation", async (
   assert(finishGameButton instanceof page.window.HTMLButtonElement);
   assert(timerDisplay instanceof page.window.HTMLElement);
   assert(resultSummary instanceof page.window.HTMLElement);
-  assert(finalReadiness instanceof page.window.HTMLElement);
+  assert(finalStatus instanceof page.window.HTMLElement);
   assert(thirdStatusList instanceof page.window.HTMLElement);
   assert.equal(structureMode.hidden, false);
   assert.equal(playersMode.hidden, true);
@@ -3921,7 +3935,7 @@ test("game page mode panels advance from setup to run and finalisation", async (
   dispatchClick(startThirdButton);
   await flushAsync();
   assert.equal(runMode.hidden, false);
-  assert.match(finalReadiness.textContent ?? "", /Running/);
+  assert.equal(finalStatus.textContent, "Live");
   assert.match(gameStateTab.textContent ?? "", /Third 1/);
   assert.equal(gameStateTab.getAttribute("data-game-state"), "running");
 
@@ -3953,7 +3967,7 @@ test("game page mode panels advance from setup to run and finalisation", async (
   await flushAsync();
 
   assert.equal(finalMode.hidden, false);
-  assert.match(finalReadiness.textContent ?? "", /Ready to finish/);
+  assert.equal(finalStatus.textContent, "Live");
   assert.match(gameStateTab.textContent ?? "", /Final/);
   assert.match(gameStateTab.textContent ?? "", /Finish game/);
   assert.equal(gameStateTab.getAttribute("data-game-state"), "ready");
@@ -4132,16 +4146,18 @@ test("game page resumes completed live timers in finalisation mode", async () =>
   const runMode = page.document.getElementById("game-mode-run");
   const finalMode = page.document.getElementById("game-mode-final");
   const finishGameButton = page.document.querySelector('[data-action="finish-game"]');
-  const finalReadiness = page.document.getElementById("final-game-readiness");
+  const finalStatus = page.document.getElementById("final-game-status");
 
   assert(runMode instanceof page.window.HTMLElement);
   assert(finalMode instanceof page.window.HTMLElement);
   assert(finishGameButton instanceof page.window.HTMLButtonElement);
-  assert(finalReadiness instanceof page.window.HTMLElement);
+  assert(finalStatus instanceof page.window.HTMLElement);
   assert.equal(runMode.hidden, true);
   assert.equal(finalMode.hidden, false);
   assert.equal(finishGameButton.disabled, false);
-  assert.match(finalReadiness.textContent ?? "", /Ready to finish/);
+  assert.equal(finalStatus.textContent, "Live");
+  assert.equal(page.document.getElementById("final-game-id-value"), null);
+  assert.equal(page.document.getElementById("final-game-readiness"), null);
 });
 
 test("game page renders final team logs and aggregate player stats", async () => {
@@ -4195,7 +4211,7 @@ test("game page renders final team logs and aggregate player stats", async () =>
     {
       gameId: "game-final-stats",
       eventId: "goal-3",
-      third: 1,
+      third: 3,
       thirdMinute: 25,
       gameMinute: 25,
       elapsedSeconds: 1680,
@@ -4240,13 +4256,12 @@ test("game page renders final team logs and aggregate player stats", async () =>
   assert(ownGoalStats instanceof page.window.HTMLElement);
   assert(fullGoalLog instanceof page.window.HTMLElement);
   assert.equal(resultSummary.hidden, false);
-  assert.match(resultSummary.textContent ?? "", new RegExp(expectedLocalTimestamp("2026-03-28T11:02:00.000Z")));
-  assert.doesNotMatch(resultSummary.textContent ?? "", /Z\b|UTC/);
+  assert.doesNotMatch(resultSummary.textContent ?? "", /Computed|2026-03-28 22:02|Z\b|UTC/);
   assert.match(redTeamLog.textContent ?? "", /Ari/);
   assert.match(redTeamLog.textContent ?? "", /1"/);
   assert.match(redTeamLog.textContent ?? "", /Assisted by Bea/);
   assert.match(redTeamLog.textContent ?? "", /Bea own goal/);
-  assert.match(redTeamLog.textContent ?? "", /25\+3"/);
+  assert.match(redTeamLog.textContent ?? "", /75\+3"/);
   assert.match(redTeamLog.textContent ?? "", /Conceded-only own goal/);
   assert.match(scorerStats.textContent ?? "", /Ari\s*1/);
   assert.match(scorerStats.textContent ?? "", /Cy\s*1/);
@@ -4254,7 +4269,17 @@ test("game page renders final team logs and aggregate player stats", async () =>
   assert.match(ownGoalStats.textContent ?? "", /Bea\s*1/);
   assert.equal(fullGoalLog.querySelectorAll('[data-ui="final-goal-item"]').length, 3);
   assert.match(fullGoalLog.textContent ?? "", /43"/);
-  assert.match(fullGoalLog.textContent ?? "", /Third 2/);
+  assert.doesNotMatch(fullGoalLog.textContent ?? "", /Third [123]/);
+  assert.equal(fullGoalLog.querySelectorAll('[data-ui="third-indicator"]').length, 3);
+  assert(
+    fullGoalLog.querySelector('[data-ui="third-indicator"][data-third="2"][aria-label="Third 2 of 3"]'),
+  );
+  assert(
+    fullGoalLog.querySelector('[data-ui="third-indicator"][data-third="1"][aria-label="Third 1 of 3"]'),
+  );
+  assert(
+    fullGoalLog.querySelector('[data-ui="third-indicator"][data-third="3"][aria-label="Third 3 of 3"]'),
+  );
 });
 
 test("game page converts partial goal times into full-match football notation", async () => {
@@ -4294,7 +4319,7 @@ test("game page converts partial goal times into full-match football notation", 
   apiState.goalEvents.set("goal-partial-stoppage", {
     gameId: "game-football-time-format",
     eventId: "goal-partial-stoppage",
-    third: 1,
+    third: 3,
     thirdMinute: 25,
     gameMinute: 0,
     elapsedSeconds: 1680,
@@ -4319,14 +4344,22 @@ test("game page converts partial goal times into full-match football notation", 
 
   const resultSummary = page.document.getElementById("game-result-summary");
   const fullGoalLog = page.document.querySelector('[data-testid="final-full-goal-log"]');
+  const timeline = page.document.getElementById("goal-timeline");
 
   assert(resultSummary instanceof page.window.HTMLElement);
   assert(fullGoalLog instanceof page.window.HTMLElement);
+  assert(timeline instanceof page.window.HTMLElement);
   assert.equal(resultSummary.hidden, false);
   assert.match(resultSummary.textContent ?? "", /43"/);
-  assert.match(resultSummary.textContent ?? "", /25\+3"/);
+  assert.match(resultSummary.textContent ?? "", /75\+3"/);
   assert.match(fullGoalLog.textContent ?? "", /43"/);
-  assert.match(fullGoalLog.textContent ?? "", /25\+3"/);
+  assert.match(fullGoalLog.textContent ?? "", /75\+3"/);
+  const latestGoal = timeline.querySelector('[data-ui="goal-event"][data-state="latest"]');
+  assert(latestGoal instanceof page.window.HTMLElement);
+  assert.match(latestGoal.textContent ?? "", /75\+3"\s*Bea\s*OG\s*→\s*Red/);
+  assert.equal(latestGoal.querySelectorAll('[data-ui="goal-team-chip"]').length, 1);
+  assert(latestGoal.querySelector('[data-ui="goal-team-chip"][data-team-id="red"]'));
+  assert(latestGoal.querySelector('[data-ui="third-indicator"][data-third="3"][aria-label="Third 3 of 3"]'));
   assert.doesNotMatch(resultSummary.textContent ?? "", /18:00|25\+03|UTC|Z\b/);
 });
 
@@ -4513,10 +4546,18 @@ test("game page reuses create goal idempotency key for unchanged retry", async (
   concedingTeamInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
   scorerInput.value = "player-ari";
   scorerInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+  const beaAssist = page.document.querySelector('#goal-assists input[value="player-bea"]');
+  assert(beaAssist instanceof page.window.HTMLInputElement);
+  beaAssist.checked = true;
+  beaAssist.dispatchEvent(new page.window.Event("change", { bubbles: true }));
 
   dispatchClick(saveGoalButton);
   await flushAsync();
   assert.equal(apiState.goalEvents.size, 0);
+  assert.equal(scoringTeamInput.value, "red");
+  assert.equal(concedingTeamInput.value, "blue");
+  assert.equal(scorerInput.value, "player-ari");
+  assert.equal(page.document.querySelectorAll('#goal-assists input[type="checkbox"]:checked').length, 1);
 
   dispatchClick(saveGoalButton);
   await flushAsync();
@@ -4525,6 +4566,12 @@ test("game page reuses create goal idempotency key for unchanged retry", async (
   assert.equal(createGoalIdempotencyKeys.length, 2);
   assert.ok(createGoalIdempotencyKeys[0]);
   assert.equal(createGoalIdempotencyKeys[0], createGoalIdempotencyKeys[1]);
+  assert.equal(scoringTeamInput.value, "");
+  assert.equal(concedingTeamInput.value, "");
+  assert.equal(scorerInput.value, "");
+  assert.equal(concedingTeamInput.disabled, true);
+  assert.equal(scorerInput.disabled, true);
+  assert.equal(page.document.querySelectorAll('#goal-assists input[type="checkbox"]:checked').length, 0);
 });
 
 test("game page treats later created same-second goals as latest", async () => {
@@ -4702,21 +4749,37 @@ test("game page reuses correction idempotency keys for unchanged retries", async
 
   const saveGoalButton = page.document.querySelector('[data-action="save-goal"]');
   const undoLastGoalButton = page.document.querySelector('[data-action="undo-last-goal"]');
+  const ownGoalInput = page.document.getElementById("goal-own-goal");
+  const concedingTeamInput = page.document.getElementById("goal-conceding-team");
+  const scorerInput = page.document.getElementById("goal-scorer");
   assert(saveGoalButton instanceof page.window.HTMLButtonElement);
   assert(undoLastGoalButton instanceof page.window.HTMLButtonElement);
+  assert(ownGoalInput instanceof page.window.HTMLInputElement);
+  assert(concedingTeamInput instanceof page.window.HTMLSelectElement);
+  assert(scorerInput instanceof page.window.HTMLSelectElement);
 
   const editGoalButton = page.document.querySelector('[data-action="edit-goal"][data-event-id="goal-1"]');
   assert(editGoalButton instanceof page.window.HTMLButtonElement);
   dispatchClick(editGoalButton);
   await flushAsync();
+  ownGoalInput.checked = true;
+  ownGoalInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+  concedingTeamInput.value = "blue";
+  concedingTeamInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+  scorerInput.value = "player-cy";
+  scorerInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
   dispatchClick(saveGoalButton);
   await flushAsync();
+  assert.equal(ownGoalInput.checked, true);
+  assert.equal(concedingTeamInput.value, "blue");
+  assert.equal(scorerInput.value, "player-cy");
   dispatchClick(saveGoalButton);
   await flushAsync();
 
   assert.equal(updateKeys.length, 2);
   assert.ok(updateKeys[0]);
   assert.equal(updateKeys[0], updateKeys[1]);
+  assert.equal(apiState.goalEvents.get("goal-1")?.ownGoal, true);
 
   const deleteGoalButton = page.document.querySelector('[data-action="delete-goal"][data-event-id="goal-1"]');
   assert(deleteGoalButton instanceof page.window.HTMLButtonElement);
@@ -4876,7 +4939,9 @@ test("game page clears a historical scorer after changing the goal context", asy
   concedingTeamInput.value = "blue";
   concedingTeamInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
 
-  assert.equal(scorerSelect.value, "player-cy");
+  assert.equal(scorerSelect.value, "");
+  assert.equal(scorerSelect.disabled, false);
+  assert.match(scorerSelect.textContent ?? "", /Cy/);
   assert.doesNotMatch(scorerSelect.textContent ?? "", /Ari \(not currently rostered\)/);
 });
 
@@ -4984,7 +5049,7 @@ test("game page reconciles current goals after stale correction replay", async (
   await flushAsync();
 
   assert.equal(patchCalls, 2);
-  assert.match(timeline.textContent ?? "", /Cy for Blue/);
+  assert.match(timeline.textContent ?? "", /Cy\s*Blue\s*→\s*Red/);
 });
 
 test("game page invalidates current goals when correction replay refresh fails", async () => {
@@ -5079,12 +5144,18 @@ test("game page invalidates current goals when correction replay refresh fails",
   const undoLastGoalButton = page.document.querySelector('[data-action="undo-last-goal"]');
   const timeline = page.document.getElementById("goal-timeline");
   const status = page.document.getElementById("setup-status");
+  const scoringTeamInput = page.document.getElementById("goal-scoring-team");
+  const concedingTeamInput = page.document.getElementById("goal-conceding-team");
+  const scorerInput = page.document.getElementById("goal-scorer");
   assert(editGoalButton instanceof page.window.HTMLButtonElement);
   assert(saveGoalButton instanceof page.window.HTMLButtonElement);
   assert(undoLastGoalButton instanceof page.window.HTMLButtonElement);
   assert(timeline instanceof page.window.HTMLElement);
   assert(status instanceof page.window.HTMLElement);
-  assert.match(timeline.textContent ?? "", /Cy for Blue/);
+  assert(scoringTeamInput instanceof page.window.HTMLSelectElement);
+  assert(concedingTeamInput instanceof page.window.HTMLSelectElement);
+  assert(scorerInput instanceof page.window.HTMLSelectElement);
+  assert.match(timeline.textContent ?? "", /Cy\s*Blue\s*→\s*Red/);
 
   dispatchClick(editGoalButton);
   await flushAsync();
@@ -5092,9 +5163,12 @@ test("game page invalidates current goals when correction replay refresh fails",
   await flushAsync();
   await flushAsync();
 
-  assert.match(status.textContent ?? "", /Goal save failed/);
+  assert.match(status.textContent ?? "", /Goal updated; timeline refresh failed/);
   assert.match(timeline.textContent ?? "", /Goal timeline unavailable/);
-  assert.doesNotMatch(timeline.textContent ?? "", /Cy for Blue/);
+  assert.doesNotMatch(timeline.textContent ?? "", /Cy\s*Blue\s*→\s*Red/);
+  assert.equal(scoringTeamInput.value, "");
+  assert.equal(concedingTeamInput.value, "");
+  assert.equal(scorerInput.value, "");
   assert.equal(saveGoalButton.disabled, true);
   assert.equal(undoLastGoalButton.disabled, true);
 });
@@ -5183,6 +5257,66 @@ test("game page renders malformed result data without crashing", async () => {
     false,
   );
   assert.doesNotMatch(resultSummary.innerHTML, /javascript:/);
+});
+
+test("game page renders malformed goal identity values without crashing", async () => {
+  const apiState = createMockApiState();
+  const thirds = createDefaultThirdTimerSegments().map((third) => ({
+    ...third,
+    startedAt: `2026-03-28T11:00:0${third.third}.000Z`,
+    finishedAt: `2026-03-28T11:00:1${third.third}.000Z`,
+  }));
+  seedGoalScoringGame(apiState, {
+    gameId: "game-malformed-goal",
+    status: "finished",
+    thirds,
+  });
+  const seededGame = apiState.games.get("game-malformed-goal");
+  assert(seededGame);
+  ensureGameTeams(apiState, seededGame);
+  const malformedRedTeam = apiState.gameTeams.get("game-malformed-goal:red");
+  assert(malformedRedTeam);
+  malformedRedTeam.name = 123 as unknown as string;
+  apiState.goalEvents.set("malformed-goal", {
+    gameId: "game-malformed-goal",
+    eventId: 123,
+    third: 1,
+    thirdMinute: 1,
+    gameMinute: 1,
+    elapsedSeconds: 30,
+    stoppageMinute: null,
+    displayTime: "1'",
+    scoringTeamId: "red",
+    concedingTeamId: 42,
+    scorerPlayerId: 99,
+    assistPlayerIds: [17],
+    ownGoal: false,
+    createdAt: "2026-03-28T11:01:01.000Z",
+    updatedAt: "2026-03-28T11:01:01.000Z",
+  } as unknown as MockGoalEvent);
+  refreshMockFinishedResult(apiState, seededGame, "2026-03-28T11:02:00.000Z");
+
+  const page = await bootPage({
+    html: renderGamePage("http://localhost:3001", { gameId: "game-malformed-goal" }),
+    url: "http://localhost:3000/games/game-malformed-goal",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+
+  const goal = page.document.querySelector('[data-ui="goal-event"][data-event-id="123"]');
+  const fullGoalLog = page.document.querySelector('[data-testid="final-full-goal-log"]');
+  const scorerStats = page.document.querySelector('[data-testid="final-scorer-stats"]');
+  assert(goal instanceof page.window.HTMLElement);
+  assert(fullGoalLog instanceof page.window.HTMLElement);
+  assert(scorerStats instanceof page.window.HTMLElement);
+  assert.match(goal.textContent ?? "", /99\s*red\s*→\s*42/);
+  assert.match(goal.textContent ?? "", /Assists: 17/);
+  assert(goal.querySelector('[data-ui="goal-team-chip"][data-team-id="red"]'));
+  assert(goal.querySelector('[data-ui="goal-team-chip"][data-team-id="42"]'));
+  assert.doesNotMatch(goal.innerHTML, /undefined|null/);
+  assert.match(fullGoalLog.textContent ?? "", /99/);
+  assert.match(scorerStats.textContent ?? "", /99\s*1/);
+  assert.doesNotMatch(fullGoalLog.innerHTML, /undefined|null/);
 });
 
 test("game page runs live goal scoring, corrections, undo, and delete", async () => {
@@ -5281,6 +5415,12 @@ test("game page runs live goal scoring, corrections, undo, and delete", async ()
   assert.match(scoreboard.textContent ?? "", /Red/);
   assert.match(timeline.textContent ?? "", /No goals yet/);
   assert.equal(undoLastGoalButton.disabled, true);
+  for (const scoreTeam of scoreboard.querySelectorAll('[data-ui="score-team"]')) {
+    assert.deepEqual(
+      [...scoreTeam.querySelectorAll("dt")].map((term) => term.textContent),
+      ["Conceded", "Scored"],
+    );
+  }
 
   dispatchClick(startThirdButton);
   await flushAsync();
@@ -5301,9 +5441,25 @@ test("game page runs live goal scoring, corrections, undo, and delete", async ()
   assert.equal(apiState.goalEvents.get("goal-1")?.scoringTeamId, "red");
   assert.match(scoreboard.querySelector('[data-team-id="red"]')?.textContent ?? "", /Scored\s*1/);
   assert.match(scoreboard.querySelector('[data-team-id="blue"]')?.textContent ?? "", /Conceded\s*1/);
-  assert.match(timeline.textContent ?? "", /Ari for Red/);
+  assert.match(timeline.textContent ?? "", /Ari\s*Red\s*→\s*Blue/);
   assert.match(timeline.textContent ?? "", /Assists: Bea/);
   assert.equal(undoLastGoalButton.disabled, false);
+  assert.equal(scoringTeamInput.value, "");
+  assert.equal(concedingTeamInput.value, "");
+  assert.equal(scorerInput.value, "");
+  assert.equal(ownGoalInput.checked, false);
+  assert.equal(concedingTeamInput.disabled, true);
+  assert.equal(scorerInput.disabled, true);
+  assert.equal(assistsElement.querySelectorAll('input[type="checkbox"]:checked').length, 0);
+  const firstGoal = timeline.querySelector('[data-ui="goal-event"][data-event-id="goal-1"]');
+  assert(firstGoal instanceof gamePage.window.HTMLElement);
+  assert(firstGoal.querySelector('[data-ui="goal-team-chip"][data-team-id="red"]'));
+  assert(firstGoal.querySelector('[data-ui="goal-team-arrow"]'));
+  assert(firstGoal.querySelector('[data-ui="goal-team-chip"][data-team-id="blue"]'));
+  assert(firstGoal.querySelector('[data-ui="third-indicator"][data-third="1"][aria-label="Third 1 of 3"]'));
+  assert(firstGoal.querySelector('[data-action="edit-goal"] [data-icon="pencil"]'));
+  assert(firstGoal.querySelector('[data-action="delete-goal"] [data-icon="trash-2"]'));
+  assert.doesNotMatch(firstGoal.textContent ?? "", /Latest/);
 
   const refreshedPage = await bootPage({
     html: renderGamePage("http://localhost:3001", { gameId: "game-live-1" }),
@@ -5321,12 +5477,14 @@ test("game page runs live goal scoring, corrections, undo, and delete", async ()
   assert(refreshedEditButton instanceof refreshedPage.window.HTMLButtonElement);
   assert.match(refreshedScoreboard.querySelector('[data-team-id="red"]')?.textContent ?? "", /Scored\s*1/);
   assert.match(refreshedScoreboard.querySelector('[data-team-id="blue"]')?.textContent ?? "", /Conceded\s*1/);
-  assert.match(refreshedTimeline.textContent ?? "", /Ari for Red/);
+  assert.match(refreshedTimeline.textContent ?? "", /Ari\s*Red\s*→\s*Blue/);
   assert.equal(refreshedUndoButton.disabled, false);
 
   const editGoalButton = gamePage.document.querySelector('[data-action="edit-goal"][data-event-id="goal-1"]');
   assert(editGoalButton instanceof gamePage.window.HTMLButtonElement);
-  dispatchClick(editGoalButton);
+  const editGoalIcon = editGoalButton.querySelector('[data-icon="pencil"]');
+  assert(editGoalIcon instanceof gamePage.window.HTMLElement);
+  dispatchClick(editGoalIcon);
   await flushAsync();
   ownGoalInput.checked = true;
   ownGoalInput.dispatchEvent(new gamePage.window.Event("change", { bubbles: true }));
@@ -5341,7 +5499,16 @@ test("game page runs live goal scoring, corrections, undo, and delete", async ()
   assert.equal(apiState.goalEvents.get("goal-1")?.scoringTeamId, null);
   assert.match(scoreboard.querySelector('[data-team-id="red"]')?.textContent ?? "", /Scored\s*0/);
   assert.match(scoreboard.querySelector('[data-team-id="blue"]')?.textContent ?? "", /Conceded\s*1/);
-  assert.match(timeline.textContent ?? "", /Cy own goal against Blue/);
+  assert.match(timeline.textContent ?? "", /Cy\s*OG\s*→\s*Blue/);
+  assert.equal(scoringTeamInput.value, "");
+  assert.equal(concedingTeamInput.value, "");
+  assert.equal(scorerInput.value, "");
+  assert.equal(ownGoalInput.checked, false);
+  const ownGoalEvent = timeline.querySelector('[data-ui="goal-event"][data-event-id="goal-1"]');
+  assert(ownGoalEvent instanceof gamePage.window.HTMLElement);
+  assert(ownGoalEvent.querySelector('[data-ui="own-goal-marker"][aria-label="Own goal"]'));
+  assert.equal(ownGoalEvent.querySelectorAll('[data-ui="goal-team-chip"]').length, 1);
+  assert(ownGoalEvent.querySelector('[data-ui="goal-team-chip"][data-team-id="blue"]'));
 
   ownGoalInput.checked = false;
   ownGoalInput.dispatchEvent(new gamePage.window.Event("change", { bubbles: true }));
@@ -5355,7 +5522,7 @@ test("game page runs live goal scoring, corrections, undo, and delete", async ()
   await flushAsync();
 
   assert.equal(apiState.goalEvents.size, 2);
-  assert.match(timeline.textContent ?? "", /Cy for Blue/);
+  assert.match(timeline.textContent ?? "", /Cy\s*Blue\s*→\s*Red/);
 
   const deleteGoalButton = gamePage.document.querySelector('[data-action="delete-goal"][data-event-id="goal-1"]');
   assert(deleteGoalButton instanceof gamePage.window.HTMLButtonElement);
@@ -5363,7 +5530,7 @@ test("game page runs live goal scoring, corrections, undo, and delete", async ()
   await flushAsync();
   assert.equal(apiState.goalEvents.has("goal-1"), false);
   assert.equal(apiState.goalEvents.has("goal-2"), true);
-  assert.match(timeline.textContent ?? "", /Cy for Blue/);
+  assert.match(timeline.textContent ?? "", /Cy\s*Blue\s*→\s*Red/);
   assert.match(scoreboard.querySelector('[data-team-id="blue"]')?.textContent ?? "", /Scored\s*1/);
   assert.match(scoreboard.querySelector('[data-team-id="red"]')?.textContent ?? "", /Conceded\s*1/);
 
@@ -5824,7 +5991,8 @@ test("game page allows admins to correct finished goals and refresh result", asy
   scorerInput.value = dee.playerId;
   scorerInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
   assert.equal(saveGoalButton.disabled, false);
-  assert.match(goalFormNote.textContent ?? "", /final whistle/);
+  assert.match(goalFormNote.textContent ?? "", /correct the finished result/);
+  assert.doesNotMatch(goalFormNote.textContent ?? "", /final whistle/);
   dispatchClick(saveGoalButton);
   await flushAsync();
 
@@ -5832,6 +6000,102 @@ test("game page allows admins to correct finished goals and refresh result", asy
   assert.equal([...apiState.goalEvents.values()][0]?.scorerPlayerId, dee.playerId);
   assert.equal(apiState.games.get("game-admin-finished-correction")?.result?.winnerTeamId, "red");
   assert.match(resultSummary.textContent ?? "", /Red win/);
+  assert.equal(scoringTeamInput.value, "");
+  assert.equal(concedingTeamInput.value, "");
+  assert.equal(scorerInput.value, "");
+});
+
+test("game page clears a committed finished-goal draft when result refresh fails", async () => {
+  const apiState = createMockApiState();
+  const finishedThirds = createDefaultThirdTimerSegments().map((third) => ({
+    ...third,
+    startedAt: `2026-03-28T11:00:0${third.third}.000Z`,
+    finishedAt: `2026-03-28T11:00:1${third.third}.000Z`,
+  }));
+  seedGoalScoringGame(apiState, {
+    gameId: "game-create-refresh-fail",
+    status: "finished",
+    thirds: finishedThirds,
+    role: "admin",
+    sessionEmail: "admin@3fc.football",
+  });
+  const seededGame = apiState.games.get("game-create-refresh-fail");
+  assert(seededGame);
+  refreshMockFinishedResult(apiState, seededGame, "2026-03-28T11:00:12.000Z");
+
+  const defaultFetch = createMockFetch(apiState);
+  let failNextGameRefresh = false;
+  const staleResultFetch: ReturnType<typeof createMockFetch> = async (input, init = {}) => {
+    const target =
+      typeof input === "string" || input instanceof URL
+        ? new URL(String(input))
+        : new URL(input.url);
+    const method = (init.method ?? "GET").toUpperCase();
+
+    if (method === "POST" && target.pathname === "/v1/games/game-create-refresh-fail/goals") {
+      const response = await defaultFetch(input, init);
+      failNextGameRefresh = true;
+      return response;
+    }
+
+    if (method === "GET" && target.pathname === "/v1/games/game-create-refresh-fail" && failNextGameRefresh) {
+      failNextGameRefresh = false;
+      return createJsonResponse(503, {
+        error: "unavailable",
+        message: "Game refresh unavailable.",
+      });
+    }
+
+    return defaultFetch(input, init);
+  };
+
+  const page = await bootPage({
+    html: renderGamePage("http://localhost:3001", { gameId: "game-create-refresh-fail" }),
+    url: "http://localhost:3000/games/game-create-refresh-fail",
+    scriptFile: "setup-flow.js",
+    apiState,
+    fetch: staleResultFetch,
+  });
+
+  const scoringTeamInput = page.document.getElementById("goal-scoring-team");
+  const concedingTeamInput = page.document.getElementById("goal-conceding-team");
+  const scorerInput = page.document.getElementById("goal-scorer");
+  const ownGoalInput = page.document.getElementById("goal-own-goal");
+  const saveGoalButton = page.document.querySelector('[data-action="save-goal"]');
+  const status = page.document.getElementById("setup-status");
+  const error = page.document.getElementById("setup-error");
+  const resultSummary = page.document.getElementById("game-result-summary");
+  assert(scoringTeamInput instanceof page.window.HTMLSelectElement);
+  assert(concedingTeamInput instanceof page.window.HTMLSelectElement);
+  assert(scorerInput instanceof page.window.HTMLSelectElement);
+  assert(ownGoalInput instanceof page.window.HTMLInputElement);
+  assert(saveGoalButton instanceof page.window.HTMLButtonElement);
+  assert(status instanceof page.window.HTMLElement);
+  assert(error instanceof page.window.HTMLElement);
+  assert(resultSummary instanceof page.window.HTMLElement);
+
+  scoringTeamInput.value = "red";
+  scoringTeamInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+  concedingTeamInput.value = "blue";
+  concedingTeamInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+  scorerInput.value = "player-ari";
+  scorerInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+  dispatchClick(saveGoalButton);
+  await flushAsync();
+
+  assert.equal(apiState.goalEvents.size, 1);
+  assert.match(status.textContent ?? "", /Goal added; result refresh failed/);
+  assert.match(error.textContent ?? "", /finished result could not be refreshed/);
+  assert.equal(resultSummary.hidden, false);
+  assert.match(resultSummary.textContent ?? "", /Result refresh required/);
+  assert.match(resultSummary.textContent ?? "", /goal change was saved/);
+  assert.equal(resultSummary.querySelector('[data-testid="game-result-outcome"]'), null);
+  assert.equal(scoringTeamInput.value, "");
+  assert.equal(concedingTeamInput.value, "");
+  assert.equal(scorerInput.value, "");
+  assert.equal(ownGoalInput.checked, false);
+  assert.equal(concedingTeamInput.disabled, true);
+  assert.equal(scorerInput.disabled, true);
 });
 
 test("game page treats committed undo as success when finished result refresh fails", async () => {
@@ -5924,10 +6188,12 @@ test("game page treats committed undo as success when finished result refresh fa
   const timeline = page.document.getElementById("goal-timeline");
   const status = page.document.getElementById("setup-status");
   const error = page.document.getElementById("setup-error");
+  const resultSummary = page.document.getElementById("game-result-summary");
   assert(undoLastGoalButton instanceof page.window.HTMLButtonElement);
   assert(timeline instanceof page.window.HTMLElement);
   assert(status instanceof page.window.HTMLElement);
   assert(error instanceof page.window.HTMLElement);
+  assert(resultSummary instanceof page.window.HTMLElement);
 
   dispatchClick(undoLastGoalButton);
   await flushAsync();
@@ -5935,10 +6201,12 @@ test("game page treats committed undo as success when finished result refresh fa
   assert.equal(apiState.goalEvents.has("goal-2"), false);
   assert.equal(apiState.goalEvents.has("goal-1"), true);
   assert.equal(apiState.games.get("game-undo-refresh-fail")?.result?.winnerTeamId, "red");
-  assert.match(timeline.textContent ?? "", /Ari for Red/);
-  assert.doesNotMatch(timeline.textContent ?? "", /Cy for Blue/);
+  assert.match(timeline.textContent ?? "", /Ari\s*Red\s*→\s*Blue/);
+  assert.doesNotMatch(timeline.textContent ?? "", /Cy\s*Blue\s*→\s*Red/);
   assert.match(status.textContent ?? "", /Latest goal undone; result refresh failed/);
   assert.match(error.textContent ?? "", /finished result could not be refreshed/);
+  assert.match(resultSummary.textContent ?? "", /Result refresh required/);
+  assert.doesNotMatch(resultSummary.textContent ?? "", /Red win|Blue win|Draw/);
 });
 
 test("setup flow resolves route ids from static shells", async () => {

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -4612,6 +4612,491 @@ test("game page reuses create goal idempotency key for unchanged retry", async (
   assert.equal(concedingTeamInput.disabled, true);
   assert.equal(scorerInput.disabled, true);
   assert.equal(page.document.querySelectorAll('#goal-assists input[type="checkbox"]:checked').length, 0);
+
+  scoringTeamInput.value = "red";
+  scoringTeamInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+  concedingTeamInput.value = "blue";
+  concedingTeamInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+  scorerInput.value = "player-ari";
+  scorerInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+  const repeatedBeaAssist = page.document.querySelector('#goal-assists input[value="player-bea"]');
+  assert(repeatedBeaAssist instanceof page.window.HTMLInputElement);
+  repeatedBeaAssist.checked = true;
+  repeatedBeaAssist.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+  dispatchClick(saveGoalButton);
+  await flushAsync();
+
+  assert.equal(apiState.goalEvents.size, 2);
+  assert.equal(createGoalIdempotencyKeys.length, 3);
+  assert.ok(createGoalIdempotencyKeys[2]);
+  assert.notEqual(createGoalIdempotencyKeys[1], createGoalIdempotencyKeys[2]);
+});
+
+test("game page reconciles authoritative goals after replayed create, delete, and undo responses", async () => {
+  const apiState = createMockApiState();
+  const thirds = createDefaultThirdTimerSegments();
+  thirds[0] = {
+    ...thirds[0],
+    startedAt: "2026-03-28T11:00:10.000Z",
+  };
+  seedGoalScoringGame(apiState, {
+    gameId: "game-goal-replay-reconcile",
+    status: "live",
+    thirds,
+  });
+
+  const defaultFetch = createMockFetch(apiState);
+  const createKeys: Array<string | null> = [];
+  const deleteKeys: Array<string | null> = [];
+  const undoKeys: Array<string | null> = [];
+  let createAttempts = 0;
+  let deleteAttempts = 0;
+  let undoAttempts = 0;
+  let authoritativeGoalGets = 0;
+  let createReplay: unknown = null;
+  let deleteReplay: unknown = null;
+  let undoReplay: unknown = null;
+
+  const externalGoal = (
+    eventId: string,
+    createdAt: string,
+    scoringTeamId: TeamId,
+    concedingTeamId: TeamId,
+    scorerPlayerId: string,
+  ): MockGoalEvent => ({
+    gameId: "game-goal-replay-reconcile",
+    eventId,
+    third: 1,
+    thirdMinute: 1,
+    gameMinute: 1,
+    elapsedSeconds: 45,
+    stoppageMinute: null,
+    displayTime: "1'",
+    scoringTeamId,
+    concedingTeamId,
+    scorerPlayerId,
+    assistPlayerIds: [],
+    ownGoal: false,
+    createdAt,
+    updatedAt: createdAt,
+  });
+
+  const replayingFetch: ReturnType<typeof createMockFetch> = async (input, init = {}) => {
+    const target =
+      typeof input === "string" || input instanceof URL
+        ? new URL(String(input))
+        : new URL(input.url);
+    const method = (init.method ?? "GET").toUpperCase();
+    const goalsPath = "/v1/games/game-goal-replay-reconcile/goals";
+
+    if (method === "POST" && target.pathname === goalsPath) {
+      createAttempts += 1;
+      createKeys.push(readInitHeader(init, "idempotency-key"));
+      if (createAttempts === 1) {
+        const committed = await defaultFetch(input, init);
+        createReplay = await committed.json();
+        apiState.goalEvents.set(
+          "goal-external-create",
+          externalGoal(
+            "goal-external-create",
+            "2026-03-28T11:01:02.000Z",
+            "blue",
+            "red",
+            "player-cy",
+          ),
+        );
+        return createJsonResponse(503, {
+          error: "response_lost",
+          message: "Goal response was lost after commit.",
+        });
+      }
+      return createJsonResponse(201, createReplay);
+    }
+
+    if (
+      method === "DELETE" &&
+      target.pathname === "/v1/games/game-goal-replay-reconcile/goals/goal-1"
+    ) {
+      deleteAttempts += 1;
+      deleteKeys.push(readInitHeader(init, "idempotency-key"));
+      if (deleteAttempts === 1) {
+        const committed = await defaultFetch(input, init);
+        deleteReplay = await committed.json();
+        apiState.goalEvents.set(
+          "goal-external-delete",
+          externalGoal(
+            "goal-external-delete",
+            "2026-03-28T11:01:03.000Z",
+            "yellow",
+            "blue",
+            "player-bea",
+          ),
+        );
+        return createJsonResponse(503, {
+          error: "response_lost",
+          message: "Delete response was lost after commit.",
+        });
+      }
+      return createJsonResponse(200, deleteReplay);
+    }
+
+    if (
+      method === "POST" &&
+      target.pathname === "/v1/games/game-goal-replay-reconcile/goals/undo-last"
+    ) {
+      undoAttempts += 1;
+      undoKeys.push(readInitHeader(init, "idempotency-key"));
+      if (undoAttempts === 1) {
+        const committed = await defaultFetch(input, init);
+        undoReplay = await committed.json();
+        apiState.goalEvents.set(
+          "goal-external-undo",
+          externalGoal(
+            "goal-external-undo",
+            "2026-03-28T11:01:04.000Z",
+            "red",
+            "yellow",
+            "player-ari",
+          ),
+        );
+        return createJsonResponse(503, {
+          error: "response_lost",
+          message: "Undo response was lost after commit.",
+        });
+      }
+      return createJsonResponse(200, undoReplay);
+    }
+
+    if (method === "GET" && target.pathname === goalsPath) {
+      authoritativeGoalGets += 1;
+    }
+
+    return defaultFetch(input, init);
+  };
+
+  const page = await bootPage({
+    html: renderGamePage("http://localhost:3001", { gameId: "game-goal-replay-reconcile" }),
+    url: "http://localhost:3000/games/game-goal-replay-reconcile",
+    scriptFile: "setup-flow.js",
+    apiState,
+    fetch: replayingFetch,
+  });
+  Object.defineProperty(page.window, "confirm", {
+    value: () => true,
+    configurable: true,
+  });
+  authoritativeGoalGets = 0;
+
+  const scoringTeamInput = page.document.getElementById("goal-scoring-team");
+  const concedingTeamInput = page.document.getElementById("goal-conceding-team");
+  const scorerInput = page.document.getElementById("goal-scorer");
+  const scoreboard = page.document.getElementById("live-scoreboard");
+  const saveGoalButton = page.document.querySelector('[data-action="save-goal"]');
+  assert(scoringTeamInput instanceof page.window.HTMLSelectElement);
+  assert(concedingTeamInput instanceof page.window.HTMLSelectElement);
+  assert(scorerInput instanceof page.window.HTMLSelectElement);
+  assert(scoreboard instanceof page.window.HTMLElement);
+  assert(saveGoalButton instanceof page.window.HTMLButtonElement);
+
+  scoringTeamInput.value = "red";
+  scoringTeamInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+  concedingTeamInput.value = "blue";
+  concedingTeamInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+  scorerInput.value = "player-ari";
+  scorerInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+
+  dispatchClick(saveGoalButton);
+  await flushAsync();
+  assert.match(scoreboard.textContent ?? "", /Scores may have changed/);
+  dispatchClick(saveGoalButton);
+  await flushAsync();
+
+  assert.equal(createAttempts, 2);
+  assert.ok(createKeys[0]);
+  assert.equal(createKeys[0], createKeys[1]);
+  assert(page.document.querySelector('[data-event-id="goal-external-create"]'));
+  assert.equal(authoritativeGoalGets, 1);
+
+  const deleteGoalButton = page.document.querySelector(
+    '[data-action="delete-goal"][data-event-id="goal-1"]',
+  );
+  assert(deleteGoalButton instanceof page.window.HTMLButtonElement);
+  dispatchClick(deleteGoalButton);
+  await flushAsync();
+  assert.match(scoreboard.textContent ?? "", /Scores may have changed/);
+  const retryDeleteGoalButton = page.document.querySelector(
+    '[data-action="delete-goal"][data-event-id="goal-1"]',
+  );
+  assert(retryDeleteGoalButton instanceof page.window.HTMLButtonElement);
+  dispatchClick(retryDeleteGoalButton);
+  await flushAsync();
+
+  assert.equal(deleteAttempts, 2);
+  assert.ok(deleteKeys[0]);
+  assert.equal(deleteKeys[0], deleteKeys[1]);
+  assert.equal(page.document.querySelector('[data-event-id="goal-1"]'), null);
+  assert(page.document.querySelector('[data-event-id="goal-external-delete"]'));
+  assert.equal(authoritativeGoalGets, 2);
+
+  const undoLastGoalButton = page.document.querySelector('[data-action="undo-last-goal"]');
+  assert(undoLastGoalButton instanceof page.window.HTMLButtonElement);
+  dispatchClick(undoLastGoalButton);
+  await flushAsync();
+  assert.match(scoreboard.textContent ?? "", /Scores may have changed/);
+  dispatchClick(undoLastGoalButton);
+  await flushAsync();
+
+  assert.equal(undoAttempts, 2);
+  assert.ok(undoKeys[0]);
+  assert.equal(undoKeys[0], undoKeys[1]);
+  assert.equal(page.document.querySelector('[data-event-id="goal-external-delete"]'), null);
+  assert(page.document.querySelector('[data-event-id="goal-external-undo"]'));
+  assert.equal(authoritativeGoalGets, 3);
+});
+
+test("game page hides finished scores until a lost correction response is replayed", async () => {
+  const apiState = createMockApiState();
+  const finishedThirds = createDefaultThirdTimerSegments().map((third) => ({
+    ...third,
+    startedAt: `2026-03-28T11:00:0${third.third}.000Z`,
+    finishedAt: `2026-03-28T11:00:1${third.third}.000Z`,
+  }));
+  seedGoalScoringGame(apiState, {
+    gameId: "game-finished-lost-correction",
+    status: "finished",
+    thirds: finishedThirds,
+    role: "admin",
+    sessionEmail: "admin@3fc.football",
+  });
+  apiState.goalEvents.set("goal-1", {
+    gameId: "game-finished-lost-correction",
+    eventId: "goal-1",
+    third: 1,
+    thirdMinute: 1,
+    gameMinute: 1,
+    elapsedSeconds: 30,
+    stoppageMinute: null,
+    displayTime: "1'",
+    scoringTeamId: "red",
+    concedingTeamId: "blue",
+    scorerPlayerId: "player-ari",
+    assistPlayerIds: [],
+    ownGoal: false,
+    createdAt: "2026-03-28T11:01:01.000Z",
+    updatedAt: "2026-03-28T11:01:01.000Z",
+  });
+  const seededGame = apiState.games.get("game-finished-lost-correction");
+  assert(seededGame);
+  refreshMockFinishedResult(apiState, seededGame, "2026-03-28T11:02:00.000Z");
+
+  const defaultFetch = createMockFetch(apiState);
+  const updateKeys: Array<string | null> = [];
+  let updateAttempts = 0;
+  let replayBody: unknown = null;
+  const lostResponseFetch: ReturnType<typeof createMockFetch> = async (input, init = {}) => {
+    const target =
+      typeof input === "string" || input instanceof URL
+        ? new URL(String(input))
+        : new URL(input.url);
+    const method = (init.method ?? "GET").toUpperCase();
+    if (
+      method === "PATCH" &&
+      target.pathname === "/v1/games/game-finished-lost-correction/goals/goal-1"
+    ) {
+      updateAttempts += 1;
+      updateKeys.push(readInitHeader(init, "idempotency-key"));
+      if (updateAttempts === 1) {
+        const committed = await defaultFetch(input, init);
+        replayBody = await committed.json();
+        return createJsonResponse(503, {
+          error: "response_lost",
+          message: "Goal update response was lost after commit.",
+        });
+      }
+      return createJsonResponse(200, replayBody);
+    }
+
+    return defaultFetch(input, init);
+  };
+
+  const page = await bootPage({
+    html: renderGamePage("http://localhost:3001", { gameId: "game-finished-lost-correction" }),
+    url: "http://localhost:3000/games/game-finished-lost-correction",
+    scriptFile: "setup-flow.js",
+    apiState,
+    fetch: lostResponseFetch,
+  });
+
+  const editGoalButton = page.document.querySelector('[data-action="edit-goal"][data-event-id="goal-1"]');
+  const scoringTeamInput = page.document.getElementById("goal-scoring-team");
+  const concedingTeamInput = page.document.getElementById("goal-conceding-team");
+  const scorerInput = page.document.getElementById("goal-scorer");
+  const saveGoalButton = page.document.querySelector('[data-action="save-goal"]');
+  const scoreboard = page.document.getElementById("live-scoreboard");
+  const resultSummary = page.document.getElementById("game-result-summary");
+  const status = page.document.getElementById("setup-status");
+  assert(editGoalButton instanceof page.window.HTMLButtonElement);
+  assert(scoringTeamInput instanceof page.window.HTMLSelectElement);
+  assert(concedingTeamInput instanceof page.window.HTMLSelectElement);
+  assert(scorerInput instanceof page.window.HTMLSelectElement);
+  assert(saveGoalButton instanceof page.window.HTMLButtonElement);
+  assert(scoreboard instanceof page.window.HTMLElement);
+  assert(resultSummary instanceof page.window.HTMLElement);
+  assert(status instanceof page.window.HTMLElement);
+  assert.match(resultSummary.textContent ?? "", /Red win/);
+
+  dispatchClick(editGoalButton);
+  await flushAsync();
+  scoringTeamInput.value = "blue";
+  scoringTeamInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+  concedingTeamInput.value = "red";
+  concedingTeamInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+  scorerInput.value = "player-cy";
+  scorerInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+  dispatchClick(saveGoalButton);
+  await flushAsync();
+
+  assert.equal(updateAttempts, 1);
+  assert.equal(apiState.goalEvents.get("goal-1")?.scoringTeamId, "blue");
+  assert.equal(apiState.games.get("game-finished-lost-correction")?.result?.winnerTeamId, "blue");
+  assert.match(scoreboard.textContent ?? "", /Scores may have changed/);
+  assert.equal(scoreboard.querySelector('[data-ui="score-team"]'), null);
+  assert.match(resultSummary.textContent ?? "", /Result may have changed/);
+  assert.doesNotMatch(resultSummary.textContent ?? "", /Red win|Blue win|Draw/);
+  assert.match(status.textContent ?? "", /Retry with the same details/);
+  assert.equal(scoringTeamInput.value, "blue");
+  assert.equal(concedingTeamInput.value, "red");
+  assert.equal(scorerInput.value, "player-cy");
+
+  dispatchClick(saveGoalButton);
+  await flushAsync();
+
+  assert.equal(updateAttempts, 2);
+  assert.ok(updateKeys[0]);
+  assert.equal(updateKeys[0], updateKeys[1]);
+  assert.equal(scoringTeamInput.value, "");
+  assert.equal(concedingTeamInput.value, "");
+  assert.equal(scorerInput.value, "");
+  assert.match(resultSummary.textContent ?? "", /Blue win/);
+  assert.doesNotMatch(resultSummary.textContent ?? "", /Result may have changed|Result refresh required/);
+  const blueScoreCard = scoreboard.querySelector('[data-ui="score-team"][data-team-id="blue"]');
+  const redScoreCard = scoreboard.querySelector('[data-ui="score-team"][data-team-id="red"]');
+  assert(blueScoreCard instanceof page.window.HTMLElement);
+  assert(redScoreCard instanceof page.window.HTMLElement);
+  assert.deepEqual(
+    [...blueScoreCard.querySelectorAll("dl div")].map((row) => row.textContent?.replace(/\s/g, "")),
+    ["Conceded0", "Scored1"],
+  );
+  assert.deepEqual(
+    [...redScoreCard.querySelectorAll("dl div")].map((row) => row.textContent?.replace(/\s/g, "")),
+    ["Conceded1", "Scored0"],
+  );
+});
+
+test("game page clears an open edit draft after a committed delete or undo", async () => {
+  const apiState = createMockApiState();
+  const thirds = createDefaultThirdTimerSegments();
+  thirds[0] = {
+    ...thirds[0],
+    startedAt: "2026-03-28T11:00:10.000Z",
+  };
+  seedGoalScoringGame(apiState, {
+    gameId: "game-edit-draft-mutation",
+    status: "live",
+    thirds,
+  });
+  apiState.goalEvents.set("goal-1", {
+    gameId: "game-edit-draft-mutation",
+    eventId: "goal-1",
+    third: 1,
+    thirdMinute: 1,
+    gameMinute: 1,
+    elapsedSeconds: 30,
+    stoppageMinute: null,
+    displayTime: "1'",
+    scoringTeamId: "red",
+    concedingTeamId: "blue",
+    scorerPlayerId: "player-ari",
+    assistPlayerIds: ["player-bea"],
+    ownGoal: false,
+    createdAt: "2026-03-28T11:01:01.000Z",
+    updatedAt: "2026-03-28T11:01:01.000Z",
+  });
+  apiState.goalEvents.set("goal-2", {
+    gameId: "game-edit-draft-mutation",
+    eventId: "goal-2",
+    third: 1,
+    thirdMinute: 1,
+    gameMinute: 1,
+    elapsedSeconds: 40,
+    stoppageMinute: null,
+    displayTime: "1'",
+    scoringTeamId: "blue",
+    concedingTeamId: "red",
+    scorerPlayerId: "player-cy",
+    assistPlayerIds: [],
+    ownGoal: false,
+    createdAt: "2026-03-28T11:01:02.000Z",
+    updatedAt: "2026-03-28T11:01:02.000Z",
+  });
+
+  const page = await bootPage({
+    html: renderGamePage("http://localhost:3001", { gameId: "game-edit-draft-mutation" }),
+    url: "http://localhost:3000/games/game-edit-draft-mutation",
+    scriptFile: "setup-flow.js",
+    apiState,
+  });
+  Object.defineProperty(page.window, "confirm", {
+    value: () => true,
+    configurable: true,
+  });
+
+  const scoringTeamInput = page.document.getElementById("goal-scoring-team");
+  const concedingTeamInput = page.document.getElementById("goal-conceding-team");
+  const scorerInput = page.document.getElementById("goal-scorer");
+  const saveGoalButton = page.document.querySelector('[data-action="save-goal"]');
+  const undoLastGoalButton = page.document.querySelector('[data-action="undo-last-goal"]');
+  assert(scoringTeamInput instanceof page.window.HTMLSelectElement);
+  assert(concedingTeamInput instanceof page.window.HTMLSelectElement);
+  assert(scorerInput instanceof page.window.HTMLSelectElement);
+  assert(saveGoalButton instanceof page.window.HTMLButtonElement);
+  assert(undoLastGoalButton instanceof page.window.HTMLButtonElement);
+
+  const editGoalOne = page.document.querySelector('[data-action="edit-goal"][data-event-id="goal-1"]');
+  const deleteGoalOne = page.document.querySelector('[data-action="delete-goal"][data-event-id="goal-1"]');
+  assert(editGoalOne instanceof page.window.HTMLButtonElement);
+  assert(deleteGoalOne instanceof page.window.HTMLButtonElement);
+  dispatchClick(editGoalOne);
+  await flushAsync();
+  assert.equal(scoringTeamInput.value, "red");
+  assert.equal(page.document.querySelectorAll('#goal-assists input[type="checkbox"]:checked').length, 1);
+
+  const refreshedDeleteGoalOne = page.document.querySelector(
+    '[data-action="delete-goal"][data-event-id="goal-1"]',
+  );
+  assert(refreshedDeleteGoalOne instanceof page.window.HTMLButtonElement);
+  dispatchClick(refreshedDeleteGoalOne);
+  await flushAsync();
+  assert.equal(apiState.goalEvents.has("goal-1"), false);
+  assert.equal(scoringTeamInput.value, "");
+  assert.equal(concedingTeamInput.value, "");
+  assert.equal(scorerInput.value, "");
+  assert.equal(page.document.querySelectorAll('#goal-assists input[type="checkbox"]:checked').length, 0);
+  assert.match(saveGoalButton.textContent ?? "", /Add goal/);
+
+  const editGoalTwo = page.document.querySelector('[data-action="edit-goal"][data-event-id="goal-2"]');
+  assert(editGoalTwo instanceof page.window.HTMLButtonElement);
+  dispatchClick(editGoalTwo);
+  await flushAsync();
+  assert.equal(scoringTeamInput.value, "blue");
+
+  dispatchClick(undoLastGoalButton);
+  await flushAsync();
+  assert.equal(apiState.goalEvents.has("goal-2"), false);
+  assert.equal(scoringTeamInput.value, "");
+  assert.equal(concedingTeamInput.value, "");
+  assert.equal(scorerInput.value, "");
+  assert.match(saveGoalButton.textContent ?? "", /Add goal/);
 });
 
 test("game page treats later created same-second goals as latest", async () => {
@@ -5183,6 +5668,7 @@ test("game page invalidates current goals when correction replay refresh fails",
   const saveGoalButton = page.document.querySelector('[data-action="save-goal"]');
   const undoLastGoalButton = page.document.querySelector('[data-action="undo-last-goal"]');
   const timeline = page.document.getElementById("goal-timeline");
+  const scoreboard = page.document.getElementById("live-scoreboard");
   const status = page.document.getElementById("setup-status");
   const scoringTeamInput = page.document.getElementById("goal-scoring-team");
   const concedingTeamInput = page.document.getElementById("goal-conceding-team");
@@ -5191,6 +5677,7 @@ test("game page invalidates current goals when correction replay refresh fails",
   assert(saveGoalButton instanceof page.window.HTMLButtonElement);
   assert(undoLastGoalButton instanceof page.window.HTMLButtonElement);
   assert(timeline instanceof page.window.HTMLElement);
+  assert(scoreboard instanceof page.window.HTMLElement);
   assert(status instanceof page.window.HTMLElement);
   assert(scoringTeamInput instanceof page.window.HTMLSelectElement);
   assert(concedingTeamInput instanceof page.window.HTMLSelectElement);
@@ -5203,9 +5690,12 @@ test("game page invalidates current goals when correction replay refresh fails",
   await flushAsync();
   await flushAsync();
 
-  assert.match(status.textContent ?? "", /Goal updated; timeline refresh failed/);
+  assert.match(status.textContent ?? "", /Goal updated; scores and timeline unavailable/);
+  assert.equal(status.hasAttribute("data-state"), false);
   assert.match(timeline.textContent ?? "", /Goal timeline unavailable/);
   assert.doesNotMatch(timeline.textContent ?? "", /Cy\s*Blue\s*→\s*Red/);
+  assert.match(scoreboard.textContent ?? "", /Scores unavailable/);
+  assert.equal(scoreboard.querySelector('[data-ui="score-team"]'), null);
   assert.equal(scoringTeamInput.value, "");
   assert.equal(concedingTeamInput.value, "");
   assert.equal(scorerInput.value, "");
@@ -5356,26 +5846,8 @@ test("game page refreshes the finished result when a committed edit timeline rel
   assert.equal(successfulGameRefreshes, 1);
   assert(resolveGameRefresh);
   assert.equal(saveGoalButton.disabled, true);
-  const pendingBlueScoreCard = page.document.querySelector(
-    '[data-ui="score-team"][data-team-id="blue"]',
-  );
-  const pendingRedScoreCard = page.document.querySelector(
-    '[data-ui="score-team"][data-team-id="red"]',
-  );
-  assert(pendingBlueScoreCard instanceof page.window.HTMLElement);
-  assert(pendingRedScoreCard instanceof page.window.HTMLElement);
-  assert.deepEqual(
-    [...pendingBlueScoreCard.querySelectorAll("dl div")].map((row) =>
-      row.textContent?.replace(/\s/g, ""),
-    ),
-    ["Conceded1", "Scored0"],
-  );
-  assert.deepEqual(
-    [...pendingRedScoreCard.querySelectorAll("dl div")].map((row) =>
-      row.textContent?.replace(/\s/g, ""),
-    ),
-    ["Conceded0", "Scored1"],
-  );
+  assert.match(page.document.getElementById("live-scoreboard")?.textContent ?? "", /Refreshing scores/);
+  assert.equal(page.document.querySelector('[data-ui="score-team"]'), null);
 
   const refreshedGame = apiState.games.get("game-finished-timeline-refresh-fail");
   assert(refreshedGame);
@@ -6445,7 +6917,7 @@ test("game page serializes goal corrections through the finished-result refresh"
   assert.equal(page.document.getElementById("setup-status")?.textContent, "Goal added.");
 });
 
-test("game page clears a committed finished-goal draft when result refresh fails", async () => {
+test("game page clears a committed finished-goal draft when timeline and result refresh fail", async () => {
   const apiState = createMockApiState();
   const finishedThirds = createDefaultThirdTimerSegments().map((third) => ({
     ...third,
@@ -6464,6 +6936,7 @@ test("game page clears a committed finished-goal draft when result refresh fails
   refreshMockFinishedResult(apiState, seededGame, "2026-03-28T11:00:12.000Z");
 
   const defaultFetch = createMockFetch(apiState);
+  let failNextGoalRefresh = false;
   let failNextGameRefresh = false;
   const staleResultFetch: ReturnType<typeof createMockFetch> = async (input, init = {}) => {
     const target =
@@ -6474,8 +6947,21 @@ test("game page clears a committed finished-goal draft when result refresh fails
 
     if (method === "POST" && target.pathname === "/v1/games/game-create-refresh-fail/goals") {
       const response = await defaultFetch(input, init);
+      failNextGoalRefresh = true;
       failNextGameRefresh = true;
       return response;
+    }
+
+    if (
+      method === "GET" &&
+      target.pathname === "/v1/games/game-create-refresh-fail/goals" &&
+      failNextGoalRefresh
+    ) {
+      failNextGoalRefresh = false;
+      return createJsonResponse(503, {
+        error: "unavailable",
+        message: "Goal refresh unavailable.",
+      });
     }
 
     if (method === "GET" && target.pathname === "/v1/games/game-create-refresh-fail" && failNextGameRefresh) {
@@ -6505,6 +6991,8 @@ test("game page clears a committed finished-goal draft when result refresh fails
   const status = page.document.getElementById("setup-status");
   const error = page.document.getElementById("setup-error");
   const resultSummary = page.document.getElementById("game-result-summary");
+  const scoreboard = page.document.getElementById("live-scoreboard");
+  const timeline = page.document.getElementById("goal-timeline");
   assert(scoringTeamInput instanceof page.window.HTMLSelectElement);
   assert(concedingTeamInput instanceof page.window.HTMLSelectElement);
   assert(scorerInput instanceof page.window.HTMLSelectElement);
@@ -6513,6 +7001,8 @@ test("game page clears a committed finished-goal draft when result refresh fails
   assert(status instanceof page.window.HTMLElement);
   assert(error instanceof page.window.HTMLElement);
   assert(resultSummary instanceof page.window.HTMLElement);
+  assert(scoreboard instanceof page.window.HTMLElement);
+  assert(timeline instanceof page.window.HTMLElement);
 
   scoringTeamInput.value = "red";
   scoringTeamInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
@@ -6524,8 +7014,12 @@ test("game page clears a committed finished-goal draft when result refresh fails
   await flushAsync();
 
   assert.equal(apiState.goalEvents.size, 1);
-  assert.match(status.textContent ?? "", /Goal added; result refresh failed/);
-  assert.match(error.textContent ?? "", /finished result could not be refreshed/);
+  assert.match(status.textContent ?? "", /Goal added; timeline and result refresh failed/);
+  assert.equal(status.getAttribute("data-state"), "error");
+  assert.match(error.textContent ?? "", /neither the latest goal state nor the finished result/);
+  assert.match(scoreboard.textContent ?? "", /Scores unavailable/);
+  assert.equal(scoreboard.querySelector('[data-ui="score-team"]'), null);
+  assert.match(timeline.textContent ?? "", /Goal timeline unavailable/);
   assert.equal(resultSummary.hidden, false);
   assert.match(resultSummary.textContent ?? "", /Result refresh required/);
   assert.match(resultSummary.textContent ?? "", /goal change was saved/);
@@ -6643,8 +7137,21 @@ test("game page treats committed undo as success when finished result refresh fa
   assert.equal(apiState.games.get("game-undo-refresh-fail")?.result?.winnerTeamId, "red");
   assert.match(timeline.textContent ?? "", /Ari\s*Red\s*→\s*Blue/);
   assert.doesNotMatch(timeline.textContent ?? "", /Cy\s*Blue\s*→\s*Red/);
-  assert.match(status.textContent ?? "", /Latest goal undone; result refresh failed/);
+  assert.match(status.textContent ?? "", /Latest goal undone\. Run scores refreshed; Match Summary unavailable/);
+  assert.equal(status.hasAttribute("data-state"), false);
   assert.match(error.textContent ?? "", /finished result could not be refreshed/);
+  const redScoreCard = page.document.querySelector('[data-ui="score-team"][data-team-id="red"]');
+  const blueScoreCard = page.document.querySelector('[data-ui="score-team"][data-team-id="blue"]');
+  assert(redScoreCard instanceof page.window.HTMLElement);
+  assert(blueScoreCard instanceof page.window.HTMLElement);
+  assert.deepEqual(
+    [...redScoreCard.querySelectorAll("dl div")].map((row) => row.textContent?.replace(/\s/g, "")),
+    ["Conceded0", "Scored1"],
+  );
+  assert.deepEqual(
+    [...blueScoreCard.querySelectorAll("dl div")].map((row) => row.textContent?.replace(/\s/g, "")),
+    ["Conceded1", "Scored0"],
+  );
   assert.match(resultSummary.textContent ?? "", /Result refresh required/);
   assert.doesNotMatch(resultSummary.textContent ?? "", /Red win|Blue win|Draw/);
 });

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -4898,6 +4898,12 @@ test("game page reconciles authoritative goals after replayed create, delete, an
           message: "Goal response was lost after commit.",
         });
       }
+      if (createAttempts === 2) {
+        return createJsonResponse(403, {
+          error: "forbidden",
+          message: "Goal access expired before replay.",
+        });
+      }
       return createJsonResponse(201, createReplay);
     }
 
@@ -4923,6 +4929,12 @@ test("game page reconciles authoritative goals after replayed create, delete, an
         return createJsonResponse(503, {
           error: "response_lost",
           message: "Delete response was lost after commit.",
+        });
+      }
+      if (deleteAttempts === 2) {
+        return createJsonResponse(403, {
+          error: "forbidden",
+          message: "Goal access expired before delete replay.",
         });
       }
       return createJsonResponse(200, deleteReplay);
@@ -4952,6 +4964,12 @@ test("game page reconciles authoritative goals after replayed create, delete, an
           message: "Undo response was lost after commit.",
         });
       }
+      if (undoAttempts === 2) {
+        return createJsonResponse(403, {
+          error: "forbidden",
+          message: "Goal access expired before undo replay.",
+        });
+      }
       return createJsonResponse(200, undoReplay);
     }
 
@@ -4979,11 +4997,13 @@ test("game page reconciles authoritative goals after replayed create, delete, an
   const concedingTeamInput = page.document.getElementById("goal-conceding-team");
   const scorerInput = page.document.getElementById("goal-scorer");
   const scoreboard = page.document.getElementById("live-scoreboard");
+  const status = page.document.getElementById("setup-status");
   const saveGoalButton = page.document.querySelector('[data-action="save-goal"]');
   assert(scoringTeamInput instanceof page.window.HTMLSelectElement);
   assert(concedingTeamInput instanceof page.window.HTMLSelectElement);
   assert(scorerInput instanceof page.window.HTMLSelectElement);
   assert(scoreboard instanceof page.window.HTMLElement);
+  assert(status instanceof page.window.HTMLElement);
   assert(saveGoalButton instanceof page.window.HTMLButtonElement);
 
   scoringTeamInput.value = "red";
@@ -4998,10 +5018,15 @@ test("game page reconciles authoritative goals after replayed create, delete, an
   assert.match(scoreboard.textContent ?? "", /Scores may have changed/);
   dispatchClick(saveGoalButton);
   await flushAsync();
+  assert.match(scoreboard.textContent ?? "", /Scores may have changed/);
+  assert.match(status.textContent ?? "", /earlier goal save is still unconfirmed/);
+  dispatchClick(saveGoalButton);
+  await flushAsync();
 
-  assert.equal(createAttempts, 2);
+  assert.equal(createAttempts, 3);
   assert.ok(createKeys[0]);
   assert.equal(createKeys[0], createKeys[1]);
+  assert.equal(createKeys[1], createKeys[2]);
   assert(page.document.querySelector('[data-event-id="goal-external-create"]'));
   assert.equal(authoritativeGoalGets, 1);
 
@@ -5018,10 +5043,19 @@ test("game page reconciles authoritative goals after replayed create, delete, an
   assert(retryDeleteGoalButton instanceof page.window.HTMLButtonElement);
   dispatchClick(retryDeleteGoalButton);
   await flushAsync();
+  assert.match(scoreboard.textContent ?? "", /Scores may have changed/);
+  assert.match(status.textContent ?? "", /earlier deletion is still unconfirmed/);
+  const replayDeleteGoalButton = page.document.querySelector(
+    '[data-action="delete-goal"][data-event-id="goal-1"]',
+  );
+  assert(replayDeleteGoalButton instanceof page.window.HTMLButtonElement);
+  dispatchClick(replayDeleteGoalButton);
+  await flushAsync();
 
-  assert.equal(deleteAttempts, 2);
+  assert.equal(deleteAttempts, 3);
   assert.ok(deleteKeys[0]);
   assert.equal(deleteKeys[0], deleteKeys[1]);
+  assert.equal(deleteKeys[1], deleteKeys[2]);
   assert.equal(page.document.querySelector('[data-event-id="goal-1"]'), null);
   assert(page.document.querySelector('[data-event-id="goal-external-delete"]'));
   assert.equal(authoritativeGoalGets, 2);
@@ -5033,10 +5067,15 @@ test("game page reconciles authoritative goals after replayed create, delete, an
   assert.match(scoreboard.textContent ?? "", /Scores may have changed/);
   dispatchClick(undoLastGoalButton);
   await flushAsync();
+  assert.match(scoreboard.textContent ?? "", /Scores may have changed/);
+  assert.match(status.textContent ?? "", /earlier undo is still unconfirmed/);
+  dispatchClick(undoLastGoalButton);
+  await flushAsync();
 
-  assert.equal(undoAttempts, 2);
+  assert.equal(undoAttempts, 3);
   assert.ok(undoKeys[0]);
   assert.equal(undoKeys[0], undoKeys[1]);
+  assert.equal(undoKeys[1], undoKeys[2]);
   assert.equal(page.document.querySelector('[data-event-id="goal-external-delete"]'), null);
   assert(page.document.querySelector('[data-event-id="goal-external-undo"]'));
   assert.equal(authoritativeGoalGets, 3);
@@ -5101,6 +5140,12 @@ test("game page hides finished scores until a lost correction response is replay
           message: "Goal update response was lost after commit.",
         });
       }
+      if (updateAttempts === 2) {
+        return createJsonResponse(403, {
+          error: "forbidden",
+          message: "Goal access expired before correction replay.",
+        });
+      }
       return createJsonResponse(200, replayBody);
     }
 
@@ -5160,8 +5205,18 @@ test("game page hides finished scores until a lost correction response is replay
   await flushAsync();
 
   assert.equal(updateAttempts, 2);
+  assert.match(scoreboard.textContent ?? "", /Scores may have changed/);
+  assert.match(resultSummary.textContent ?? "", /Result may have changed/);
+  assert.equal(scoringTeamInput.value, "blue");
+  assert.equal(concedingTeamInput.value, "red");
+  assert.equal(scorerInput.value, "player-cy");
+  dispatchClick(saveGoalButton);
+  await flushAsync();
+
+  assert.equal(updateAttempts, 3);
   assert.ok(updateKeys[0]);
   assert.equal(updateKeys[0], updateKeys[1]);
+  assert.equal(updateKeys[1], updateKeys[2]);
   assert.equal(scoringTeamInput.value, "");
   assert.equal(concedingTeamInput.value, "");
   assert.equal(scorerInput.value, "");

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -4632,6 +4632,194 @@ test("game page reuses create goal idempotency key for unchanged retry", async (
   assert.notEqual(createGoalIdempotencyKeys[1], createGoalIdempotencyKeys[2]);
 });
 
+test("game page preserves authoritative scores and retires retry keys after rejected goal mutations", async () => {
+  const apiState = createMockApiState();
+  const finishedThirds = createDefaultThirdTimerSegments().map((third) => ({
+    ...third,
+    startedAt: `2026-03-28T11:00:0${third.third}.000Z`,
+    finishedAt: `2026-03-28T11:00:1${third.third}.000Z`,
+  }));
+  seedGoalScoringGame(apiState, {
+    gameId: "game-goal-rejected",
+    status: "finished",
+    thirds: finishedThirds,
+    role: "admin",
+    sessionEmail: "admin@3fc.football",
+  });
+  apiState.goalEvents.set("goal-1", {
+    gameId: "game-goal-rejected",
+    eventId: "goal-1",
+    third: 1,
+    thirdMinute: 1,
+    gameMinute: 1,
+    elapsedSeconds: 30,
+    stoppageMinute: null,
+    displayTime: "1'",
+    scoringTeamId: "red",
+    concedingTeamId: "blue",
+    scorerPlayerId: "player-ari",
+    assistPlayerIds: [],
+    ownGoal: false,
+    createdAt: "2026-03-28T11:01:01.000Z",
+    updatedAt: "2026-03-28T11:01:01.000Z",
+  });
+  const seededGame = apiState.games.get("game-goal-rejected");
+  assert(seededGame);
+  refreshMockFinishedResult(apiState, seededGame, "2026-03-28T11:02:00.000Z");
+
+  const defaultFetch = createMockFetch(apiState);
+  const updateKeys: Array<string | null> = [];
+  const undoKeys: Array<string | null> = [];
+  const deleteKeys: Array<string | null> = [];
+  const rejectedFetch: ReturnType<typeof createMockFetch> = async (input, init = {}) => {
+    const target =
+      typeof input === "string" || input instanceof URL
+        ? new URL(String(input))
+        : new URL(input.url);
+    const method = (init.method ?? "GET").toUpperCase();
+    const goalsPath = "/v1/games/game-goal-rejected/goals";
+
+    if (method === "PATCH" && target.pathname === `${goalsPath}/goal-1`) {
+      updateKeys.push(readInitHeader(init, "idempotency-key"));
+      return createJsonResponse(403, {
+        error: "forbidden",
+        message: "Goal correction is not permitted.",
+      });
+    }
+    if (method === "POST" && target.pathname === `${goalsPath}/undo-last`) {
+      undoKeys.push(readInitHeader(init, "idempotency-key"));
+      return createJsonResponse(409, {
+        error: "goal_conflict",
+        message: "The latest goal cannot be undone.",
+      });
+    }
+    if (method === "DELETE" && target.pathname === `${goalsPath}/goal-1`) {
+      deleteKeys.push(readInitHeader(init, "idempotency-key"));
+      return createJsonResponse(403, {
+        error: "forbidden",
+        message: "Goal deletion is not permitted.",
+      });
+    }
+
+    return defaultFetch(input, init);
+  };
+
+  const page = await bootPage({
+    html: renderGamePage("http://localhost:3001", { gameId: "game-goal-rejected" }),
+    url: "http://localhost:3000/games/game-goal-rejected",
+    scriptFile: "setup-flow.js",
+    apiState,
+    fetch: rejectedFetch,
+  });
+  Object.defineProperty(page.window, "confirm", {
+    value: () => true,
+    configurable: true,
+  });
+
+  const scoreboard = page.document.getElementById("live-scoreboard");
+  const resultSummary = page.document.getElementById("game-result-summary");
+  const status = page.document.getElementById("setup-status");
+  const error = page.document.getElementById("setup-error");
+  const editGoalButton = page.document.querySelector(
+    '[data-action="edit-goal"][data-event-id="goal-1"]',
+  );
+  const scoringTeamInput = page.document.getElementById("goal-scoring-team");
+  const concedingTeamInput = page.document.getElementById("goal-conceding-team");
+  const scorerInput = page.document.getElementById("goal-scorer");
+  const saveGoalButton = page.document.querySelector('[data-action="save-goal"]');
+  const undoLastGoalButton = page.document.querySelector('[data-action="undo-last-goal"]');
+  assert(scoreboard instanceof page.window.HTMLElement);
+  assert(resultSummary instanceof page.window.HTMLElement);
+  assert(status instanceof page.window.HTMLElement);
+  assert(error instanceof page.window.HTMLElement);
+  assert(editGoalButton instanceof page.window.HTMLButtonElement);
+  assert(scoringTeamInput instanceof page.window.HTMLSelectElement);
+  assert(concedingTeamInput instanceof page.window.HTMLSelectElement);
+  assert(scorerInput instanceof page.window.HTMLSelectElement);
+  assert(saveGoalButton instanceof page.window.HTMLButtonElement);
+  assert(undoLastGoalButton instanceof page.window.HTMLButtonElement);
+
+  const assertAuthoritativeRedResult = () => {
+    const redScoreCard = scoreboard.querySelector('[data-ui="score-team"][data-team-id="red"]');
+    const blueScoreCard = scoreboard.querySelector('[data-ui="score-team"][data-team-id="blue"]');
+    assert(redScoreCard instanceof page.window.HTMLElement);
+    assert(blueScoreCard instanceof page.window.HTMLElement);
+    assert.deepEqual(
+      [...redScoreCard.querySelectorAll("dl div")].map((row) => row.textContent?.replace(/\s/g, "")),
+      ["Conceded0", "Scored1"],
+    );
+    assert.deepEqual(
+      [...blueScoreCard.querySelectorAll("dl div")].map((row) => row.textContent?.replace(/\s/g, "")),
+      ["Conceded1", "Scored0"],
+    );
+    assert.match(resultSummary.textContent ?? "", /Red win/);
+    assert.doesNotMatch(resultSummary.textContent ?? "", /Result may have changed|Result refresh required/);
+    assert(page.document.querySelector('[data-event-id="goal-1"]'));
+  };
+
+  assertAuthoritativeRedResult();
+  dispatchClick(editGoalButton);
+  await flushAsync();
+  scoringTeamInput.value = "blue";
+  scoringTeamInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+  concedingTeamInput.value = "red";
+  concedingTeamInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+  scorerInput.value = "player-cy";
+  scorerInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+
+  dispatchClick(saveGoalButton);
+  await flushAsync();
+  assertAuthoritativeRedResult();
+  assert.match(status.textContent ?? "", /Goal was not saved/);
+  assert.match(error.textContent ?? "", /Goal correction is not permitted/);
+  assert.equal(scoringTeamInput.value, "blue");
+  assert.equal(concedingTeamInput.value, "red");
+  assert.equal(scorerInput.value, "player-cy");
+  dispatchClick(saveGoalButton);
+  await flushAsync();
+  assert.equal(updateKeys.length, 2);
+  assert.ok(updateKeys[0]);
+  assert.ok(updateKeys[1]);
+  assert.notEqual(updateKeys[0], updateKeys[1]);
+  assertAuthoritativeRedResult();
+
+  dispatchClick(undoLastGoalButton);
+  await flushAsync();
+  assertAuthoritativeRedResult();
+  assert.match(status.textContent ?? "", /latest goal was not undone/i);
+  assert.match(error.textContent ?? "", /latest goal cannot be undone/i);
+  dispatchClick(undoLastGoalButton);
+  await flushAsync();
+  assert.equal(undoKeys.length, 2);
+  assert.ok(undoKeys[0]);
+  assert.ok(undoKeys[1]);
+  assert.notEqual(undoKeys[0], undoKeys[1]);
+  assertAuthoritativeRedResult();
+
+  const deleteGoalButton = page.document.querySelector(
+    '[data-action="delete-goal"][data-event-id="goal-1"]',
+  );
+  assert(deleteGoalButton instanceof page.window.HTMLButtonElement);
+  dispatchClick(deleteGoalButton);
+  await flushAsync();
+  assertAuthoritativeRedResult();
+  assert.match(status.textContent ?? "", /goal was not deleted/i);
+  assert.match(error.textContent ?? "", /Goal deletion is not permitted/);
+  const retryDeleteGoalButton = page.document.querySelector(
+    '[data-action="delete-goal"][data-event-id="goal-1"]',
+  );
+  assert(retryDeleteGoalButton instanceof page.window.HTMLButtonElement);
+  dispatchClick(retryDeleteGoalButton);
+  await flushAsync();
+  assert.equal(deleteKeys.length, 2);
+  assert.ok(deleteKeys[0]);
+  assert.ok(deleteKeys[1]);
+  assert.notEqual(deleteKeys[0], deleteKeys[1]);
+  assertAuthoritativeRedResult();
+  assert.equal(apiState.goalEvents.get("goal-1")?.scoringTeamId, "red");
+  assert.equal(apiState.games.get("game-goal-rejected")?.result?.winnerTeamId, "red");
+});
+
 test("game page reconciles authoritative goals after replayed create, delete, and undo responses", async () => {
   const apiState = createMockApiState();
   const thirds = createDefaultThirdTimerSegments();

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -4412,6 +4412,22 @@ test("game page remains usable when goal timeline load fails", async () => {
         ? new URL(String(input))
         : new URL(input.url);
     const method = (init.method ?? "GET").toUpperCase();
+    if (method === "GET" && target.pathname === "/v1/games/game-goals-fail/roster") {
+      const response = await defaultFetch(input, init);
+      const payload = (await response.json()) as {
+        teams?: Array<Record<string, unknown>>;
+        roster?: unknown[];
+      };
+      return createJsonResponse(200, {
+        ...payload,
+        teams: (payload.teams ?? []).map((team) => ({
+          ...team,
+          conceded: 0,
+          scored: 0,
+        })),
+      });
+    }
+
     if (method === "GET" && target.pathname === "/v1/games/game-goals-fail/goals") {
       return createJsonResponse(503, {
         error: "unavailable",
@@ -4454,6 +4470,22 @@ test("game page remains usable when goal timeline load fails", async () => {
   assert.match(resultSummary.textContent ?? "", /Red win/);
   assert.match(resultSummary.textContent ?? "", /Goal summaries unavailable/);
   assert.doesNotMatch(resultSummary.textContent ?? "", /No goals recorded|No scorers recorded/);
+  const initialRedScoreCard = page.document.querySelector('[data-ui="score-team"][data-team-id="red"]');
+  const initialBlueScoreCard = page.document.querySelector('[data-ui="score-team"][data-team-id="blue"]');
+  assert(initialRedScoreCard instanceof page.window.HTMLElement);
+  assert(initialBlueScoreCard instanceof page.window.HTMLElement);
+  assert.deepEqual(
+    [...initialRedScoreCard.querySelectorAll("dl div")].map((row) =>
+      row.textContent?.replace(/\s/g, ""),
+    ),
+    ["Conceded0", "Scored1"],
+  );
+  assert.deepEqual(
+    [...initialBlueScoreCard.querySelectorAll("dl div")].map((row) =>
+      row.textContent?.replace(/\s/g, ""),
+    ),
+    ["Conceded1", "Scored0"],
+  );
   assert.equal(page.document.querySelector('[data-testid="final-full-goal-log"]'), null);
   assert.equal(quickCreateButton.disabled, false);
 });
@@ -5215,6 +5247,10 @@ test("game page refreshes the finished result when a committed edit timeline rel
   const seededGame = apiState.games.get("game-finished-timeline-refresh-fail");
   assert(seededGame);
   refreshMockFinishedResult(apiState, seededGame, "2026-03-28T11:02:00.000Z");
+  const originalGoal = apiState.goalEvents.get("goal-1");
+  assert(originalGoal);
+  const staleReplayGoal = { ...originalGoal };
+  const staleReplayScoreboard = recomputeMockScoreboard(apiState, seededGame);
 
   const defaultFetch = createMockFetch(apiState);
   let correctionCommitted = false;
@@ -5232,9 +5268,15 @@ test("game page refreshes the finished result when a committed edit timeline rel
       method === "PATCH" &&
       target.pathname === "/v1/games/game-finished-timeline-refresh-fail/goals/goal-1"
     ) {
-      const response = await defaultFetch(input, init);
+      await defaultFetch(input, init);
       correctionCommitted = true;
-      return response;
+      return createJsonResponse(200, {
+        goal: staleReplayGoal,
+        scoreboard: {
+          teams: staleReplayScoreboard,
+        },
+        timeline: [staleReplayGoal],
+      });
     }
 
     if (
@@ -5314,6 +5356,26 @@ test("game page refreshes the finished result when a committed edit timeline rel
   assert.equal(successfulGameRefreshes, 1);
   assert(resolveGameRefresh);
   assert.equal(saveGoalButton.disabled, true);
+  const pendingBlueScoreCard = page.document.querySelector(
+    '[data-ui="score-team"][data-team-id="blue"]',
+  );
+  const pendingRedScoreCard = page.document.querySelector(
+    '[data-ui="score-team"][data-team-id="red"]',
+  );
+  assert(pendingBlueScoreCard instanceof page.window.HTMLElement);
+  assert(pendingRedScoreCard instanceof page.window.HTMLElement);
+  assert.deepEqual(
+    [...pendingBlueScoreCard.querySelectorAll("dl div")].map((row) =>
+      row.textContent?.replace(/\s/g, ""),
+    ),
+    ["Conceded1", "Scored0"],
+  );
+  assert.deepEqual(
+    [...pendingRedScoreCard.querySelectorAll("dl div")].map((row) =>
+      row.textContent?.replace(/\s/g, ""),
+    ),
+    ["Conceded0", "Scored1"],
+  );
 
   const refreshedGame = apiState.games.get("game-finished-timeline-refresh-fail");
   assert(refreshedGame);
@@ -5322,7 +5384,7 @@ test("game page refreshes the finished result when a committed edit timeline rel
 
   assert.equal(failedGoalRefreshes, 1);
   assert.equal(successfulGameRefreshes, 1);
-  assert.match(status.textContent ?? "", /Goal updated\. Match Summary refreshed; goal timeline unavailable/);
+  assert.match(status.textContent ?? "", /Goal updated\. Scores refreshed; goal timeline unavailable/);
   assert.match(error.textContent ?? "", /Goal details could not be loaded\. Reload to try again/);
   assert.match(timeline.textContent ?? "", /Goal timeline unavailable/);
   assert.equal(resultSummary.hidden, false);
@@ -5341,6 +5403,18 @@ test("game page refreshes the finished result when a committed edit timeline rel
   );
   assert.deepEqual(
     [...redTeam.querySelectorAll("dl div")].map((row) => row.textContent?.replace(/\s/g, "")),
+    ["Conceded1", "Scored0"],
+  );
+  const blueScoreCard = page.document.querySelector('[data-ui="score-team"][data-team-id="blue"]');
+  const redScoreCard = page.document.querySelector('[data-ui="score-team"][data-team-id="red"]');
+  assert(blueScoreCard instanceof page.window.HTMLElement);
+  assert(redScoreCard instanceof page.window.HTMLElement);
+  assert.deepEqual(
+    [...blueScoreCard.querySelectorAll("dl div")].map((row) => row.textContent?.replace(/\s/g, "")),
+    ["Conceded0", "Scored1"],
+  );
+  assert.deepEqual(
+    [...redScoreCard.querySelectorAll("dl div")].map((row) => row.textContent?.replace(/\s/g, "")),
     ["Conceded1", "Scored0"],
   );
   assert(resultSummary.querySelector('[data-testid="final-team-log-unavailable-blue"]'));

--- a/app/src/tests/ui-layout.test.ts
+++ b/app/src/tests/ui-layout.test.ts
@@ -271,6 +271,9 @@ test("game page renders editable game metadata view", () => {
   assert.match(html, /data-testid="run-console"/);
   assert.match(html, /data-testid="run-score-strip"/);
   assert.match(html, /data-testid="run-primary-scoring"/);
+  assert.match(html, /<div data-ui="run-scoring-panel" data-testid="panel-game-live">/);
+  assert.match(html, /data-testid="run-primary-scoring" aria-labelledby="run-goal-form-heading"/);
+  assert.doesNotMatch(html, /aria-labelledby="run-scoring-heading"/);
   assert.match(html, /data-testid="run-timer-bar"/);
   assert.match(html, /data-testid="run-third-history"/);
   assert.match(html, /data-testid="run-latest-goals"/);
@@ -283,6 +286,11 @@ test("game page renders editable game metadata view", () => {
   assert.match(html, /data-testid="game-result-summary"/);
   assert.match(html, /data-testid="panel-game-final"/);
   assert.match(html, /data-testid="finalisation-board"/);
+  assert.match(html, />Match Summary</);
+  assert.doesNotMatch(html, />Run game</);
+  assert.doesNotMatch(html, /Record goals first/);
+  assert.doesNotMatch(html, />Finalisation</);
+  assert.doesNotMatch(html, /final-game-id-value|final-game-readiness/);
   assert.match(html, /data-testid="game-edit-third-length"/);
   assert.ok(
     html.indexOf('data-testid="game-mode-structure"') < html.indexOf('data-testid="game-mode-players"'),

--- a/app/src/ui/layout.ts
+++ b/app/src/ui/layout.ts
@@ -1066,14 +1066,10 @@ export function renderGamePage(apiBaseUrl: string, input: GameContextPageInput):
   const scorePanel = `<div data-ui="run-score-strip" data-testid="run-score-strip">
     <div data-ui="live-scoreboard" id="live-scoreboard" data-testid="live-scoreboard"></div>
   </div>`;
-  const livePanel = `<section data-ui="run-scoring-panel" data-testid="panel-game-live" aria-labelledby="run-scoring-heading">
-    <header data-ui="section-heading">
-      <h2 id="run-scoring-heading">Run game</h2>
-      <p>Record goals first; review corrections when needed.</p>
-    </header>
+  const livePanel = `<div data-ui="run-scoring-panel" data-testid="panel-game-live">
     <section data-ui="run-primary-scoring" data-testid="run-primary-scoring" aria-labelledby="run-goal-form-heading">
       <header>
-        <h3 id="run-goal-form-heading">Record goal</h3>
+        <h2 id="run-goal-form-heading">Record goal</h2>
       </header>
       <div data-ui="run-goal-form">
         <div data-ui="field">
@@ -1116,19 +1112,17 @@ export function renderGamePage(apiBaseUrl: string, input: GameContextPageInput):
         })}
       </div>
     </section>
-  </section>`;
+  </div>`;
   const latestGoalsPanel = `<details data-ui="run-latest-goals" data-testid="run-latest-goals" open>
       <summary>Latest goals</summary>
       <ol id="goal-timeline" data-ui="goal-timeline" data-testid="goal-timeline"></ol>
     </details>`;
   const finalPanel = renderPanel(
-    "Finalisation",
-    "Finish the match and review the summary.",
+    "Match Summary",
+    "Review the final result and player statistics.",
     `<div data-ui="finalisation-board" data-testid="finalisation-board">
-      <dl data-ui="id-preview" data-testid="finalisation-context">
-        <div><dt>Game</dt><dd id="final-game-id-value">${gameHeading}</dd></div>
+      <dl data-ui="final-summary-status" data-testid="finalisation-context">
         <div><dt>Status</dt><dd id="final-game-status">Loading…</dd></div>
-        <div><dt>Timeline</dt><dd id="final-game-readiness">Loading…</dd></div>
       </dl>
       <div data-ui="game-result-summary" id="game-result-summary" data-testid="game-result-summary" hidden></div>
     </div>`,
@@ -1213,7 +1207,7 @@ export function renderGamePage(apiBaseUrl: string, input: GameContextPageInput):
               ${latestGoalsPanel}
             </div>
           </section>
-          <section data-ui="game-mode-panel" id="game-mode-final" aria-label="Finalisation" data-game-mode="final" data-testid="game-mode-final" hidden>
+          <section data-ui="game-mode-panel" id="game-mode-final" aria-label="Match summary" data-game-mode="final" data-testid="game-mode-final" hidden>
             ${finalPanel}
           </section>
         </section>

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -2034,9 +2034,7 @@
     const finishThirdButton = root.querySelector('[data-action="finish-active-third"]');
     const finishGameButton = root.querySelector('[data-action="finish-game"]');
     const gameResultSummaryElement = document.getElementById("game-result-summary");
-    const finalGameIdValue = document.getElementById("final-game-id-value");
     const finalGameStatus = document.getElementById("final-game-status");
-    const finalGameReadiness = document.getElementById("final-game-readiness");
     const playerNicknameInput = document.getElementById("player-nickname");
     const quickCreatePlayerButton = root.querySelector('[data-action="quick-create-player"]');
     const playerSearchInput = document.getElementById("player-search");
@@ -2080,6 +2078,7 @@
     let scoreboardTeams = [];
     let goalTimeline = [];
     let goalTimelineLoaded = false;
+    let finishedResultUnavailable = false;
     let editingGoalId = null;
     let currentLeagueRole = null;
     let manualGameModeSelected = false;
@@ -2291,14 +2290,6 @@
       const hasStarted = timer ? timer.thirds.some((third) => third.startedAt !== null) : false;
       const complete = timer?.status === "complete";
       const finished = isGameFinished();
-      const finalReadiness = finished
-        ? "Summary posted"
-        : complete
-          ? "Ready to finish"
-          : hasStarted
-            ? humanTimerStatus(timer.status)
-            : "Not started";
-
       setModeMeta("structure", humanGameStatus(currentGame?.status));
       setModeMeta("players", `${rosteredCount} assigned`);
       setModeMeta("run", timer ? humanTimerStatus(timer.status) : "Timer");
@@ -2310,14 +2301,8 @@
         gameStateTab.setAttribute("data-game-state", gameState.state);
       }
 
-      if (finalGameIdValue instanceof HTMLElement && currentGame?.gameId) {
-        finalGameIdValue.textContent = currentGame.gameId;
-      }
       if (finalGameStatus instanceof HTMLElement) {
         finalGameStatus.textContent = humanGameStatus(currentGame?.status);
-      }
-      if (finalGameReadiness instanceof HTMLElement) {
-        finalGameReadiness.textContent = finalReadiness;
       }
     }
 
@@ -2544,11 +2529,21 @@
     }
 
     function playerNickname(playerId) {
-      return playerById(playerId)?.nickname ?? playerId;
+      const nickname = playerById(playerId)?.nickname;
+      if (typeof nickname === "string" && nickname.length > 0) {
+        return nickname;
+      }
+
+      return String(playerId ?? "Unknown player");
     }
 
     function teamName(teamId) {
-      return teamById(teamId)?.name ?? teamId;
+      const name = teamById(teamId)?.name;
+      if (typeof name === "string" && name.length > 0) {
+        return name;
+      }
+
+      return String(teamId ?? "Unknown team");
     }
 
     function assignmentByPlayerId(playerId) {
@@ -2591,7 +2586,10 @@
       return teams.map((team) => ({
         gameId: team.gameId ?? gameId,
         teamId: team.teamId,
-        name: team.name ?? team.teamId,
+        name:
+          typeof team.name === "string" && team.name.length > 0
+            ? team.name
+            : String(team.teamId ?? "Unknown team"),
         color: typeof team.color === "string" ? team.color : null,
         scored: Number.isInteger(team.scored) && team.scored >= 0 ? team.scored : 0,
         conceded: Number.isInteger(team.conceded) && team.conceded >= 0 ? team.conceded : 0,
@@ -2672,6 +2670,19 @@
         return;
       }
 
+      if (isGameFinished() && finishedResultUnavailable) {
+        gameResultSummaryElement.hidden = false;
+        gameResultSummaryElement.innerHTML = `<section data-ui="result-board" data-state="unavailable">
+          <header>
+            <span>Final result</span>
+            <strong>Result refresh required</strong>
+          </header>
+          <p data-ui="empty-note">The goal change was saved, but the updated match result could not be loaded.</p>
+        </section>`;
+        syncGameModeState();
+        return;
+      }
+
       const result = currentGame?.result;
       const teams = resultTeams();
       if (!isGameFinished() || !result || teams.length === 0) {
@@ -2684,15 +2695,12 @@
       const winner = teams.find((team) => team.teamId === result.winnerTeamId) ?? null;
       const outcomeText = winner ? `${winner.name} win` : "Draw";
       const resultOutcome = result.outcome === "win" ? "win" : "draw";
-      const computedAt = typeof result.computedAt === "string" ? formatLocalTimestamp(result.computedAt) : "";
-
       const goalLogsLoaded = goalTimelineLoaded;
       gameResultSummaryElement.hidden = false;
       gameResultSummaryElement.innerHTML = `<section data-ui="result-board" data-outcome="${escapeHtml(resultOutcome)}">
         <header>
           <span>Final result</span>
           <strong data-testid="game-result-outcome">${escapeHtml(outcomeText)}</strong>
-          ${computedAt ? `<small>Computed ${escapeHtml(computedAt)}</small>` : ""}
         </header>
         <div data-ui="result-team-list" data-testid="game-result-teams">
           ${teams
@@ -2727,13 +2735,25 @@
       syncGameModeState();
     }
 
-    function renderSelectOptions(selectElement, options, selectedValue, emptyLabel = "Select", missingSelectedLabel = null) {
+    function renderSelectOptions(
+      selectElement,
+      options,
+      selectedValue,
+      emptyLabel = "Select",
+      missingSelectedLabel = null,
+      includePlaceholder = false,
+    ) {
       const selectedExists = options.some((option) => option.value === selectedValue);
       const preservesMissingSelection =
         !selectedExists && Boolean(selectedValue) && typeof missingSelectedLabel === "string";
       const safeSelected = selectedExists || preservesMissingSelection
         ? selectedValue
-        : (options[0]?.value ?? "");
+        : includePlaceholder
+          ? ""
+          : (options[0]?.value ?? "");
+      const placeholderOption = includePlaceholder
+        ? `<option value=""${safeSelected === "" ? " selected" : ""}>${escapeHtml(emptyLabel)}</option>`
+        : "";
       const preservedOption = preservesMissingSelection
         ? `<option value="${escapeHtml(selectedValue)}" selected>${escapeHtml(missingSelectedLabel)}</option>`
         : "";
@@ -2748,7 +2768,7 @@
 
       selectElement.innerHTML =
         options.length > 0 || preservesMissingSelection
-          ? `${preservedOption}${renderedOptions}`
+          ? `${placeholderOption}${preservedOption}${renderedOptions}`
           : `<option value="">${escapeHtml(emptyLabel)}</option>`;
       selectElement.value = safeSelected;
       selectElement.disabled = options.length === 0 && !preservesMissingSelection;
@@ -2773,8 +2793,8 @@
               <strong>${escapeHtml(team.name)}</strong>
             </header>
             <dl>
-              <div><dt>Scored</dt><dd>${escapeHtml(String(team.scored))}</dd></div>
               <div><dt>Conceded</dt><dd>${escapeHtml(String(team.conceded))}</dd></div>
+              <div><dt>Scored</dt><dd>${escapeHtml(String(team.scored))}</dd></div>
             </dl>
           </article>`,
         )
@@ -2839,14 +2859,24 @@
         goalScoringTeamInput.value = "";
         goalScoringTeamInput.disabled = true;
       } else {
-        renderSelectOptions(goalScoringTeamInput, teamOptions, previousScoringTeamId, "No teams");
+        renderSelectOptions(goalScoringTeamInput, teamOptions, previousScoringTeamId, "Choose scoring team", null, true);
       }
 
       const scoringTeamId = ownGoal ? null : goalScoringTeamInput.value;
       const concedingOptions = ownGoal
         ? teamOptions
         : teamOptions.filter((team) => team.value !== scoringTeamId);
-      renderSelectOptions(goalConcedingTeamInput, concedingOptions, previousConcedingTeamId, "No conceding teams");
+      renderSelectOptions(
+        goalConcedingTeamInput,
+        concedingOptions,
+        previousConcedingTeamId,
+        "Choose conceding team",
+        null,
+        true,
+      );
+      if (!ownGoal && !scoringTeamId) {
+        goalConcedingTeamInput.disabled = true;
+      }
 
       const concedingTeamId = goalConcedingTeamInput.value;
       const scorerPool = ownGoal
@@ -2875,7 +2905,11 @@
         selectedScorerId,
         "Assign players first",
         selectedScorerLabel,
+        true,
       );
+      if (!concedingTeamId || (!ownGoal && !scoringTeamId)) {
+        goalScorerInput.disabled = true;
+      }
       renderGoalAssistChoices(goalScorerInput.value, seed.assistPlayerIds ?? null);
 
       const activeThird = activeThirdNumber();
@@ -2934,6 +2968,18 @@
         return;
       }
 
+      if (!goalOwnGoalInput.checked && !goalScoringTeamInput.value) {
+        saveGoalButton.disabled = true;
+        goalFormNote.textContent = "Choose a scoring team before adding a goal.";
+        return;
+      }
+
+      if (!goalConcedingTeamInput.value) {
+        saveGoalButton.disabled = true;
+        goalFormNote.textContent = "Choose a conceding team before adding a goal.";
+        return;
+      }
+
       if (!goalScorerInput.value) {
         saveGoalButton.disabled = true;
         goalFormNote.textContent = "Choose a scorer before adding a goal.";
@@ -2951,7 +2997,7 @@
       if (!activeThird) {
         saveGoalButton.disabled = !creatingFinishedCorrection;
         goalFormNote.textContent = creatingFinishedCorrection
-          ? "Finished-game correction will be recorded at final whistle."
+          ? "Choose the goal details to correct the finished result."
           : "Start a third before adding goals.";
         return;
       }
@@ -2960,13 +3006,23 @@
       goalFormNote.textContent = `Goal will be added to third ${activeThird}.`;
     }
 
-    function timelineGoalLabel(goal) {
-      const scorer = playerNickname(goal.scorerPlayerId);
-      if (goal.ownGoal) {
-        return `${scorer} own goal against ${teamName(goal.concedingTeamId)}`;
+    function renderThirdIndicator(third) {
+      const safeThird = Number.isInteger(third) && third >= 1 && third <= 3 ? third : null;
+      if (!safeThird) {
+        return "";
       }
 
-      return `${scorer} for ${teamName(goal.scoringTeamId)}`;
+      return `<span data-ui="third-indicator" data-third="${safeThird}" role="img" aria-label="Third ${safeThird} of 3"></span>`;
+    }
+
+    function renderGoalTeamChip(teamId) {
+      const team = teamById(teamId);
+      const name = typeof team?.name === "string" && team.name.length > 0
+        ? team.name
+        : String(teamId ?? "Unknown team");
+      return `<span data-ui="goal-team-chip" data-team-id="${escapeHtml(String(teamId ?? ""))}"${
+        team ? teamSwatchStyle(team) : ""
+      }><span data-ui="team-swatch" aria-hidden="true"></span><span>${escapeHtml(name)}</span></span>`;
     }
 
     function goalDisplayTime(goal) {
@@ -3070,28 +3126,29 @@
       return goals
         .map((goal) => {
           const detail = finalTeamGoalDetail(goal);
-          const rowDetail =
-            options.includeThird === true && Number.isInteger(goal.third)
-              ? `Third ${goal.third} · ${detail}`
-              : detail;
-          return `<li data-ui="final-goal-item" data-event-id="${escapeHtml(String(goal.eventId ?? ""))}">
+          const includesThird = options.includeThird === true && Number.isInteger(goal.third);
+          return `<li data-ui="final-goal-item" data-event-id="${escapeHtml(String(goal.eventId ?? ""))}"${
+            includesThird ? ' data-has-third="true"' : ""
+          }>
             <span data-ui="goal-time">${escapeHtml(goalDisplayTime(goal))}</span>
             <div>
               <strong>${escapeHtml(finalTeamGoalLabel(goal))}</strong>
-              <small>${escapeHtml(rowDetail)}</small>
+              <small>${escapeHtml(detail)}</small>
             </div>
+            ${includesThird ? renderThirdIndicator(goal.third) : ""}
           </li>`;
         })
         .join("");
     }
 
     function incrementPlayerStat(stats, playerId) {
-      if (typeof playerId !== "string" || playerId.length === 0) {
+      const normalizedPlayerId = String(playerId ?? "");
+      if (normalizedPlayerId.length === 0) {
         return;
       }
 
-      const existing = stats.get(playerId) ?? 0;
-      stats.set(playerId, existing + 1);
+      const existing = stats.get(normalizedPlayerId) ?? 0;
+      stats.set(normalizedPlayerId, existing + 1);
     }
 
     function sortedPlayerStats(stats) {
@@ -3209,23 +3266,38 @@
               ? goal.assistPlayerIds.map((playerId) => playerNickname(playerId)).join(", ")
               : "None";
           const latest = goal.eventId === latestEventId;
-          return `<li data-ui="goal-event" data-event-id="${escapeHtml(goal.eventId)}"${
+          const displayTime = goalDisplayTime(goal);
+          const scorer = String(playerNickname(goal.scorerPlayerId));
+          const eventId = String(goal.eventId ?? "");
+          const scoringContext = goal.ownGoal
+            ? `<span data-ui="own-goal-marker" aria-label="Own goal">OG</span>`
+            : renderGoalTeamChip(goal.scoringTeamId);
+          return `<li data-ui="goal-event" data-event-id="${escapeHtml(eventId)}"${
             latest ? ' data-state="latest"' : ""
           }>
             <div data-ui="goal-event-main">
-              <strong>${escapeHtml(goalDisplayTime(goal))} · Third ${escapeHtml(String(goal.third))}</strong>
-              <span>${escapeHtml(timelineGoalLabel(goal))}</span>
+              <div data-ui="goal-primary-row">
+                <strong data-ui="goal-time">${escapeHtml(displayTime)}</strong>
+                <span data-ui="goal-scorer">${escapeHtml(scorer)}</span>
+                ${scoringContext}
+                <span data-ui="goal-team-arrow" aria-hidden="true">→</span>
+                ${renderGoalTeamChip(goal.concedingTeamId)}
+                ${renderThirdIndicator(goal.third)}
+              </div>
               <small>Assists: ${escapeHtml(assists)}</small>
               ${goal.ownGoal ? `<small>Own goal: conceding tally only</small>` : ""}
             </div>
             <div data-ui="row-action-buttons">
-              ${latest ? `<span data-ui="latest-flag">Latest</span>` : ""}
-              <button data-ui="row-action" type="button" data-action="edit-goal" data-event-id="${escapeHtml(
-                goal.eventId,
-              )}"${disabledAttribute}>Edit</button>
-              <button data-ui="row-action" data-tone="danger" type="button" data-action="delete-goal" data-event-id="${escapeHtml(
-                goal.eventId,
-              )}"${disabledAttribute}>Delete</button>
+              <button data-ui="icon-button" type="button" data-action="edit-goal" data-event-id="${escapeHtml(
+                eventId,
+              )}" aria-label="Edit ${escapeHtml(scorer)} goal at ${escapeHtml(displayTime)}" title="Edit goal"${
+                disabledAttribute
+              }>${renderClientIcon("pencil")}</button>
+              <button data-ui="icon-button" data-variant="danger" type="button" data-action="delete-goal" data-event-id="${escapeHtml(
+                eventId,
+              )}" aria-label="Delete ${escapeHtml(scorer)} goal at ${escapeHtml(displayTime)}" title="Delete goal"${
+                disabledAttribute
+              }>${renderClientIcon("trash-2")}</button>
             </div>
           </li>`;
         })
@@ -3271,7 +3343,27 @@
       if (goalOwnGoalInput instanceof HTMLInputElement) {
         goalOwnGoalInput.checked = false;
       }
-      renderLiveScoring();
+      if (goalScoringTeamInput instanceof HTMLSelectElement) {
+        goalScoringTeamInput.value = "";
+      }
+      if (goalConcedingTeamInput instanceof HTMLSelectElement) {
+        goalConcedingTeamInput.value = "";
+      }
+      if (goalScorerInput instanceof HTMLSelectElement) {
+        goalScorerInput.value = "";
+      }
+      for (const input of goalAssistsElement?.querySelectorAll('input[type="checkbox"]') ?? []) {
+        if (input instanceof HTMLInputElement) {
+          input.checked = false;
+        }
+      }
+      renderLiveScoring({
+        ownGoal: false,
+        scoringTeamId: "",
+        concedingTeamId: "",
+        scorerPlayerId: "",
+        assistPlayerIds: [],
+      });
     }
 
     function populateGoalForm(goal) {
@@ -3607,7 +3699,15 @@
         }),
       ]);
 
-      rosterTeams = Array.isArray(rosterPayload?.teams) ? rosterPayload.teams : [];
+      rosterTeams = Array.isArray(rosterPayload?.teams)
+        ? rosterPayload.teams.map((team) => ({
+            ...team,
+            name:
+              typeof team.name === "string" && team.name.length > 0
+                ? team.name
+                : String(team.teamId ?? "Unknown team"),
+          }))
+        : [];
       rosterAssignments = Array.isArray(rosterPayload?.roster) ? rosterPayload.roster : [];
       rosterPlayers = Array.isArray(playersPayload?.players) ? playersPayload.players : [];
       if (scoreboardTeams.length === 0 || goalTimeline.length === 0) {
@@ -3656,6 +3756,7 @@
       });
 
       currentGame = game;
+      finishedResultUnavailable = false;
       currentLeagueId = game.leagueId;
       currentSeasonId = game.seasonId;
 
@@ -3669,9 +3770,6 @@
 
       if (gameIdValue) {
         gameIdValue.textContent = game.gameId;
-      }
-      if (finalGameIdValue) {
-        finalGameIdValue.textContent = game.gameId;
       }
       if (gameJoinCodeValue) {
         gameJoinCodeValue.textContent = typeof game.joinCode === "string" && game.joinCode.length > 0
@@ -4221,11 +4319,12 @@
         const actionLabel = eventId ? "Saving goal edit" : "Adding goal";
         setStatus(`${actionLabel}…`, "default");
 
+        let result;
         try {
           const path = eventId
             ? `/v1/games/${encodeURIComponent(gameId)}/goals/${encodeURIComponent(eventId)}`
             : `/v1/games/${encodeURIComponent(gameId)}/goals`;
-          const result = await requestJsonOrThrow(path, {
+          result = await requestJsonOrThrow(path, {
             method: eventId ? "PATCH" : "POST",
             headers: {
               "Content-Type": "application/json",
@@ -4233,37 +4332,53 @@
             },
             body: JSON.stringify(draft.payload),
           });
-
-          if (!eventId) {
-            applyGoalMutationResult(result);
-            pendingCreateGoalIdempotency = null;
-            const gameRefreshed = await refreshGameAfterFinishedCorrection();
-            if (!gameRefreshed) {
-              showError("Goal was added, but the finished result could not be refreshed.");
-              setStatus("Goal added; result refresh failed.", "success");
-              return;
-            }
-          } else {
-            const goalsLoaded = await loadGameGoals();
-            if (!goalsLoaded) {
-              throw new Error("Goal update was saved, but the latest goal state could not be loaded.");
-            }
-            const gameRefreshed = await refreshGameAfterFinishedCorrection();
-            if (!gameRefreshed) {
-              throw new Error("Goal update was saved, but the finished result could not be refreshed.");
-            }
-            editingGoalId = null;
-            clearGoalMutationIdempotency("update-goal", `${gameId}-${eventId}`);
-          }
-          setStatus(eventId ? "Goal updated." : "Goal added.", "success");
         } catch (error) {
           const message = error instanceof Error ? error.message : "Could not save goal.";
           showError(message);
           setStatus("Goal save failed.", "error");
-        } finally {
           saveGoalButton.disabled = false;
           renderLiveScoring();
+          return;
         }
+
+        if (isGameFinished()) {
+          finishedResultUnavailable = true;
+        }
+        applyGoalMutationResult(result);
+        if (eventId) {
+          clearGoalMutationIdempotency("update-goal", `${gameId}-${eventId}`);
+        } else {
+          pendingCreateGoalIdempotency = null;
+        }
+        resetGoalForm();
+
+        if (eventId) {
+          const goalsLoaded = await loadGameGoals();
+          if (!goalsLoaded) {
+            showError("Goal update was saved, but the latest goal state could not be loaded.");
+            setStatus("Goal updated; timeline refresh failed.", "success");
+            saveGoalButton.disabled = false;
+            renderLiveScoring();
+            return;
+          }
+        }
+
+        const gameRefreshed = await refreshGameAfterFinishedCorrection();
+        if (!gameRefreshed) {
+          showError(
+            eventId
+              ? "Goal was updated, but the finished result could not be refreshed."
+              : "Goal was added, but the finished result could not be refreshed.",
+          );
+          setStatus(eventId ? "Goal updated; result refresh failed." : "Goal added; result refresh failed.", "success");
+          saveGoalButton.disabled = false;
+          renderLiveScoring();
+          return;
+        }
+
+        setStatus(eventId ? "Goal updated." : "Goal added.", "success");
+        saveGoalButton.disabled = false;
+        renderLiveScoring();
       });
 
       cancelGoalEditButton.addEventListener("click", () => {
@@ -4299,6 +4414,9 @@
             }),
           });
 
+          if (isGameFinished()) {
+            finishedResultUnavailable = true;
+          }
           applyGoalMutationResult(result, { deletedEventId: latest.eventId });
           clearGoalMutationIdempotency("undo-goal", stablePart);
           const gameRefreshed = await refreshGameAfterFinishedCorrection();
@@ -4371,6 +4489,9 @@
             },
           );
 
+          if (isGameFinished()) {
+            finishedResultUnavailable = true;
+          }
           applyGoalMutationResult(result, { deletedEventId: eventId });
           clearGoalMutationIdempotency("delete-goal", stablePart);
           const gameRefreshed = await refreshGameAfterFinishedCorrection();

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -4373,7 +4373,8 @@
             return;
           }
 
-          if (isGameFinished()) {
+          const finishedCorrection = isGameFinished();
+          if (finishedCorrection) {
             finishedResultUnavailable = true;
           }
           applyGoalMutationResult(result);
@@ -4384,16 +4385,28 @@
           }
           resetGoalForm();
 
-          if (eventId) {
-            const goalsLoaded = await loadGameGoals();
-            if (!goalsLoaded) {
-              showError("Goal update was saved, but the latest goal state could not be loaded.");
-              setStatus("Goal updated; timeline refresh failed.", "success");
-              return;
-            }
-          }
+          const goalsLoaded = eventId ? await loadGameGoals() : true;
 
           const gameRefreshed = await refreshGameAfterFinishedCorrection();
+          if (!goalsLoaded) {
+            if (!gameRefreshed) {
+              showError(
+                "Goal update was saved, but neither the latest goal state nor the finished result could be refreshed. Reload to try again.",
+              );
+              setStatus("Goal updated; timeline and result refresh failed.", "error");
+            } else if (finishedCorrection) {
+              showError("Goal details could not be loaded. Reload to try again.");
+              setStatus(
+                "Goal updated. Match Summary refreshed; goal timeline unavailable.",
+                "default",
+              );
+            } else {
+              showError("Goal update was saved, but the latest goal state could not be loaded.");
+              setStatus("Goal updated; timeline refresh failed.", "default");
+            }
+            return;
+          }
+
           if (!gameRefreshed) {
             showError(
               eventId

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -2076,9 +2076,10 @@
     let rosterSearchTimer = 0;
     let openTransferPlayerId = null;
     let scoreboardTeams = [];
+    let scoreboardState = "loading";
     let goalTimeline = [];
     let goalTimelineLoaded = false;
-    let finishedResultUnavailable = false;
+    let finishedResultState = "authoritative";
     let editingGoalId = null;
     let goalMutationInFlight = false;
     let currentLeagueRole = null;
@@ -2677,14 +2678,26 @@
         return;
       }
 
-      if (isGameFinished() && finishedResultUnavailable) {
+      if (isGameFinished() && finishedResultState !== "authoritative") {
+        const resultPending = finishedResultState === "refreshing";
+        const resultUncertain = finishedResultState === "uncertain";
+        const heading = resultPending
+          ? "Refreshing result"
+          : resultUncertain
+            ? "Result may have changed"
+            : "Result refresh required";
+        const message = resultPending
+          ? "Checking the latest match result…"
+          : resultUncertain
+            ? "The correction outcome could not be confirmed. Retry the same action."
+            : "The goal change was saved, but the updated match result could not be loaded.";
         gameResultSummaryElement.hidden = false;
         gameResultSummaryElement.innerHTML = `<section data-ui="result-board" data-state="unavailable">
           <header>
             <span>Final result</span>
-            <strong>Result refresh required</strong>
+            <strong>${heading}</strong>
           </header>
-          <p data-ui="empty-note">The goal change was saved, but the updated match result could not be loaded.</p>
+          <p data-ui="empty-note">${message}</p>
         </section>`;
         syncGameModeState();
         return;
@@ -2783,6 +2796,18 @@
 
     function renderLiveScoreboard() {
       if (!(liveScoreboardElement instanceof HTMLElement)) {
+        return;
+      }
+
+      if (scoreboardState !== "authoritative") {
+        const message = scoreboardState === "unavailable"
+          ? "Scores unavailable. Reload to try again."
+          : scoreboardState === "uncertain"
+            ? "Scores may have changed. Retry the same action."
+          : scoreboardState === "refreshing"
+            ? "Refreshing scores…"
+            : "Loading scores…";
+        liveScoreboardElement.innerHTML = `<p data-ui="empty-note" data-testid="live-scoreboard-${escapeHtml(scoreboardState)}">${message}</p>`;
         return;
       }
 
@@ -3349,6 +3374,7 @@
     }
 
     function applyGoalMutationResult(result, fallback = {}) {
+      scoreboardState = "refreshing";
       if (Array.isArray(result?.scoreboard?.teams)) {
         scoreboardTeams = normalizeScoreboardTeams(result.scoreboard.teams);
       }
@@ -3775,6 +3801,7 @@
       goalTimelineLoaded = true;
       if (Array.isArray(payload?.scoreboard?.teams)) {
         scoreboardTeams = normalizeScoreboardTeams(payload.scoreboard.teams);
+        scoreboardState = "authoritative";
       }
 
       goalTimeline = Array.isArray(payload?.timeline) ? sortGoalTimeline(payload.timeline) : [];
@@ -3788,9 +3815,10 @@
       });
 
       currentGame = game;
-      finishedResultUnavailable = false;
+      finishedResultState = "authoritative";
       if (game.status === "finished" && Array.isArray(game.result?.teams)) {
         scoreboardTeams = normalizeScoreboardTeams(game.result.teams);
+        scoreboardState = "authoritative";
       }
       currentLeagueId = game.leagueId;
       currentSeasonId = game.seasonId;
@@ -4038,6 +4066,7 @@
         });
         if (Array.isArray(currentGame?.result?.teams)) {
           scoreboardTeams = normalizeScoreboardTeams(currentGame.result.teams);
+          scoreboardState = "authoritative";
         }
         if (isGameFinished()) {
           await loadLeagueAccess();
@@ -4353,6 +4382,10 @@
         const actionLabel = eventId ? "Saving goal edit" : "Adding goal";
         setStatus(`${actionLabel}…`, "default");
         goalMutationInFlight = true;
+        scoreboardState = "refreshing";
+        if (isGameFinished()) {
+          finishedResultState = "refreshing";
+        }
         renderLiveScoring();
 
         try {
@@ -4371,41 +4404,53 @@
             });
           } catch (error) {
             const message = error instanceof Error ? error.message : "Could not save goal.";
+            scoreboardState = "uncertain";
+            if (isGameFinished()) {
+              finishedResultState = "uncertain";
+            }
             showError(message);
-            setStatus("Goal save failed.", "error");
+            setStatus(
+              "Could not confirm whether the goal was saved. Retry with the same details.",
+              "error",
+            );
             return;
           }
 
           const finishedCorrection = isGameFinished();
           if (finishedCorrection) {
-            finishedResultUnavailable = true;
+            finishedResultState = "saved-unavailable";
           }
           applyGoalMutationResult(result);
+          resetGoalForm();
+
+          const goalsLoaded = await loadGameGoals();
           if (eventId) {
             clearGoalMutationIdempotency("update-goal", `${gameId}-${eventId}`);
           } else {
             pendingCreateGoalIdempotency = null;
           }
-          resetGoalForm();
-
-          const goalsLoaded = eventId ? await loadGameGoals() : true;
 
           const gameRefreshed = await refreshGameAfterFinishedCorrection();
           if (!goalsLoaded) {
+            if (scoreboardState !== "authoritative") {
+              scoreboardState = "unavailable";
+            }
+            const savedLabel = eventId ? "Goal update" : "Goal addition";
+            const savedStatus = eventId ? "Goal updated" : "Goal added";
             if (!gameRefreshed) {
               showError(
-                "Goal update was saved, but neither the latest goal state nor the finished result could be refreshed. Reload to try again.",
+                `${savedLabel} was saved, but neither the latest goal state nor the finished result could be refreshed. Reload to try again.`,
               );
-              setStatus("Goal updated; timeline and result refresh failed.", "error");
+              setStatus(`${savedStatus}; timeline and result refresh failed.`, "error");
             } else if (finishedCorrection) {
               showError("Goal details could not be loaded. Reload to try again.");
               setStatus(
-                "Goal updated. Scores refreshed; goal timeline unavailable.",
+                `${savedStatus}. Scores refreshed; goal timeline unavailable.`,
                 "default",
               );
             } else {
-              showError("Goal update was saved, but the latest goal state could not be loaded.");
-              setStatus("Goal updated; timeline refresh failed.", "default");
+              showError(`${savedLabel} was saved, but the latest scores and goal timeline could not be loaded.`);
+              setStatus(`${savedStatus}; scores and timeline unavailable.`, "default");
             }
             return;
           }
@@ -4417,8 +4462,10 @@
                 : "Goal was added, but the finished result could not be refreshed.",
             );
             setStatus(
-              eventId ? "Goal updated; result refresh failed." : "Goal added; result refresh failed.",
-              "success",
+              eventId
+                ? "Goal updated. Run scores refreshed; Match Summary unavailable."
+                : "Goal added. Run scores refreshed; Match Summary unavailable.",
+              "default",
             );
             return;
           }
@@ -4450,6 +4497,10 @@
         }
 
         goalMutationInFlight = true;
+        scoreboardState = "refreshing";
+        if (isGameFinished()) {
+          finishedResultState = "refreshing";
+        }
         clearError();
         setStatus("Undoing latest goal…", "default");
         renderLiveScoring();
@@ -4468,21 +4519,51 @@
           });
 
           if (isGameFinished()) {
-            finishedResultUnavailable = true;
+            finishedResultState = "saved-unavailable";
           }
           applyGoalMutationResult(result, { deletedEventId: latest.eventId });
+          resetGoalForm();
+          const goalsLoaded = await loadGameGoals();
           clearGoalMutationIdempotency("undo-goal", stablePart);
           const gameRefreshed = await refreshGameAfterFinishedCorrection();
+          if (!goalsLoaded) {
+            if (scoreboardState !== "authoritative") {
+              scoreboardState = "unavailable";
+            }
+            if (!gameRefreshed) {
+              showError(
+                "The latest goal was undone, but neither the latest goal state nor the finished result could be refreshed. Reload to try again.",
+              );
+              setStatus("Latest goal undone; timeline and result refresh failed.", "error");
+            } else if (isGameFinished()) {
+              showError("Goal details could not be loaded. Reload to try again.");
+              setStatus(
+                "Latest goal undone. Scores refreshed; goal timeline unavailable.",
+                "default",
+              );
+            } else {
+              showError("The latest goal was undone, but the latest scores and goal timeline could not be loaded.");
+              setStatus("Latest goal undone; scores and timeline unavailable.", "default");
+            }
+            return;
+          }
           if (!gameRefreshed) {
             showError("Latest goal was undone, but the finished result could not be refreshed.");
-            setStatus("Latest goal undone; result refresh failed.", "success");
+            setStatus(
+              "Latest goal undone. Run scores refreshed; Match Summary unavailable.",
+              "default",
+            );
             return;
           }
           setStatus("Latest goal undone.", "success");
         } catch (error) {
           const message = error instanceof Error ? error.message : "Could not undo latest goal.";
+          scoreboardState = "uncertain";
+          if (isGameFinished()) {
+            finishedResultState = "uncertain";
+          }
           showError(message);
-          setStatus("Goal undo failed.", "error");
+          setStatus("Could not confirm the undo. Retry the same action.", "error");
         } finally {
           goalMutationInFlight = false;
           renderLiveScoring();
@@ -4527,6 +4608,10 @@
         }
 
         goalMutationInFlight = true;
+        scoreboardState = "refreshing";
+        if (isGameFinished()) {
+          finishedResultState = "refreshing";
+        }
         clearError();
         setStatus("Deleting goal…", "default");
         renderLiveScoring();
@@ -4544,21 +4629,45 @@
           );
 
           if (isGameFinished()) {
-            finishedResultUnavailable = true;
+            finishedResultState = "saved-unavailable";
           }
           applyGoalMutationResult(result, { deletedEventId: eventId });
+          resetGoalForm();
+          const goalsLoaded = await loadGameGoals();
           clearGoalMutationIdempotency("delete-goal", stablePart);
           const gameRefreshed = await refreshGameAfterFinishedCorrection();
+          if (!goalsLoaded) {
+            if (scoreboardState !== "authoritative") {
+              scoreboardState = "unavailable";
+            }
+            if (!gameRefreshed) {
+              showError(
+                "The goal was deleted, but neither the latest goal state nor the finished result could be refreshed. Reload to try again.",
+              );
+              setStatus("Goal deleted; timeline and result refresh failed.", "error");
+            } else if (isGameFinished()) {
+              showError("Goal details could not be loaded. Reload to try again.");
+              setStatus("Goal deleted. Scores refreshed; goal timeline unavailable.", "default");
+            } else {
+              showError("The goal was deleted, but the latest scores and goal timeline could not be loaded.");
+              setStatus("Goal deleted; scores and timeline unavailable.", "default");
+            }
+            return;
+          }
           if (!gameRefreshed) {
             showError("Goal was deleted, but the finished result could not be refreshed.");
-            setStatus("Goal deleted; result refresh failed.", "success");
+            setStatus("Goal deleted. Run scores refreshed; Match Summary unavailable.", "default");
             return;
           }
           setStatus("Goal deleted.", "success");
         } catch (error) {
           const message = error instanceof Error ? error.message : "Could not delete goal.";
+          scoreboardState = "uncertain";
+          if (isGameFinished()) {
+            finishedResultState = "uncertain";
+          }
           showError(message);
-          setStatus("Goal deletion failed.", "error");
+          setStatus("Could not confirm the deletion. Retry the same action.", "error");
         } finally {
           goalMutationInFlight = false;
           renderLiveScoring();
@@ -4571,6 +4680,10 @@
     await loadLeagueAccess();
     await loadRosterSetup({ updateStatus: false });
     const goalsLoaded = await loadGameGoals();
+    if (!goalsLoaded && scoreboardState !== "authoritative") {
+      scoreboardState = "unavailable";
+      renderLiveScoring();
+    }
     if (!manualGameModeSelected) {
       setGameMode(preferredInitialGameMode());
     }

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -3519,6 +3519,7 @@
         const next = {
           fingerprint,
           key: createIdempotencyKey(prefix, stablePart),
+          uncertain: false,
         };
         pendingGoalMutationIdempotency.set(cacheKey, next);
         return next.key;
@@ -3529,6 +3530,17 @@
 
     function clearGoalMutationIdempotency(prefix, stablePart) {
       pendingGoalMutationIdempotency.delete(`${prefix}:${stablePart}`);
+    }
+
+    function isGoalMutationIdempotencyUncertain(prefix, stablePart) {
+      return pendingGoalMutationIdempotency.get(`${prefix}:${stablePart}`)?.uncertain === true;
+    }
+
+    function markGoalMutationIdempotencyUncertain(prefix, stablePart) {
+      const entry = pendingGoalMutationIdempotency.get(`${prefix}:${stablePart}`);
+      if (entry) {
+        entry.uncertain = true;
+      }
     }
 
     async function refreshGameAfterFinishedCorrection() {
@@ -3561,6 +3573,7 @@
         pendingCreateGoalIdempotency = {
           fingerprint,
           key: createIdempotencyKey("create-goal", `${gameId}-new`),
+          uncertain: false,
         };
       }
 
@@ -4391,6 +4404,11 @@
         const actionLabel = eventId ? "Saving goal edit" : "Adding goal";
         const previousScoreboardState = scoreboardState;
         const previousFinishedResultState = finishedResultState;
+        const saveStablePart = eventId ? `${gameId}-${eventId}` : null;
+        const saveIdempotencyKey = idempotencyKeyForGoalSave(eventId, draft.payload);
+        const wasUncertainRetry = eventId
+          ? isGoalMutationIdempotencyUncertain("update-goal", saveStablePart)
+          : pendingCreateGoalIdempotency?.uncertain === true;
         setStatus(`${actionLabel}…`, "default");
         goalMutationInFlight = true;
         scoreboardState = "refreshing";
@@ -4409,7 +4427,7 @@
               method: eventId ? "PATCH" : "POST",
               headers: {
                 "Content-Type": "application/json",
-                "Idempotency-Key": idempotencyKeyForGoalSave(eventId, draft.payload),
+                "Idempotency-Key": saveIdempotencyKey,
               },
               body: JSON.stringify(draft.payload),
             });
@@ -4419,13 +4437,25 @@
             if (isDefinitiveRequestRejection(error)) {
               scoreboardState = previousScoreboardState;
               finishedResultState = previousFinishedResultState;
-              if (eventId) {
-                clearGoalMutationIdempotency("update-goal", `${gameId}-${eventId}`);
-              } else {
-                pendingCreateGoalIdempotency = null;
+              if (!wasUncertainRetry) {
+                if (eventId) {
+                  clearGoalMutationIdempotency("update-goal", saveStablePart);
+                } else {
+                  pendingCreateGoalIdempotency = null;
+                }
               }
-              setStatus("Goal was not saved. Review the error and try again.", "error");
+              setStatus(
+                wasUncertainRetry
+                  ? "The retry was rejected, but the earlier goal save is still unconfirmed. Restore access and retry the same details."
+                  : "Goal was not saved. Review the error and try again.",
+                "error",
+              );
               return;
+            }
+            if (eventId) {
+              markGoalMutationIdempotencyUncertain("update-goal", saveStablePart);
+            } else if (pendingCreateGoalIdempotency) {
+              pendingCreateGoalIdempotency.uncertain = true;
             }
             scoreboardState = "uncertain";
             if (isGameFinished()) {
@@ -4530,12 +4560,18 @@
         renderLiveScoring();
 
         const stablePart = `${gameId}-${latest.eventId}`;
+        const undoIdempotencyKey = idempotencyKeyForGoalMutation(
+          "undo-goal",
+          stablePart,
+          latest.eventId,
+        );
+        const wasUncertainRetry = isGoalMutationIdempotencyUncertain("undo-goal", stablePart);
         try {
           const result = await requestJsonOrThrow(`/v1/games/${encodeURIComponent(gameId)}/goals/undo-last`, {
             method: "POST",
             headers: {
               "Content-Type": "application/json",
-              "Idempotency-Key": idempotencyKeyForGoalMutation("undo-goal", stablePart, latest.eventId),
+              "Idempotency-Key": undoIdempotencyKey,
             },
             body: JSON.stringify({
               expectedEventId: latest.eventId,
@@ -4586,10 +4622,18 @@
           if (isDefinitiveRequestRejection(error)) {
             scoreboardState = previousScoreboardState;
             finishedResultState = previousFinishedResultState;
-            clearGoalMutationIdempotency("undo-goal", stablePart);
-            setStatus("The latest goal was not undone. Review the error and try again.", "error");
+            if (!wasUncertainRetry) {
+              clearGoalMutationIdempotency("undo-goal", stablePart);
+            }
+            setStatus(
+              wasUncertainRetry
+                ? "The retry was rejected, but the earlier undo is still unconfirmed. Restore access and retry the same action."
+                : "The latest goal was not undone. Review the error and try again.",
+              "error",
+            );
             return;
           }
+          markGoalMutationIdempotencyUncertain("undo-goal", stablePart);
           scoreboardState = "uncertain";
           if (isGameFinished()) {
             finishedResultState = "uncertain";
@@ -4650,13 +4694,19 @@
         renderLiveScoring();
 
         const stablePart = `${gameId}-${eventId}`;
+        const deleteIdempotencyKey = idempotencyKeyForGoalMutation(
+          "delete-goal",
+          stablePart,
+          eventId,
+        );
+        const wasUncertainRetry = isGoalMutationIdempotencyUncertain("delete-goal", stablePart);
         try {
           const result = await requestJsonOrThrow(
             `/v1/games/${encodeURIComponent(gameId)}/goals/${encodeURIComponent(eventId)}`,
             {
               method: "DELETE",
               headers: {
-                "Idempotency-Key": idempotencyKeyForGoalMutation("delete-goal", stablePart, eventId),
+                "Idempotency-Key": deleteIdempotencyKey,
               },
             },
           );
@@ -4699,10 +4749,18 @@
           if (isDefinitiveRequestRejection(error)) {
             scoreboardState = previousScoreboardState;
             finishedResultState = previousFinishedResultState;
-            clearGoalMutationIdempotency("delete-goal", stablePart);
-            setStatus("The goal was not deleted. Review the error and try again.", "error");
+            if (!wasUncertainRetry) {
+              clearGoalMutationIdempotency("delete-goal", stablePart);
+            }
+            setStatus(
+              wasUncertainRetry
+                ? "The retry was rejected, but the earlier deletion is still unconfirmed. Restore access and retry the same action."
+                : "The goal was not deleted. Review the error and try again.",
+              "error",
+            );
             return;
           }
+          markGoalMutationIdempotencyUncertain("delete-goal", stablePart);
           scoreboardState = "uncertain";
           if (isGameFinished()) {
             finishedResultState = "uncertain";

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -841,6 +841,15 @@
     return error instanceof Error && (error.statusCode === 404 || error.statusCode === 405);
   }
 
+  function isDefinitiveRequestRejection(error) {
+    return (
+      error instanceof Error &&
+      Number.isInteger(error.statusCode) &&
+      error.statusCode >= 400 &&
+      error.statusCode < 500
+    );
+  }
+
   async function requestJsonOrThrowWithFallback(primaryPath, fallbackPath, init = {}, validateFallback = null) {
     try {
       return await requestJsonOrThrow(primaryPath, init);
@@ -4380,6 +4389,8 @@
 
         const eventId = editingGoalId;
         const actionLabel = eventId ? "Saving goal edit" : "Adding goal";
+        const previousScoreboardState = scoreboardState;
+        const previousFinishedResultState = finishedResultState;
         setStatus(`${actionLabel}…`, "default");
         goalMutationInFlight = true;
         scoreboardState = "refreshing";
@@ -4404,11 +4415,22 @@
             });
           } catch (error) {
             const message = error instanceof Error ? error.message : "Could not save goal.";
+            showError(message);
+            if (isDefinitiveRequestRejection(error)) {
+              scoreboardState = previousScoreboardState;
+              finishedResultState = previousFinishedResultState;
+              if (eventId) {
+                clearGoalMutationIdempotency("update-goal", `${gameId}-${eventId}`);
+              } else {
+                pendingCreateGoalIdempotency = null;
+              }
+              setStatus("Goal was not saved. Review the error and try again.", "error");
+              return;
+            }
             scoreboardState = "uncertain";
             if (isGameFinished()) {
               finishedResultState = "uncertain";
             }
-            showError(message);
             setStatus(
               "Could not confirm whether the goal was saved. Retry with the same details.",
               "error",
@@ -4496,6 +4518,8 @@
           return;
         }
 
+        const previousScoreboardState = scoreboardState;
+        const previousFinishedResultState = finishedResultState;
         goalMutationInFlight = true;
         scoreboardState = "refreshing";
         if (isGameFinished()) {
@@ -4505,8 +4529,8 @@
         setStatus("Undoing latest goal…", "default");
         renderLiveScoring();
 
+        const stablePart = `${gameId}-${latest.eventId}`;
         try {
-          const stablePart = `${gameId}-${latest.eventId}`;
           const result = await requestJsonOrThrow(`/v1/games/${encodeURIComponent(gameId)}/goals/undo-last`, {
             method: "POST",
             headers: {
@@ -4558,11 +4582,18 @@
           setStatus("Latest goal undone.", "success");
         } catch (error) {
           const message = error instanceof Error ? error.message : "Could not undo latest goal.";
+          showError(message);
+          if (isDefinitiveRequestRejection(error)) {
+            scoreboardState = previousScoreboardState;
+            finishedResultState = previousFinishedResultState;
+            clearGoalMutationIdempotency("undo-goal", stablePart);
+            setStatus("The latest goal was not undone. Review the error and try again.", "error");
+            return;
+          }
           scoreboardState = "uncertain";
           if (isGameFinished()) {
             finishedResultState = "uncertain";
           }
-          showError(message);
           setStatus("Could not confirm the undo. Retry the same action.", "error");
         } finally {
           goalMutationInFlight = false;
@@ -4607,6 +4638,8 @@
           return;
         }
 
+        const previousScoreboardState = scoreboardState;
+        const previousFinishedResultState = finishedResultState;
         goalMutationInFlight = true;
         scoreboardState = "refreshing";
         if (isGameFinished()) {
@@ -4616,8 +4649,8 @@
         setStatus("Deleting goal…", "default");
         renderLiveScoring();
 
+        const stablePart = `${gameId}-${eventId}`;
         try {
-          const stablePart = `${gameId}-${eventId}`;
           const result = await requestJsonOrThrow(
             `/v1/games/${encodeURIComponent(gameId)}/goals/${encodeURIComponent(eventId)}`,
             {
@@ -4662,11 +4695,18 @@
           setStatus("Goal deleted.", "success");
         } catch (error) {
           const message = error instanceof Error ? error.message : "Could not delete goal.";
+          showError(message);
+          if (isDefinitiveRequestRejection(error)) {
+            scoreboardState = previousScoreboardState;
+            finishedResultState = previousFinishedResultState;
+            clearGoalMutationIdempotency("delete-goal", stablePart);
+            setStatus("The goal was not deleted. Review the error and try again.", "error");
+            return;
+          }
           scoreboardState = "uncertain";
           if (isGameFinished()) {
             finishedResultState = "uncertain";
           }
-          showError(message);
           setStatus("Could not confirm the deletion. Retry the same action.", "error");
         } finally {
           goalMutationInFlight = false;

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -2080,6 +2080,7 @@
     let goalTimelineLoaded = false;
     let finishedResultUnavailable = false;
     let editingGoalId = null;
+    let goalMutationInFlight = false;
     let currentLeagueRole = null;
     let manualGameModeSelected = false;
     let pendingCreateGoalIdempotency = null;
@@ -2529,6 +2530,12 @@
     }
 
     function playerNickname(playerId) {
+      if (typeof playerId !== "string" || playerId.length === 0) {
+        return typeof playerId === "number" && Number.isFinite(playerId)
+          ? `Unknown player (invalid ID: ${playerId})`
+          : "Unknown player (invalid ID)";
+      }
+
       const nickname = playerById(playerId)?.nickname;
       if (typeof nickname === "string" && nickname.length > 0) {
         return nickname;
@@ -2920,8 +2927,27 @@
       cancelGoalEditButton.hidden = editingGoalId === null;
       cancelGoalEditButton.disabled = editingGoalId === null;
       undoLastGoalButton.disabled =
-        !goalTimelineLoaded || goalTimeline.length === 0 || (gameFinished && !finishedCorrectionsAllowed);
+        goalMutationInFlight ||
+        !goalTimelineLoaded ||
+        goalTimeline.length === 0 ||
+        (gameFinished && !finishedCorrectionsAllowed);
       undoLastGoalButton.textContent = "Undo last";
+
+      if (goalMutationInFlight) {
+        goalScoringTeamInput.disabled = true;
+        goalConcedingTeamInput.disabled = true;
+        goalOwnGoalInput.disabled = true;
+        goalScorerInput.disabled = true;
+        saveGoalButton.disabled = true;
+        cancelGoalEditButton.disabled = true;
+        for (const input of goalAssistsElement.querySelectorAll("input")) {
+          if (input instanceof HTMLInputElement) {
+            input.disabled = true;
+          }
+        }
+        goalFormNote.textContent = "Saving goal change…";
+        return;
+      }
 
       if (!goalTimelineLoaded) {
         goalScoringTeamInput.disabled = true;
@@ -3015,14 +3041,14 @@
       return `<span data-ui="third-indicator" data-third="${safeThird}" role="img" aria-label="Third ${safeThird} of 3"></span>`;
     }
 
-    function renderGoalTeamChip(teamId) {
+    function renderGoalTeamChip(teamId, relationship = "") {
       const team = teamById(teamId);
       const name = typeof team?.name === "string" && team.name.length > 0
         ? team.name
         : String(teamId ?? "Unknown team");
-      return `<span data-ui="goal-team-chip" data-team-id="${escapeHtml(String(teamId ?? ""))}"${
+      return `<span data-ui="goal-team-chip" role="img" data-team-id="${escapeHtml(String(teamId ?? ""))}"${
         team ? teamSwatchStyle(team) : ""
-      }><span data-ui="team-swatch" aria-hidden="true"></span><span>${escapeHtml(name)}</span></span>`;
+      }${relationship ? ` aria-label="${escapeHtml(`${relationship}: ${name}`)}"` : ""}><span data-ui="team-swatch" aria-hidden="true"></span><span>${escapeHtml(name)}</span></span>`;
     }
 
     function goalDisplayTime(goal) {
@@ -3127,6 +3153,11 @@
         .map((goal) => {
           const detail = finalTeamGoalDetail(goal);
           const includesThird = options.includeThird === true && Number.isInteger(goal.third);
+          const goalTeamSemantics = options.includeThird === true
+            ? goal.ownGoal
+              ? `Own goal. No scoring team. Conceding team: ${teamName(goal.concedingTeamId)}.`
+              : `Scoring team: ${teamName(goal.scoringTeamId)}. Conceding team: ${teamName(goal.concedingTeamId)}.`
+            : "";
           return `<li data-ui="final-goal-item" data-event-id="${escapeHtml(String(goal.eventId ?? ""))}"${
             includesThird ? ' data-has-third="true"' : ""
           }>
@@ -3134,6 +3165,7 @@
             <div>
               <strong>${escapeHtml(finalTeamGoalLabel(goal))}</strong>
               <small>${escapeHtml(detail)}</small>
+              ${goalTeamSemantics ? `<span class="sr-only" data-ui="goal-team-semantics">${escapeHtml(goalTeamSemantics)}</span>` : ""}
             </div>
             ${includesThird ? renderThirdIndicator(goal.third) : ""}
           </li>`;
@@ -3142,13 +3174,12 @@
     }
 
     function incrementPlayerStat(stats, playerId) {
-      const normalizedPlayerId = String(playerId ?? "");
-      if (normalizedPlayerId.length === 0) {
+      if (playerId === null || playerId === undefined || playerId === "") {
         return;
       }
 
-      const existing = stats.get(normalizedPlayerId) ?? 0;
-      stats.set(normalizedPlayerId, existing + 1);
+      const existing = stats.get(playerId) ?? 0;
+      stats.set(playerId, existing + 1);
     }
 
     function sortedPlayerStats(stats) {
@@ -3256,7 +3287,8 @@
       }
 
       const latestEventId = goalTimeline.at(-1)?.eventId ?? null;
-      const finishedActionsDisabled = isGameFinished() && !canCorrectFinishedGoals();
+      const finishedActionsDisabled =
+        goalMutationInFlight || (isGameFinished() && !canCorrectFinishedGoals());
       const disabledAttribute = finishedActionsDisabled ? " disabled" : "";
       goalTimelineElement.innerHTML = [...goalTimeline]
         .reverse()
@@ -3271,7 +3303,7 @@
           const eventId = String(goal.eventId ?? "");
           const scoringContext = goal.ownGoal
             ? `<span data-ui="own-goal-marker" aria-label="Own goal">OG</span>`
-            : renderGoalTeamChip(goal.scoringTeamId);
+            : renderGoalTeamChip(goal.scoringTeamId, "Scoring team");
           return `<li data-ui="goal-event" data-event-id="${escapeHtml(eventId)}"${
             latest ? ' data-state="latest"' : ""
           }>
@@ -3281,7 +3313,7 @@
                 <span data-ui="goal-scorer">${escapeHtml(scorer)}</span>
                 ${scoringContext}
                 <span data-ui="goal-team-arrow" aria-hidden="true">→</span>
-                ${renderGoalTeamChip(goal.concedingTeamId)}
+                ${renderGoalTeamChip(goal.concedingTeamId, "Conceding team")}
                 ${renderThirdIndicator(goal.third)}
               </div>
               <small>Assists: ${escapeHtml(assists)}</small>
@@ -4301,7 +4333,7 @@
       });
 
       saveGoalButton.addEventListener("click", async () => {
-        if (isGameFinished() && !canCorrectFinishedGoals()) {
+        if (goalMutationInFlight || (isGameFinished() && !canCorrectFinishedGoals())) {
           renderLiveScoring();
           return;
         }
@@ -4314,80 +4346,84 @@
           return;
         }
 
-        saveGoalButton.disabled = true;
         const eventId = editingGoalId;
         const actionLabel = eventId ? "Saving goal edit" : "Adding goal";
         setStatus(`${actionLabel}…`, "default");
+        goalMutationInFlight = true;
+        renderLiveScoring();
 
-        let result;
         try {
           const path = eventId
             ? `/v1/games/${encodeURIComponent(gameId)}/goals/${encodeURIComponent(eventId)}`
             : `/v1/games/${encodeURIComponent(gameId)}/goals`;
-          result = await requestJsonOrThrow(path, {
-            method: eventId ? "PATCH" : "POST",
-            headers: {
-              "Content-Type": "application/json",
-              "Idempotency-Key": idempotencyKeyForGoalSave(eventId, draft.payload),
-            },
-            body: JSON.stringify(draft.payload),
-          });
-        } catch (error) {
-          const message = error instanceof Error ? error.message : "Could not save goal.";
-          showError(message);
-          setStatus("Goal save failed.", "error");
-          saveGoalButton.disabled = false;
-          renderLiveScoring();
-          return;
-        }
-
-        if (isGameFinished()) {
-          finishedResultUnavailable = true;
-        }
-        applyGoalMutationResult(result);
-        if (eventId) {
-          clearGoalMutationIdempotency("update-goal", `${gameId}-${eventId}`);
-        } else {
-          pendingCreateGoalIdempotency = null;
-        }
-        resetGoalForm();
-
-        if (eventId) {
-          const goalsLoaded = await loadGameGoals();
-          if (!goalsLoaded) {
-            showError("Goal update was saved, but the latest goal state could not be loaded.");
-            setStatus("Goal updated; timeline refresh failed.", "success");
-            saveGoalButton.disabled = false;
-            renderLiveScoring();
+          let result;
+          try {
+            result = await requestJsonOrThrow(path, {
+              method: eventId ? "PATCH" : "POST",
+              headers: {
+                "Content-Type": "application/json",
+                "Idempotency-Key": idempotencyKeyForGoalSave(eventId, draft.payload),
+              },
+              body: JSON.stringify(draft.payload),
+            });
+          } catch (error) {
+            const message = error instanceof Error ? error.message : "Could not save goal.";
+            showError(message);
+            setStatus("Goal save failed.", "error");
             return;
           }
-        }
 
-        const gameRefreshed = await refreshGameAfterFinishedCorrection();
-        if (!gameRefreshed) {
-          showError(
-            eventId
-              ? "Goal was updated, but the finished result could not be refreshed."
-              : "Goal was added, but the finished result could not be refreshed.",
-          );
-          setStatus(eventId ? "Goal updated; result refresh failed." : "Goal added; result refresh failed.", "success");
-          saveGoalButton.disabled = false;
+          if (isGameFinished()) {
+            finishedResultUnavailable = true;
+          }
+          applyGoalMutationResult(result);
+          if (eventId) {
+            clearGoalMutationIdempotency("update-goal", `${gameId}-${eventId}`);
+          } else {
+            pendingCreateGoalIdempotency = null;
+          }
+          resetGoalForm();
+
+          if (eventId) {
+            const goalsLoaded = await loadGameGoals();
+            if (!goalsLoaded) {
+              showError("Goal update was saved, but the latest goal state could not be loaded.");
+              setStatus("Goal updated; timeline refresh failed.", "success");
+              return;
+            }
+          }
+
+          const gameRefreshed = await refreshGameAfterFinishedCorrection();
+          if (!gameRefreshed) {
+            showError(
+              eventId
+                ? "Goal was updated, but the finished result could not be refreshed."
+                : "Goal was added, but the finished result could not be refreshed.",
+            );
+            setStatus(
+              eventId ? "Goal updated; result refresh failed." : "Goal added; result refresh failed.",
+              "success",
+            );
+            return;
+          }
+
+          setStatus(eventId ? "Goal updated." : "Goal added.", "success");
+        } finally {
+          goalMutationInFlight = false;
           renderLiveScoring();
-          return;
         }
-
-        setStatus(eventId ? "Goal updated." : "Goal added.", "success");
-        saveGoalButton.disabled = false;
-        renderLiveScoring();
       });
 
       cancelGoalEditButton.addEventListener("click", () => {
+        if (goalMutationInFlight) {
+          return;
+        }
         resetGoalForm();
         setStatus("Goal edit cancelled.", "default");
       });
 
       undoLastGoalButton.addEventListener("click", async () => {
-        if (isGameFinished() && !canCorrectFinishedGoals()) {
+        if (goalMutationInFlight || (isGameFinished() && !canCorrectFinishedGoals())) {
           renderLiveScoring();
           return;
         }
@@ -4397,9 +4433,10 @@
           return;
         }
 
-        undoLastGoalButton.disabled = true;
+        goalMutationInFlight = true;
         clearError();
         setStatus("Undoing latest goal…", "default");
+        renderLiveScoring();
 
         try {
           const stablePart = `${gameId}-${latest.eventId}`;
@@ -4431,7 +4468,7 @@
           showError(message);
           setStatus("Goal undo failed.", "error");
         } finally {
-          undoLastGoalButton.disabled = false;
+          goalMutationInFlight = false;
           renderLiveScoring();
         }
       });
@@ -4458,7 +4495,7 @@
           return;
         }
 
-        if (isGameFinished() && !canCorrectFinishedGoals()) {
+        if (goalMutationInFlight || (isGameFinished() && !canCorrectFinishedGoals())) {
           renderLiveScoring();
           return;
         }
@@ -4473,9 +4510,10 @@
           return;
         }
 
-        target.disabled = true;
+        goalMutationInFlight = true;
         clearError();
         setStatus("Deleting goal…", "default");
+        renderLiveScoring();
 
         try {
           const stablePart = `${gameId}-${eventId}`;
@@ -4506,7 +4544,7 @@
           showError(message);
           setStatus("Goal deletion failed.", "error");
         } finally {
-          target.disabled = false;
+          goalMutationInFlight = false;
           renderLiveScoring();
         }
       });

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -3742,7 +3742,7 @@
         : [];
       rosterAssignments = Array.isArray(rosterPayload?.roster) ? rosterPayload.roster : [];
       rosterPlayers = Array.isArray(playersPayload?.players) ? playersPayload.players : [];
-      if (scoreboardTeams.length === 0 || goalTimeline.length === 0) {
+      if (scoreboardTeams.length === 0 || (goalTimeline.length === 0 && !isGameFinished())) {
         scoreboardTeams = normalizeScoreboardTeams(rosterTeams);
       }
       renderRosterSetup();
@@ -3789,6 +3789,9 @@
 
       currentGame = game;
       finishedResultUnavailable = false;
+      if (game.status === "finished" && Array.isArray(game.result?.teams)) {
+        scoreboardTeams = normalizeScoreboardTeams(game.result.teams);
+      }
       currentLeagueId = game.leagueId;
       currentSeasonId = game.seasonId;
 
@@ -4397,7 +4400,7 @@
             } else if (finishedCorrection) {
               showError("Goal details could not be loaded. Reload to try again.");
               setStatus(
-                "Goal updated. Match Summary refreshed; goal timeline unavailable.",
+                "Goal updated. Scores refreshed; goal timeline unavailable.",
                 "default",
               );
             } else {

--- a/app/src/ui/styles.css
+++ b/app/src/ui/styles.css
@@ -765,6 +765,7 @@ body {
     display: grid;
     gap: 0.1rem;
 
+    h2,
     h3 {
       margin: 0;
       font-size: 1rem;
@@ -1022,6 +1023,10 @@ body {
   border-radius: 8px;
   background: #ffffff;
 
+  &[data-has-third="true"] {
+    grid-template-columns: 3rem minmax(0, 1fr) auto;
+  }
+
   [data-ui="goal-time"] {
     border-radius: 999px;
     background: #edf6f2;
@@ -1046,6 +1051,27 @@ body {
   small {
     color: var(--ink-soft);
     font-size: 0.76rem;
+  }
+}
+
+[data-ui="final-summary-status"] {
+  margin: 0;
+
+  div {
+    display: flex;
+    align-items: baseline;
+    gap: 0.4rem;
+  }
+
+  dt {
+    color: var(--ink-soft);
+    font-size: 0.78rem;
+    font-weight: 800;
+  }
+
+  dd {
+    margin: 0;
+    font-weight: 850;
   }
 }
 
@@ -1460,14 +1486,103 @@ body {
   }
 }
 
-[data-ui="latest-flag"] {
-  align-self: center;
+[data-ui="goal-primary-row"] {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+  min-width: 0;
+
+  [data-ui="goal-time"],
+  [data-ui="goal-scorer"] {
+    font-weight: 850;
+  }
+
+  [data-ui="third-indicator"] {
+    margin-left: auto;
+  }
+}
+
+[data-ui="goal-team-chip"] {
+  --team-color: #8db8a9;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.28rem;
+  border: 1px solid var(--team-color);
   border-radius: 999px;
-  padding: 0.22rem 0.5rem;
-  background: #ffffff;
-  color: var(--accent-strong);
-  font-size: 0.72rem;
+  padding: 0.18rem 0.48rem;
+  background: color-mix(in srgb, var(--team-color) 15%, white);
+  color: var(--ink-strong);
+  font-size: 0.76rem;
   font-weight: 850;
+
+  [data-ui="team-swatch"] {
+    width: 0.62rem;
+    height: 0.62rem;
+    border-radius: 999px;
+    background: var(--team-color);
+    box-shadow: inset 0 0 0 1px rgba(29, 42, 47, 0.2);
+  }
+}
+
+[data-ui="goal-team-arrow"] {
+  color: var(--ink-soft);
+  font-weight: 900;
+}
+
+[data-ui="own-goal-marker"] {
+  border: 1px solid #b7c7c2;
+  border-radius: 999px;
+  padding: 0.14rem 0.42rem;
+  background: #eef2f1;
+  color: #4b5f5b;
+  font-size: 0.72rem;
+  font-weight: 900;
+}
+
+[data-ui="third-indicator"] {
+  --third-active: #0b7867;
+  --third-idle: #d8e5e1;
+  display: inline-block;
+  flex: 0 0 auto;
+  width: 1.35rem;
+  height: 1.35rem;
+  border: 1px solid #9fb9b1;
+  border-radius: 999px;
+  background:
+    conic-gradient(
+      from -90deg,
+      transparent 0deg 118deg,
+      #fff 118deg 122deg,
+      transparent 122deg 238deg,
+      #fff 238deg 242deg,
+      transparent 242deg 358deg,
+      #fff 358deg 360deg
+    ),
+    conic-gradient(
+      from -90deg,
+      var(--third-one) 0deg 120deg,
+      var(--third-two) 120deg 240deg,
+      var(--third-three) 240deg 360deg
+    );
+
+  &[data-third="1"] {
+    --third-one: var(--third-active);
+    --third-two: var(--third-idle);
+    --third-three: var(--third-idle);
+  }
+
+  &[data-third="2"] {
+    --third-one: var(--third-idle);
+    --third-two: var(--third-active);
+    --third-three: var(--third-idle);
+  }
+
+  &[data-third="3"] {
+    --third-one: var(--third-idle);
+    --third-two: var(--third-idle);
+    --third-three: var(--third-active);
+  }
 }
 
 [data-ui="table-wrap"] {

--- a/tests/e2e/m2-smoke.spec.ts
+++ b/tests/e2e/m2-smoke.spec.ts
@@ -938,7 +938,13 @@ test.describe("M2 local-stack smoke", () => {
 
       const magicLink = await waitForMagicLink(email);
       await page.goto(magicLink);
-      await page.waitForURL("**/setup");
+      await expect(page.getByTestId("auth-callback-shell")).toBeVisible();
+      const completeMagicLinkButton = page.getByTestId("complete-magic-link");
+      await expect(completeMagicLinkButton).toBeVisible();
+      await Promise.all([
+        page.waitForURL("**/setup"),
+        completeMagicLinkButton.click(),
+      ]);
       await expect(page.getByTestId("setup-shell")).toBeVisible();
 
       await page.locator("#league-name").fill(leagueName);
@@ -1074,9 +1080,12 @@ test.describe("M2 local-stack smoke", () => {
       await expect(page.getByTestId("final-team-log-red")).toContainText(ariNickname);
       await expect(page.getByTestId("final-scorer-stats").locator("li").filter({ hasText: ariNickname })).toContainText("1");
       await expect(page.getByTestId("final-assist-stats").locator("li").filter({ hasText: beaNickname })).toContainText("1");
-      await expect(page.getByTestId("final-full-goal-log")).toContainText(ariNickname);
-      await expect(page.getByTestId("final-full-goal-log").locator('[data-ui="third-indicator"][aria-label="Third 1 of 3"]')).toBeVisible();
-      await expect(page.getByTestId("final-full-goal-log")).not.toContainText("Third 1");
+      const fullGoalLog = page.getByTestId("final-full-goal-log");
+      await expect(fullGoalLog).toContainText(ariNickname);
+      await fullGoalLog.locator("summary").click();
+      await expect(fullGoalLog).toHaveAttribute("open", "");
+      await expect(fullGoalLog.locator('[data-ui="third-indicator"][aria-label="Third 1 of 3"]')).toBeVisible();
+      await expect(fullGoalLog).not.toContainText("Third 1");
       await expect(page.locator("#game-edit-status")).toHaveValue("finished");
       await expect(page.getByTestId("finish-game")).toBeDisabled();
       await expect(page.getByTestId("finish-game")).toHaveText("Game finished");
@@ -1085,6 +1094,13 @@ test.describe("M2 local-stack smoke", () => {
       await expect(page.getByTestId("quick-create-player")).toBeEnabled();
       await expectAllEnabled(page.locator('[data-action="assign-player"]'));
       await selectGameMode(page, "run");
+      await expect(page.locator("#goal-scoring-team")).toHaveValue("");
+      await expect(page.locator("#goal-conceding-team")).toBeDisabled();
+      await expect(page.locator("#goal-scorer")).toBeDisabled();
+      await expect(page.getByTestId("add-goal")).toBeDisabled();
+      await page.locator("#goal-scoring-team").selectOption("red");
+      await page.locator("#goal-conceding-team").selectOption("blue");
+      await page.locator("#goal-scorer").selectOption(ariPlayerId);
       await expect(page.getByTestId("add-goal")).toBeEnabled();
       await expect(page.locator("#goal-form-note")).not.toContainText("final whistle");
       await expect(page.locator('[data-action="edit-goal"]').first()).toBeEnabled();

--- a/tests/e2e/m2-smoke.spec.ts
+++ b/tests/e2e/m2-smoke.spec.ts
@@ -1036,10 +1036,19 @@ test.describe("M2 local-stack smoke", () => {
       await page.locator(`#goal-assists input[value="${beaPlayerId}"]`).check();
       await page.getByTestId("add-goal").click();
 
-      await expect(page.getByTestId("goal-timeline")).toContainText(`${ariNickname} for Red`);
+      await expect(page.getByTestId("goal-timeline")).toContainText(ariNickname);
+      await expect(page.getByTestId("goal-timeline").locator('[data-ui="goal-team-chip"][data-team-id="red"]')).toContainText("Red");
+      await expect(page.getByTestId("goal-timeline").locator('[data-ui="goal-team-chip"][data-team-id="blue"]')).toContainText("Blue");
       await expect(page.getByTestId("goal-timeline")).toContainText(`Assists: ${beaNickname}`);
+      await expect(page.getByTestId("goal-timeline").locator('[data-ui="third-indicator"][aria-label="Third 1 of 3"]')).toBeVisible();
+      await expect(page.locator("#goal-scoring-team")).toHaveValue("");
+      await expect(page.locator("#goal-conceding-team")).toHaveValue("");
+      await expect(page.locator("#goal-scorer")).toHaveValue("");
       await expect(page.locator('[data-ui="score-team"][data-team-id="red"]')).toContainText(/Scored\s*1/);
       await expect(page.locator('[data-ui="score-team"][data-team-id="blue"]')).toContainText(/Conceded\s*1/);
+      expect(
+        await page.locator('[data-ui="score-team"][data-team-id="red"] dt').allTextContents(),
+      ).toEqual(["Conceded", "Scored"]);
 
       await finishThird(page, 1);
       await startThird(page, 2);
@@ -1052,7 +1061,11 @@ test.describe("M2 local-stack smoke", () => {
       await page.getByTestId("finish-game").click();
 
       await expect(page.getByTestId("game-result-summary")).toBeVisible();
+      await expect(page.getByTestId("panel-game-final").getByRole("heading", { name: "Match Summary" })).toBeVisible();
+      await expect(page.getByTestId("finalisation-context").locator("dt")).toHaveText("Status");
+      await expect(page.getByTestId("finalisation-context")).not.toContainText(/Game|Timeline/);
       await expect(page.getByTestId("game-result-outcome")).toHaveText("Red win");
+      await expect(page.getByTestId("game-result-summary")).not.toContainText("Computed");
       const resultTeams = page.getByTestId("game-result-teams");
       await expect(resultTeams.locator('[data-ui="result-team"][data-team-id="red"]')).toContainText(/Conceded\s*0/);
       await expect(resultTeams.locator('[data-ui="result-team"][data-team-id="red"]')).toContainText(/Scored\s*1/);
@@ -1062,6 +1075,8 @@ test.describe("M2 local-stack smoke", () => {
       await expect(page.getByTestId("final-scorer-stats").locator("li").filter({ hasText: ariNickname })).toContainText("1");
       await expect(page.getByTestId("final-assist-stats").locator("li").filter({ hasText: beaNickname })).toContainText("1");
       await expect(page.getByTestId("final-full-goal-log")).toContainText(ariNickname);
+      await expect(page.getByTestId("final-full-goal-log").locator('[data-ui="third-indicator"][aria-label="Third 1 of 3"]')).toBeVisible();
+      await expect(page.getByTestId("final-full-goal-log")).not.toContainText("Third 1");
       await expect(page.locator("#game-edit-status")).toHaveValue("finished");
       await expect(page.getByTestId("finish-game")).toBeDisabled();
       await expect(page.getByTestId("finish-game")).toHaveText("Game finished");
@@ -1071,7 +1086,7 @@ test.describe("M2 local-stack smoke", () => {
       await expectAllEnabled(page.locator('[data-action="assign-player"]'));
       await selectGameMode(page, "run");
       await expect(page.getByTestId("add-goal")).toBeEnabled();
-      await expect(page.locator("#goal-form-note")).toContainText("final whistle");
+      await expect(page.locator("#goal-form-note")).not.toContainText("final whistle");
       await expect(page.locator('[data-action="edit-goal"]').first()).toBeEnabled();
       await expect(page.locator('[data-action="delete-goal"]').first()).toBeEnabled();
       await expect(page.getByTestId("undo-last-goal")).toBeEnabled();


### PR DESCRIPTION
<!-- review-packet-version:1 -->

## Behavioural claim

Live scoring now starts each goal from a deliberate blank state, presents scored and conceded semantics consistently, and turns the finished-game view into a compact Match Summary with accessible team and thirds indicators without changing scoring computations.

## Specification and acceptance evidence

| Acceptance criterion | Evidence | Result |
| --- | --- | --- |
| Run view renders Conceded before Scored without changing stored totals or winner semantics | `app/src/tests/setup-flow-e2e.test.ts` live-flow and final-result assertions; INV-005 disposition below | PASS |
| Goal create/edit clears all selectors, own-goal state, and assists after commit, including when a later result refresh fails | Successful create/edit and committed-refresh-failure scenarios in `setup-flow-e2e.test.ts` | PASS |
| Failed goal requests preserve the complete draft and idempotency key for retry | Create and edit failure/retry scenarios covering team, scorer, assist, own-goal, payload, and key reuse | PASS |
| Latest goals show time, scorer, scoring/conceding chips or OG marker, compact actions, and an accessible thirds indicator | Standard, own-goal, stoppage-time, malformed-identity, icon-child, and all-thirds scenarios | PASS |
| Final mode is a Match Summary with no game ID, readiness/timeline/computed chatter, while retaining result totals, stats, and full match log | Layout assertions plus finished-game JSDOM scenarios | PASS |
| Local deterministic validation on current head `b5abb63` | `npm run lint`; `npm test` (269 API, 91 app, 57 review-gate); `npm run contracts:check` | PASS |
| Resource-controlled real-stack browser smoke | `env THREEFC_SKIP_WEB_SERVER=1 npm run smoke:m2:playwright` after serial local-stack startup: 4/4 PASS | PASS |
| Independent UX, engineering, and quality review | Read-only audit rounds completed; material findings fixed and re-audited with no remaining material source issue | PASS |
| Signed-in QA with the exact PR3 head deployed through top-of-stack `5dea5fa` | At 323px/389px/479px/845px the finished game shows authoritative Run totals, Conceded-before-Scored, blank dependent goal controls, named scoring/conceding/own-goal relationships, aligned thirds, Match Summary totals/stats, removed chatter, and zero overflow. The exact deployed 479px pass rechecked dashboard, league, season, game, players, Run, and Final without errors. Controller-only uncertain-response/replay branches are covered deterministically rather than faulting shared QA. | PASS |

## Scope boundaries

Included:

- Run-view score ordering, goal-form dependency/reset/retry behavior, and concise operational copy.
- Latest-goal team chips, own-goal marker, Iconify actions, and CSS thirds visualization.
- Match Summary result, player statistics, team logs, and full match log presentation.
- Focused JSDOM/layout coverage and exact-flow Playwright smoke updates.

Excluded:

- REST/OpenAPI contracts, authentication, permissions, durable data, and deployment configuration.
- Score, winner, own-goal, assist, or season-stat computation changes.
- Management/player density refinements, which are isolated in the child PR.

## Change classification

- Declared risk: `medium`
- [ ] `documentation-only` — Documentation only
- [ ] `tests-only` — Tests only
- [x] `application-behaviour` — Application or API behaviour
- [ ] `backlog-maintenance` — Canonical backlog maintenance
- [ ] `dependency-tooling` — Dependency or tooling
- [ ] `public-contract` — Public API or repository contract
- [ ] `data-migration` — Database schema or data migration
- [ ] `permission-trust-boundary` — Permission or trust boundary
- [ ] `durable-state-ownership` — Durable state or ownership
- [ ] `destructive-behaviour` — Destructive or difficult-to-reverse behaviour
- [ ] `new-production-dependency` — New production dependency
- [ ] `authentication-authorisation` — Authentication or authorisation
- [ ] `privacy-regulated-data` — Privacy or regulated data
- [ ] `infrastructure-production-configuration` — Infrastructure or deployment control
- [ ] `review-policy` — Review policy, packet, or workflow

## Architecture and invariants

- [ ] `architecture:none`
- [x] `architecture:documented`
- [ ] `architecture:judgement-required`

### Affected invariants

| Invariant | How this PR affects it | Why it remains valid | Evidence |
| --- | --- | --- | --- |
| INV-005 | Changes the presentation order of each team's `conceded` and `scored` values and the rendering of own-goal events. | Computation and persisted values are untouched: own goals still increment conceded only, normal goals retain distinct scoring/conceding teams, and winner comparison remains fewest conceded then most scored. | Live-flow, normal-goal, own-goal, winner, draw, malformed-result, and final aggregate assertions in `setup-flow-e2e.test.ts`; real-stack M2 completion smoke. |

### Architecture or decision record

No ADR is required. UI rendering and form-state transitions change within the existing app boundary; API ownership, score computation, permissions, routes, and durable state remain unchanged.

## Failure and rollback

### Failure behaviour

Validation and fresh definitive 4xx rejections preserve the existing authoritative score/result surfaces and retain the editable draft or mutation target while retiring the rejected key. Transport/5xx failures preserve the exact idempotency key for safe replay and suppress potentially stale Run/Match Summary values. If an unchanged replay is temporarily rejected with 4xx after an earlier ambiguous response, the client preserves both the uncertain state and the same key rather than reopening the mutation. Every confirmed/replayed create, update, delete, or undo performs an authoritative goals refresh before retry ownership is retired; successful goal/result refreshes independently restore only their authoritative surfaces.

### Rollback approach

Revert the PR3 commit range ending at `b5abb63`; no schema, contract, dependency, or data rollback is required.

### Rollback evidence

The exact current content passed lint, full repository tests, contracts, and review-gate tests. The unchanged presentation path passed the resource-controlled real-stack Playwright M2 smoke and signed-in responsive QA; controller-only replay/failure branches are covered by focused deterministic regressions.

## Automated and agent review disposition

### Unresolved blocking findings

None.

### Rejected findings and evidence

None.

All material audit findings were implemented and re-audited, including complete draft retention, serialized correction/result-refresh ownership, authoritative reconciliation after every replayable mutation, idempotency-key retirement after successful reconciliation or fresh definitive rejection, same-key retention through 503/transport ambiguity followed by a temporary 4xx, preservation of authoritative surfaces after fresh rejected 4xx mutations, independent timeline/result partial-failure handling, authoritative agreement between Run and Match Summary under stale replay/initial-load failures, post-commit stale-result suppression, typed malformed-identity aggregation, valid landmark naming, explicit scoring/conceding accessibility semantics, own-goal chip semantics, and disclosure-aware Playwright evidence.

## Human judgement

- [x] `human-judgement:none`
- [ ] `human-judgement:required`

### Decision requiring judgement

None.

### Options considered

None.

### Reason selected

None.

### Reversal cost

None.

## Review focus

Please focus on INV-005 score semantics, complete goal-draft reset/retry ownership, committed-write/result-refresh partial failure, own-goal presentation, malformed identity handling, accessible thirds indicators, and the final-log disclosure path.
