### PR TITLE
feat(app): refine live goal controls

### DIFF
--- a/app/src/tests/server.test.ts
+++ b/app/src/tests/server.test.ts
@@ -100,6 +100,14 @@ test("stylesheet route serves external UI css", () => {
   assert.match(response.body, /\[data-testid="league-seasons-table"\]/);
   assert.match(response.body, /\[data-testid="season-upcoming-games-table"\]/);
   assert.match(response.body, /\[data-testid="season-completed-games-table"\]/);
+  assert.match(
+    response.body,
+    /\[data-ui="assist-summary"\]\s*\{[^}]*overflow-wrap:\s*anywhere;[^}]*white-space:\s*normal;/s,
+  );
+  assert.doesNotMatch(
+    response.body,
+    /\[data-ui="assist-summary"\]\s*\{[^}]*text-overflow:\s*ellipsis;/s,
+  );
   assert.match(response.body, /&:hover/);
 });
 

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -3751,8 +3751,10 @@ test("game roster transfer remains open after assignment failure", async () => {
   assert(malformedRedChip instanceof page.window.HTMLButtonElement);
   assert(validBlueRoster instanceof page.window.HTMLElement);
   assert(spacedIdTransfer instanceof page.window.HTMLButtonElement);
-  assert.equal(malformedRedRoster.hasAttribute("style"), false);
-  assert.equal(malformedRedChip.hasAttribute("style"), false);
+  assert.match(malformedRedRoster.getAttribute("style") ?? "", /^--team-color: #[0-9a-f]{6}$/i);
+  assert.match(malformedRedChip.getAttribute("style") ?? "", /^--team-color: #[0-9a-f]{6}$/i);
+  assert.doesNotMatch(malformedRedRoster.getAttribute("style") ?? "", /javascript:/i);
+  assert.doesNotMatch(malformedRedChip.getAttribute("style") ?? "", /javascript:/i);
   assert.match(validBlueRoster.getAttribute("style") ?? "", /--team-color: #2364d2/);
   assert.equal(spacedIdTransfer.getAttribute("aria-controls"), "transfer-options-player%20one");
   assert(page.document.getElementById("transfer-options-player%20one"));
@@ -4597,7 +4599,7 @@ test("game page converts partial goal times into full-match football notation", 
   assert.match(fullGoalLog.textContent ?? "", /75\+3"/);
   const latestGoal = timeline.querySelector('[data-ui="goal-event"][data-state="latest"]');
   assert(latestGoal instanceof page.window.HTMLElement);
-  assert.match(latestGoal.textContent ?? "", /75\+3"\s*Bea\s*OG\s*→\s*Red/);
+  assert.match(latestGoal.textContent ?? "", /75\+3"\s*Bea\s*OG\s*→/);
   assert.equal(latestGoal.querySelectorAll('[data-ui="goal-team-chip"]').length, 1);
   assert(latestGoal.querySelector('[data-ui="goal-team-chip"][data-team-id="red"]'));
   assert(latestGoal.querySelector('[data-ui="third-indicator"][data-third="3"][aria-label="Third 3 of 3"]'));
@@ -5672,7 +5674,7 @@ test("game page reuses correction idempotency keys for unchanged retries", async
     scoringTeamId: "red",
     concedingTeamId: "blue",
     scorerPlayerId: "player-ari",
-    assistPlayerIds: [],
+    assistPlayerIds: ["player-bea", "player-cy"],
     ownGoal: false,
     createdAt: "2026-03-28T11:01:01.000Z",
     updatedAt: "2026-03-28T11:01:01.000Z",
@@ -5756,37 +5758,39 @@ test("game page reuses correction idempotency keys for unchanged retries", async
 
   const saveGoalButton = page.document.querySelector('[data-action="save-goal"]');
   const undoLastGoalButton = page.document.querySelector('[data-action="undo-last-goal"]');
-  const ownGoalInput = page.document.getElementById("goal-own-goal");
-  const concedingTeamInput = page.document.getElementById("goal-conceding-team");
-  const scorerInput = page.document.getElementById("goal-scorer");
+  const assistsDropdown = page.document.getElementById("goal-assists-dropdown");
+  const assistsSummary = page.document.getElementById("goal-assists-summary");
   assert(saveGoalButton instanceof page.window.HTMLButtonElement);
   assert(undoLastGoalButton instanceof page.window.HTMLButtonElement);
-  assert(ownGoalInput instanceof page.window.HTMLInputElement);
-  assert(concedingTeamInput instanceof page.window.HTMLSelectElement);
-  assert(scorerInput instanceof page.window.HTMLSelectElement);
+  assert(assistsDropdown instanceof page.window.HTMLDetailsElement);
+  assert(assistsSummary instanceof page.window.HTMLElement);
 
   const editGoalButton = page.document.querySelector('[data-action="edit-goal"][data-event-id="goal-1"]');
   assert(editGoalButton instanceof page.window.HTMLButtonElement);
   dispatchClick(editGoalButton);
   await flushAsync();
-  ownGoalInput.checked = true;
-  ownGoalInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
-  concedingTeamInput.value = "blue";
-  concedingTeamInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
-  scorerInput.value = "player-cy";
-  scorerInput.dispatchEvent(new page.window.Event("change", { bubbles: true }));
+  assert.equal(assistsDropdown.open, false);
+  assert.equal(assistsSummary.textContent, "Bea, Cy");
+  assert.equal(assistsSummary.getAttribute("title"), "Bea, Cy");
+  assert.equal(page.document.querySelectorAll('#goal-assists input[type="checkbox"]:checked').length, 2);
+  assistsDropdown.open = true;
   dispatchClick(saveGoalButton);
   await flushAsync();
-  assert.equal(ownGoalInput.checked, true);
-  assert.equal(concedingTeamInput.value, "blue");
-  assert.equal(scorerInput.value, "player-cy");
+  assert.equal(assistsDropdown.open, true);
+  assert.equal(assistsSummary.textContent, "Bea, Cy");
+  assert.equal(assistsSummary.getAttribute("title"), "Bea, Cy");
+  assert.equal(page.document.querySelectorAll('#goal-assists input[type="checkbox"]:checked').length, 2);
   dispatchClick(saveGoalButton);
   await flushAsync();
 
   assert.equal(updateKeys.length, 2);
   assert.ok(updateKeys[0]);
   assert.equal(updateKeys[0], updateKeys[1]);
-  assert.equal(apiState.goalEvents.get("goal-1")?.ownGoal, true);
+  assert.equal(apiState.goalEvents.get("goal-1")?.ownGoal, false);
+  assert.equal(assistsDropdown.open, false);
+  assert.equal(assistsSummary.textContent, "Choose assists");
+  assert.equal(assistsSummary.hasAttribute("title"), false);
+  assert.equal(page.document.querySelectorAll('#goal-assists input[type="checkbox"]:checked').length, 0);
 
   const deleteGoalButton = page.document.querySelector('[data-action="delete-goal"][data-event-id="goal-1"]');
   assert(deleteGoalButton instanceof page.window.HTMLButtonElement);
@@ -6056,7 +6060,7 @@ test("game page reconciles current goals after stale correction replay", async (
   await flushAsync();
 
   assert.equal(patchCalls, 2);
-  assert.match(timeline.textContent ?? "", /Cy\s*Blue\s*→\s*Red/);
+  assert.match(timeline.textContent ?? "", /Cy\s*→/);
 });
 
 test("game page invalidates current goals when correction replay refresh fails", async () => {
@@ -6164,7 +6168,7 @@ test("game page invalidates current goals when correction replay refresh fails",
   assert(scoringTeamInput instanceof page.window.HTMLSelectElement);
   assert(concedingTeamInput instanceof page.window.HTMLSelectElement);
   assert(scorerInput instanceof page.window.HTMLSelectElement);
-  assert.match(timeline.textContent ?? "", /Cy\s*Blue\s*→\s*Red/);
+  assert.match(timeline.textContent ?? "", /Cy\s*→/);
 
   dispatchClick(editGoalButton);
   await flushAsync();
@@ -6175,7 +6179,7 @@ test("game page invalidates current goals when correction replay refresh fails",
   assert.match(status.textContent ?? "", /Goal updated; scores and timeline unavailable/);
   assert.equal(status.hasAttribute("data-state"), false);
   assert.match(timeline.textContent ?? "", /Goal timeline unavailable/);
-  assert.doesNotMatch(timeline.textContent ?? "", /Cy\s*Blue\s*→\s*Red/);
+  assert.doesNotMatch(timeline.textContent ?? "", /Cy\s*→/);
   assert.match(scoreboard.textContent ?? "", /Scores unavailable/);
   assert.equal(scoreboard.querySelector('[data-ui="score-team"]'), null);
   assert.equal(scoringTeamInput.value, "");
@@ -6464,9 +6468,9 @@ test("game page renders malformed result data without crashing", async () => {
     resultSummary.querySelector('[data-ui="result-team"][data-team-id="red"] strong')?.textContent,
     "red",
   );
-  assert.equal(
-    resultSummary.querySelector('[data-ui="result-team"][data-team-id="red"]')?.hasAttribute("style"),
-    false,
+  assert.match(
+    resultSummary.querySelector('[data-ui="result-team"][data-team-id="red"]')?.getAttribute("style") ?? "",
+    /^--team-color: #[0-9a-f]{6}$/i,
   );
   assert.doesNotMatch(resultSummary.innerHTML, /javascript:/);
 });
@@ -6489,6 +6493,13 @@ test("game page renders malformed goal identity values without crashing", async 
   const malformedRedTeam = apiState.gameTeams.get("game-malformed-goal:red");
   assert(malformedRedTeam);
   malformedRedTeam.name = 123 as unknown as string;
+  malformedRedTeam.color = "javascript:alert(1)";
+  apiState.gameTeams.set("game-malformed-goal:constructor", {
+    ...malformedRedTeam,
+    teamId: "constructor" as TeamId,
+    name: "Constructor",
+    color: null,
+  });
   for (const player of [
     { playerId: "99", nickname: "Valid 99" },
     { playerId: "17", nickname: "Valid 17" },
@@ -6523,7 +6534,7 @@ test("game page renders malformed goal identity values without crashing", async 
     stoppageMinute: null,
     displayTime: "1'",
     scoringTeamId: "red",
-    concedingTeamId: 42,
+    concedingTeamId: "constructor",
     scorerPlayerId: 99,
     assistPlayerIds: [17],
     ownGoal: false,
@@ -6566,10 +6577,18 @@ test("game page renders malformed goal identity values without crashing", async 
   assert(fullGoalLog instanceof page.window.HTMLElement);
   assert(scorerStats instanceof page.window.HTMLElement);
   assert(assistStats instanceof page.window.HTMLElement);
-  assert.match(goal.textContent ?? "", /Unknown player \(invalid ID: 99\)\s*red\s*→\s*42/);
+  assert.match(goal.textContent ?? "", /Unknown player \(invalid ID: 99\)\s*→/);
   assert.match(goal.textContent ?? "", /Assists: Unknown player \(invalid ID: 17\)/);
-  assert(goal.querySelector('[data-ui="goal-team-chip"][data-team-id="red"]'));
-  assert(goal.querySelector('[data-ui="goal-team-chip"][data-team-id="42"]'));
+  assert(goal.querySelector('[data-ui="goal-team-chip"][data-team-id="red"][aria-label="Scoring team: red"]'));
+  assert(goal.querySelector('[data-ui="goal-team-chip"][data-team-id="constructor"][aria-label="Conceding team: Constructor"]'));
+  assert.equal(goal.querySelector('[data-team-id="red"]')?.textContent, "");
+  assert.equal(goal.querySelector('[data-team-id="constructor"]')?.textContent, "");
+  const malformedScoringDotStyle = goal.querySelector('[data-team-id="red"]')?.getAttribute("style");
+  const malformedConcedingDotStyle = goal.querySelector('[data-team-id="constructor"]')?.getAttribute("style");
+  assert.match(malformedScoringDotStyle ?? "", /^--team-color: #[0-9a-f]{6}$/i);
+  assert.match(malformedConcedingDotStyle ?? "", /^--team-color: #[0-9a-f]{6}$/i);
+  assert.notEqual(malformedScoringDotStyle, malformedConcedingDotStyle);
+  assert.doesNotMatch(goal.innerHTML, /javascript:/i);
   assert.doesNotMatch(goal.innerHTML, /undefined|null/);
   assert.match(fullGoalLog.textContent ?? "", /Unknown player \(invalid ID: 99\)/);
   assert.match(scorerStats.textContent ?? "", /Valid 99\s*2/);
@@ -6616,6 +6635,8 @@ test("game page runs live goal scoring, corrections, undo, and delete", async ()
     { playerId: "player-ari", nickname: "Ari", teamId: "red" as TeamId },
     { playerId: "player-bea", nickname: "Bea", teamId: "red" as TeamId },
     { playerId: "player-cy", nickname: "Cy", teamId: "blue" as TeamId },
+    { playerId: "player-dax", nickname: "Dax", teamId: "red" as TeamId },
+    { playerId: "player-eve", nickname: "Eve", teamId: "blue" as TeamId },
   ];
   for (const playerSeed of playerSeeds) {
     apiState.players.set(playerSeed.playerId, {
@@ -6657,6 +6678,8 @@ test("game page runs live goal scoring, corrections, undo, and delete", async ()
   const concedingTeamInput = gamePage.document.getElementById("goal-conceding-team");
   const ownGoalInput = gamePage.document.getElementById("goal-own-goal");
   const scorerInput = gamePage.document.getElementById("goal-scorer");
+  const assistsDropdown = gamePage.document.getElementById("goal-assists-dropdown");
+  const assistsSummary = gamePage.document.getElementById("goal-assists-summary");
   const assistsElement = gamePage.document.getElementById("goal-assists");
   const saveGoalButton = gamePage.document.querySelector('[data-action="save-goal"]');
   const undoLastGoalButton = gamePage.document.querySelector('[data-action="undo-last-goal"]');
@@ -6668,6 +6691,8 @@ test("game page runs live goal scoring, corrections, undo, and delete", async ()
   assert(concedingTeamInput instanceof gamePage.window.HTMLSelectElement);
   assert(ownGoalInput instanceof gamePage.window.HTMLInputElement);
   assert(scorerInput instanceof gamePage.window.HTMLSelectElement);
+  assert(assistsDropdown instanceof gamePage.window.HTMLDetailsElement);
+  assert(assistsSummary instanceof gamePage.window.HTMLElement);
   assert(assistsElement instanceof gamePage.window.HTMLElement);
   assert(saveGoalButton instanceof gamePage.window.HTMLButtonElement);
   assert(undoLastGoalButton instanceof gamePage.window.HTMLButtonElement);
@@ -6675,6 +6700,10 @@ test("game page runs live goal scoring, corrections, undo, and delete", async ()
 
   assert.match(scoreboard.textContent ?? "", /Red/);
   assert.match(timeline.textContent ?? "", /No goals yet/);
+  assert.equal(scoringTeamInput.options[0]?.textContent, "Choose Team");
+  assert.equal(concedingTeamInput.options[0]?.textContent, "Choose Team");
+  assert.equal(assistsDropdown.open, false);
+  assert.equal(assistsSummary.textContent, "Choose assists");
   assert.equal(undoLastGoalButton.disabled, true);
   for (const scoreTeam of scoreboard.querySelectorAll('[data-ui="score-team"]')) {
     assert.deepEqual(
@@ -6694,16 +6723,44 @@ test("game page runs live goal scoring, corrections, undo, and delete", async ()
   scorerInput.dispatchEvent(new gamePage.window.Event("change", { bubbles: true }));
   const beaAssist = assistsElement.querySelector('input[value="player-bea"]');
   assert(beaAssist instanceof gamePage.window.HTMLInputElement);
+  assistsDropdown.open = true;
+  beaAssist.focus();
   beaAssist.checked = true;
   beaAssist.dispatchEvent(new gamePage.window.Event("change", { bubbles: true }));
+  const focusedBeaAssist = assistsElement.querySelector('input[value="player-bea"]');
+  const cyAssist = assistsElement.querySelector('input[value="player-cy"]');
+  assert(focusedBeaAssist instanceof gamePage.window.HTMLInputElement);
+  assert(cyAssist instanceof gamePage.window.HTMLInputElement);
+  assert.equal(gamePage.document.activeElement, focusedBeaAssist);
+  assert.equal(assistsSummary.textContent, "Bea");
+  cyAssist.checked = true;
+  cyAssist.dispatchEvent(new gamePage.window.Event("change", { bubbles: true }));
+  assert.equal(assistsSummary.textContent, "Bea, Cy");
+  assert.equal(assistsElement.querySelectorAll('input[type="checkbox"]:checked').length, 2);
+  const daxAssist = assistsElement.querySelector('input[value="player-dax"]');
+  assert(daxAssist instanceof gamePage.window.HTMLInputElement);
+  daxAssist.checked = true;
+  daxAssist.dispatchEvent(new gamePage.window.Event("change", { bubbles: true }));
+  assert.equal(assistsSummary.textContent, "3 selected");
+  assert.equal(assistsSummary.getAttribute("title"), "Bea, Cy, Dax");
+  const eveAssist = assistsElement.querySelector('input[value="player-eve"]');
+  assert(eveAssist instanceof gamePage.window.HTMLInputElement);
+  assert.equal(eveAssist.disabled, true);
+  assert.equal(assistsElement.querySelectorAll('input[type="checkbox"]:checked').length, 3);
+  const assistsSummaryControl = assistsDropdown.querySelector("summary");
+  assert(assistsSummaryControl instanceof gamePage.window.HTMLElement);
+  assistsDropdown.dispatchEvent(new gamePage.window.KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+  assert.equal(assistsDropdown.open, false);
+  assert.equal(gamePage.document.activeElement, assistsSummaryControl);
   dispatchClick(saveGoalButton);
   await flushAsync();
 
   assert.equal(apiState.goalEvents.get("goal-1")?.scoringTeamId, "red");
   assert.match(scoreboard.querySelector('[data-team-id="red"]')?.textContent ?? "", /Scored\s*1/);
   assert.match(scoreboard.querySelector('[data-team-id="blue"]')?.textContent ?? "", /Conceded\s*1/);
-  assert.match(timeline.textContent ?? "", /Ari\s*Red\s*→\s*Blue/);
-  assert.match(timeline.textContent ?? "", /Assists: Bea/);
+  assert.match(timeline.textContent ?? "", /Ari\s*→/);
+  assert.deepEqual(apiState.goalEvents.get("goal-1")?.assistPlayerIds, ["player-bea", "player-cy", "player-dax"]);
+  assert.match(timeline.textContent ?? "", /Assists: Bea, Cy, Dax/);
   assert.equal(undoLastGoalButton.disabled, false);
   assert.equal(scoringTeamInput.value, "");
   assert.equal(concedingTeamInput.value, "");
@@ -6712,6 +6769,8 @@ test("game page runs live goal scoring, corrections, undo, and delete", async ()
   assert.equal(concedingTeamInput.disabled, true);
   assert.equal(scorerInput.disabled, true);
   assert.equal(assistsElement.querySelectorAll('input[type="checkbox"]:checked').length, 0);
+  assert.equal(assistsDropdown.open, false);
+  assert.equal(assistsSummary.textContent, "Choose assists");
   const firstGoal = timeline.querySelector('[data-ui="goal-event"][data-event-id="goal-1"]');
   assert(firstGoal instanceof gamePage.window.HTMLElement);
   assert.equal(firstGoal.querySelector('[data-ui="goal-scorer"]')?.getAttribute("title"), "Ari");
@@ -6720,12 +6779,17 @@ test("game page runs live goal scoring, corrections, undo, and delete", async ()
       '[data-ui="goal-team-chip"][role="img"][data-team-id="red"][aria-label="Scoring team: Red"]',
     ),
   );
+  assert.equal(firstGoal.querySelector('[data-team-id="red"]')?.textContent, "");
+  assert.equal(firstGoal.querySelector('[data-team-id="red"]')?.getAttribute("title"), "Scoring team: Red");
   assert(firstGoal.querySelector('[data-ui="goal-team-arrow"]'));
   assert(
     firstGoal.querySelector(
       '[data-ui="goal-team-chip"][role="img"][data-team-id="blue"][aria-label="Conceding team: Blue"]',
     ),
   );
+  assert.equal(firstGoal.querySelector('[data-team-id="blue"]')?.textContent, "");
+  assert.equal(firstGoal.querySelector('[data-team-id="blue"]')?.getAttribute("title"), "Conceding team: Blue");
+  assert.doesNotMatch(firstGoal.textContent ?? "", /\bRed\b|\bBlue\b/);
   assert(firstGoal.querySelector('[data-ui="third-indicator"][data-third="1"][aria-label="Third 1 of 3"]'));
   assert(firstGoal.querySelector('[data-action="edit-goal"] [data-icon="pencil"]'));
   assert(firstGoal.querySelector('[data-action="delete-goal"] [data-icon="trash-2"]'));
@@ -6747,7 +6811,7 @@ test("game page runs live goal scoring, corrections, undo, and delete", async ()
   assert(refreshedEditButton instanceof refreshedPage.window.HTMLButtonElement);
   assert.match(refreshedScoreboard.querySelector('[data-team-id="red"]')?.textContent ?? "", /Scored\s*1/);
   assert.match(refreshedScoreboard.querySelector('[data-team-id="blue"]')?.textContent ?? "", /Conceded\s*1/);
-  assert.match(refreshedTimeline.textContent ?? "", /Ari\s*Red\s*→\s*Blue/);
+  assert.match(refreshedTimeline.textContent ?? "", /Ari\s*→/);
   assert.equal(refreshedUndoButton.disabled, false);
 
   const editGoalButton = gamePage.document.querySelector('[data-action="edit-goal"][data-event-id="goal-1"]');
@@ -6769,7 +6833,7 @@ test("game page runs live goal scoring, corrections, undo, and delete", async ()
   assert.equal(apiState.goalEvents.get("goal-1")?.scoringTeamId, null);
   assert.match(scoreboard.querySelector('[data-team-id="red"]')?.textContent ?? "", /Scored\s*0/);
   assert.match(scoreboard.querySelector('[data-team-id="blue"]')?.textContent ?? "", /Conceded\s*1/);
-  assert.match(timeline.textContent ?? "", /Cy\s*OG\s*→\s*Blue/);
+  assert.match(timeline.textContent ?? "", /Cy\s*OG\s*→/);
   assert.equal(scoringTeamInput.value, "");
   assert.equal(concedingTeamInput.value, "");
   assert.equal(scorerInput.value, "");
@@ -6796,7 +6860,7 @@ test("game page runs live goal scoring, corrections, undo, and delete", async ()
   await flushAsync();
 
   assert.equal(apiState.goalEvents.size, 2);
-  assert.match(timeline.textContent ?? "", /Cy\s*Blue\s*→\s*Red/);
+  assert.match(timeline.textContent ?? "", /Cy\s*→/);
 
   const deleteGoalButton = gamePage.document.querySelector('[data-action="delete-goal"][data-event-id="goal-1"]');
   assert(deleteGoalButton instanceof gamePage.window.HTMLButtonElement);
@@ -6804,7 +6868,7 @@ test("game page runs live goal scoring, corrections, undo, and delete", async ()
   await flushAsync();
   assert.equal(apiState.goalEvents.has("goal-1"), false);
   assert.equal(apiState.goalEvents.has("goal-2"), true);
-  assert.match(timeline.textContent ?? "", /Cy\s*Blue\s*→\s*Red/);
+  assert.match(timeline.textContent ?? "", /Cy\s*→/);
   assert.match(scoreboard.querySelector('[data-team-id="blue"]')?.textContent ?? "", /Scored\s*1/);
   assert.match(scoreboard.querySelector('[data-team-id="red"]')?.textContent ?? "", /Conceded\s*1/);
 
@@ -7648,8 +7712,8 @@ test("game page treats committed undo as success when finished result refresh fa
   assert.equal(apiState.goalEvents.has("goal-2"), false);
   assert.equal(apiState.goalEvents.has("goal-1"), true);
   assert.equal(apiState.games.get("game-undo-refresh-fail")?.result?.winnerTeamId, "red");
-  assert.match(timeline.textContent ?? "", /Ari\s*Red\s*→\s*Blue/);
-  assert.doesNotMatch(timeline.textContent ?? "", /Cy\s*Blue\s*→\s*Red/);
+  assert.match(timeline.textContent ?? "", /Ari\s*→/);
+  assert.doesNotMatch(timeline.textContent ?? "", /Cy\s*→/);
   assert.match(status.textContent ?? "", /Latest goal undone\. Run scores refreshed; Match Summary unavailable/);
   assert.equal(status.hasAttribute("data-state"), false);
   assert.match(error.textContent ?? "", /finished result could not be refreshed/);

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -6661,11 +6661,25 @@ test("game page renders malformed goal identity values without crashing", async 
   assert.notEqual(duplicateScoringDotStyle, duplicateConcedingDotStyle);
   assert.notEqual(duplicateScoringDotStyle, "--team-color: #112233");
   assert.notEqual(duplicateConcedingDotStyle, "--team-color: #112233");
+  const liveScoreboard = page.document.getElementById("live-scoreboard");
+  assert(liveScoreboard instanceof page.window.HTMLElement);
+  assert.equal(
+    liveScoreboard.querySelector('[data-ui="score-team"][data-team-id="red"]')?.getAttribute("style"),
+    duplicateScoringDotStyle,
+  );
+  assert.equal(
+    liveScoreboard.querySelector('[data-ui="score-team"][data-team-id="blue"]')?.getAttribute("style"),
+    duplicateConcedingDotStyle,
+  );
   const unsafeColorGoal = page.document.querySelector('[data-ui="goal-event"][data-event-id="unsafe-color-goal"]');
   assert(unsafeColorGoal instanceof page.window.HTMLElement);
   const unsafeDotStyle = unsafeColorGoal.querySelector('[data-team-id="yellow"]')?.getAttribute("style");
   assert.match(unsafeDotStyle ?? "", /^--team-color: #[0-9a-f]{6}$/i);
   assert.doesNotMatch(unsafeColorGoal.innerHTML, /javascript:/i);
+  assert.equal(
+    liveScoreboard.querySelector('[data-ui="score-team"][data-team-id="yellow"]')?.getAttribute("style"),
+    unsafeDotStyle,
+  );
   const unknownColorGoal = page.document.querySelector('[data-ui="goal-event"][data-event-id="unknown-color-goal"]');
   assert(unknownColorGoal instanceof page.window.HTMLElement);
   const unknownScoringDotStyle = unknownColorGoal.querySelector('[data-team-id="1"]')?.getAttribute("style");

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -6493,12 +6493,18 @@ test("game page renders malformed goal identity values without crashing", async 
   const malformedRedTeam = apiState.gameTeams.get("game-malformed-goal:red");
   assert(malformedRedTeam);
   malformedRedTeam.name = 123 as unknown as string;
-  malformedRedTeam.color = "javascript:alert(1)";
+  malformedRedTeam.color = "#123";
+  const malformedBlueTeam = apiState.gameTeams.get("game-malformed-goal:blue");
+  assert(malformedBlueTeam);
+  malformedBlueTeam.color = "#112233";
+  const malformedYellowTeam = apiState.gameTeams.get("game-malformed-goal:yellow");
+  assert(malformedYellowTeam);
+  malformedYellowTeam.color = "javascript:alert(1)";
   apiState.gameTeams.set("game-malformed-goal:constructor", {
     ...malformedRedTeam,
     teamId: "constructor" as TeamId,
     name: "Constructor",
-    color: null,
+    color: "#0000",
   });
   for (const player of [
     { playerId: "99", nickname: "Valid 99" },
@@ -6561,6 +6567,40 @@ test("game page renders malformed goal identity values without crashing", async 
     });
   }
   refreshMockFinishedResult(apiState, seededGame, "2026-03-28T11:02:00.000Z");
+  apiState.goalEvents.set("unsafe-color-goal", {
+    gameId: "game-malformed-goal",
+    eventId: "unsafe-color-goal",
+    third: 1,
+    thirdMinute: 4,
+    gameMinute: 4,
+    elapsedSeconds: 120,
+    stoppageMinute: null,
+    displayTime: "4'",
+    scoringTeamId: "yellow",
+    concedingTeamId: "red",
+    scorerPlayerId: "unsafe-player",
+    assistPlayerIds: [],
+    ownGoal: false,
+    createdAt: "2026-03-28T11:01:04.000Z",
+    updatedAt: "2026-03-28T11:01:04.000Z",
+  });
+  apiState.goalEvents.set("unknown-color-goal", {
+    gameId: "game-malformed-goal",
+    eventId: "unknown-color-goal",
+    third: 1,
+    thirdMinute: 5,
+    gameMinute: 5,
+    elapsedSeconds: 150,
+    stoppageMinute: null,
+    displayTime: "5'",
+    scoringTeamId: 1 as unknown as TeamId,
+    concedingTeamId: 6 as unknown as TeamId,
+    scorerPlayerId: "unknown-color-player",
+    assistPlayerIds: [],
+    ownGoal: false,
+    createdAt: "2026-03-28T11:01:05.000Z",
+    updatedAt: "2026-03-28T11:01:05.000Z",
+  });
 
   const page = await bootPage({
     html: renderGamePage("http://localhost:3001", { gameId: "game-malformed-goal" }),
@@ -6588,6 +6628,26 @@ test("game page renders malformed goal identity values without crashing", async 
   assert.match(malformedScoringDotStyle ?? "", /^--team-color: #[0-9a-f]{6}$/i);
   assert.match(malformedConcedingDotStyle ?? "", /^--team-color: #[0-9a-f]{6}$/i);
   assert.notEqual(malformedScoringDotStyle, malformedConcedingDotStyle);
+  assert.doesNotMatch(malformedConcedingDotStyle ?? "", /#0000/i);
+  const duplicateColorGoal = page.document.querySelector('[data-ui="goal-event"][data-event-id="valid-goal-1"]');
+  assert(duplicateColorGoal instanceof page.window.HTMLElement);
+  const duplicateScoringDotStyle = duplicateColorGoal.querySelector('[data-team-id="red"]')?.getAttribute("style");
+  const duplicateConcedingDotStyle = duplicateColorGoal.querySelector('[data-team-id="blue"]')?.getAttribute("style");
+  assert.match(duplicateScoringDotStyle ?? "", /^--team-color: #[0-9a-f]{6}$/i);
+  assert.match(duplicateConcedingDotStyle ?? "", /^--team-color: #[0-9a-f]{6}$/i);
+  assert.notEqual(duplicateScoringDotStyle, duplicateConcedingDotStyle);
+  const unsafeColorGoal = page.document.querySelector('[data-ui="goal-event"][data-event-id="unsafe-color-goal"]');
+  assert(unsafeColorGoal instanceof page.window.HTMLElement);
+  const unsafeDotStyle = unsafeColorGoal.querySelector('[data-team-id="yellow"]')?.getAttribute("style");
+  assert.match(unsafeDotStyle ?? "", /^--team-color: #[0-9a-f]{6}$/i);
+  assert.doesNotMatch(unsafeColorGoal.innerHTML, /javascript:/i);
+  const unknownColorGoal = page.document.querySelector('[data-ui="goal-event"][data-event-id="unknown-color-goal"]');
+  assert(unknownColorGoal instanceof page.window.HTMLElement);
+  const unknownScoringDotStyle = unknownColorGoal.querySelector('[data-team-id="1"]')?.getAttribute("style");
+  const unknownConcedingDotStyle = unknownColorGoal.querySelector('[data-team-id="6"]')?.getAttribute("style");
+  assert.match(unknownScoringDotStyle ?? "", /^--team-color: #[0-9a-f]{6}$/i);
+  assert.match(unknownConcedingDotStyle ?? "", /^--team-color: #[0-9a-f]{6}$/i);
+  assert.notEqual(unknownScoringDotStyle, unknownConcedingDotStyle);
   assert.doesNotMatch(goal.innerHTML, /javascript:/i);
   assert.doesNotMatch(goal.innerHTML, /undefined|null/);
   assert.match(fullGoalLog.textContent ?? "", /Unknown player \(invalid ID: 99\)/);

--- a/app/src/tests/setup-flow-e2e.test.ts
+++ b/app/src/tests/setup-flow-e2e.test.ts
@@ -6496,7 +6496,7 @@ test("game page renders malformed goal identity values without crashing", async 
   malformedRedTeam.color = "#123";
   const malformedBlueTeam = apiState.gameTeams.get("game-malformed-goal:blue");
   assert(malformedBlueTeam);
-  malformedBlueTeam.color = "#112233";
+  malformedBlueTeam.color = "#123f";
   const malformedYellowTeam = apiState.gameTeams.get("game-malformed-goal:yellow");
   assert(malformedYellowTeam);
   malformedYellowTeam.color = "javascript:alert(1)";
@@ -6504,7 +6504,13 @@ test("game page renders malformed goal identity values without crashing", async 
     ...malformedRedTeam,
     teamId: "constructor" as TeamId,
     name: "Constructor",
-    color: "#0000",
+    color: "#00000080",
+  });
+  apiState.gameTeams.set("game-malformed-goal:opaque-alpha", {
+    ...malformedRedTeam,
+    teamId: "opaque-alpha" as TeamId,
+    name: "Opaque Alpha",
+    color: "#1a2b3cff",
   });
   for (const player of [
     { playerId: "99", nickname: "Valid 99" },
@@ -6601,6 +6607,23 @@ test("game page renders malformed goal identity values without crashing", async 
     createdAt: "2026-03-28T11:01:05.000Z",
     updatedAt: "2026-03-28T11:01:05.000Z",
   });
+  apiState.goalEvents.set("opaque-alpha-goal", {
+    gameId: "game-malformed-goal",
+    eventId: "opaque-alpha-goal",
+    third: 1,
+    thirdMinute: 6,
+    gameMinute: 6,
+    elapsedSeconds: 180,
+    stoppageMinute: null,
+    displayTime: "6'",
+    scoringTeamId: "opaque-alpha" as TeamId,
+    concedingTeamId: "red",
+    scorerPlayerId: "opaque-alpha-player",
+    assistPlayerIds: [],
+    ownGoal: false,
+    createdAt: "2026-03-28T11:01:06.000Z",
+    updatedAt: "2026-03-28T11:01:06.000Z",
+  });
 
   const page = await bootPage({
     html: renderGamePage("http://localhost:3001", { gameId: "game-malformed-goal" }),
@@ -6628,7 +6651,7 @@ test("game page renders malformed goal identity values without crashing", async 
   assert.match(malformedScoringDotStyle ?? "", /^--team-color: #[0-9a-f]{6}$/i);
   assert.match(malformedConcedingDotStyle ?? "", /^--team-color: #[0-9a-f]{6}$/i);
   assert.notEqual(malformedScoringDotStyle, malformedConcedingDotStyle);
-  assert.doesNotMatch(malformedConcedingDotStyle ?? "", /#0000/i);
+  assert.doesNotMatch(malformedConcedingDotStyle ?? "", /#00000080/i);
   const duplicateColorGoal = page.document.querySelector('[data-ui="goal-event"][data-event-id="valid-goal-1"]');
   assert(duplicateColorGoal instanceof page.window.HTMLElement);
   const duplicateScoringDotStyle = duplicateColorGoal.querySelector('[data-team-id="red"]')?.getAttribute("style");
@@ -6636,6 +6659,8 @@ test("game page renders malformed goal identity values without crashing", async 
   assert.match(duplicateScoringDotStyle ?? "", /^--team-color: #[0-9a-f]{6}$/i);
   assert.match(duplicateConcedingDotStyle ?? "", /^--team-color: #[0-9a-f]{6}$/i);
   assert.notEqual(duplicateScoringDotStyle, duplicateConcedingDotStyle);
+  assert.notEqual(duplicateScoringDotStyle, "--team-color: #112233");
+  assert.notEqual(duplicateConcedingDotStyle, "--team-color: #112233");
   const unsafeColorGoal = page.document.querySelector('[data-ui="goal-event"][data-event-id="unsafe-color-goal"]');
   assert(unsafeColorGoal instanceof page.window.HTMLElement);
   const unsafeDotStyle = unsafeColorGoal.querySelector('[data-team-id="yellow"]')?.getAttribute("style");
@@ -6648,6 +6673,12 @@ test("game page renders malformed goal identity values without crashing", async 
   assert.match(unknownScoringDotStyle ?? "", /^--team-color: #[0-9a-f]{6}$/i);
   assert.match(unknownConcedingDotStyle ?? "", /^--team-color: #[0-9a-f]{6}$/i);
   assert.notEqual(unknownScoringDotStyle, unknownConcedingDotStyle);
+  const opaqueAlphaGoal = page.document.querySelector('[data-ui="goal-event"][data-event-id="opaque-alpha-goal"]');
+  assert(opaqueAlphaGoal instanceof page.window.HTMLElement);
+  assert.equal(
+    opaqueAlphaGoal.querySelector('[data-team-id="opaque-alpha"]')?.getAttribute("style"),
+    "--team-color: #1a2b3c",
+  );
   assert.doesNotMatch(goal.innerHTML, /javascript:/i);
   assert.doesNotMatch(goal.innerHTML, /undefined|null/);
   assert.match(fullGoalLog.textContent ?? "", /Unknown player \(invalid ID: 99\)/);
@@ -6801,7 +6832,7 @@ test("game page runs live goal scoring, corrections, undo, and delete", async ()
   assert(daxAssist instanceof gamePage.window.HTMLInputElement);
   daxAssist.checked = true;
   daxAssist.dispatchEvent(new gamePage.window.Event("change", { bubbles: true }));
-  assert.equal(assistsSummary.textContent, "3 selected");
+  assert.equal(assistsSummary.textContent, "Bea, Cy, Dax");
   assert.equal(assistsSummary.getAttribute("title"), "Bea, Cy, Dax");
   const eveAssist = assistsElement.querySelector('input[value="player-eve"]');
   assert(eveAssist instanceof gamePage.window.HTMLInputElement);

--- a/app/src/tests/ui-layout.test.ts
+++ b/app/src/tests/ui-layout.test.ts
@@ -385,6 +385,10 @@ test("game page renders editable game metadata view", () => {
   assert.match(html, /data-testid="goal-own-goal"/);
   assert.match(html, /data-testid="goal-scorer"/);
   assert.match(html, /data-testid="goal-assists"/);
+  assert.match(html, /id="goal-assists-dropdown"[^>]*data-testid="goal-assists-dropdown"/);
+  assert.doesNotMatch(html, /id="goal-assists-dropdown"[^>]*\sopen(?:\s|>)/);
+  assert.match(html, /id="goal-assists-summary"[^>]*>Choose assists<\/span>/);
+  assert.match(html, /data-icon="chevron-down"/);
   assert.match(html, /data-testid="add-goal"/);
   assert.match(html, /data-testid="undo-last-goal"/);
   assert.match(html, /data-testid="goal-timeline"/);

--- a/app/src/ui/layout.ts
+++ b/app/src/ui/layout.ts
@@ -1121,8 +1121,8 @@ export function renderGamePage(apiBaseUrl: string, input: GameContextPageInput):
           <input id="goal-own-goal" type="checkbox" data-testid="goal-own-goal" />
           <span>Own goal</span>
         </label>
-        <details data-ui="run-secondary-scoring" open>
-          <summary>Assists</summary>
+        <details id="goal-assists-dropdown" data-ui="run-secondary-scoring" data-testid="goal-assists-dropdown">
+          <summary><span>Assists</span><span id="goal-assists-summary" data-ui="assist-summary">Choose assists</span>${renderIcon("chevron-down")}</summary>
           <div id="goal-assists" data-ui="assist-list" data-testid="goal-assists"></div>
         </details>
       </div>

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -2751,6 +2751,89 @@
       return ` style="--team-color: ${escapeHtml(color)}"`;
     }
 
+    function goalTeamDotStyle(teamId) {
+      const availableTeams = rosterTeams.length > 0 ? rosterTeams : scoreboardTeams;
+      const teamsById = new Map();
+      for (const team of availableTeams) {
+        if (team && typeof team.teamId === "string" && team.teamId.length > 0) {
+          teamsById.set(team.teamId, team);
+        }
+      }
+      for (const goal of goalTimeline) {
+        for (const id of [goal?.scoringTeamId, goal?.concedingTeamId]) {
+          const normalizedId = id === null || id === undefined ? "" : String(id);
+          if (normalizedId.length > 0 && !teamsById.has(normalizedId)) {
+            teamsById.set(normalizedId, { teamId: normalizedId, color: null });
+          }
+        }
+      }
+      if (!teamsById.has(teamId)) {
+        teamsById.set(teamId, teamById(teamId) ?? { teamId, color: null });
+      }
+
+      const opaqueColor = (value) => {
+        if (typeof value !== "string") {
+          return null;
+        }
+        const match = value.match(/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/);
+        if (!match) {
+          return null;
+        }
+        const hex = match[1].toLowerCase();
+        return hex.length === 3
+          ? `#${[...hex].map((character) => `${character}${character}`).join("")}`
+          : `#${hex}`;
+      };
+      const colorCounts = new Map();
+      for (const team of teamsById.values()) {
+        const color = opaqueColor(team.color);
+        if (color) {
+          colorCounts.set(color, (colorCounts.get(color) ?? 0) + 1);
+        }
+      }
+
+      const colors = new Map();
+      const usedColors = new Set();
+      for (const [id, team] of teamsById) {
+        const color = opaqueColor(team.color);
+        if (color && colorCounts.get(color) === 1) {
+          colors.set(id, color);
+          usedColors.add(color);
+        }
+      }
+
+      const fallbackPalette = [
+        "#d64545",
+        "#2f6fcb",
+        "#d4a800",
+        "#477a70",
+        "#8a5b9b",
+        "#b5663d",
+        "#387c94",
+        "#7a7139",
+      ];
+      for (const id of teamsById.keys()) {
+        if (colors.has(id)) {
+          continue;
+        }
+        const preferredColor = fallbackTeamColor(id);
+        let color = [preferredColor, ...fallbackPalette].find((candidate) => !usedColors.has(candidate));
+        if (!color) {
+          const base = [...String(id || "unknown")]
+            .reduce((value, character) => ((value * 31) + character.charCodeAt(0)) >>> 0, 0);
+          let attempt = 0;
+          do {
+            color = `#${((base + (attempt * 2654435761)) & 0xffffff).toString(16).padStart(6, "0")}`;
+            attempt += 1;
+          } while (usedColors.has(color));
+        }
+        colors.set(id, color);
+        usedColors.add(color);
+      }
+
+      return ` style="--team-color: ${escapeHtml(colors.get(teamId) ?? fallbackTeamColor(teamId))}"`;
+    }
+
     function resultTeams() {
       const teams = currentGame?.result?.teams;
       if (!Array.isArray(teams)) {
@@ -3186,7 +3269,7 @@
         : String(teamId ?? "Unknown team");
       const accessibleName = relationship ? `${relationship}: ${name}` : name;
       return `<span data-ui="goal-team-chip" data-display="dot" role="img" data-team-id="${escapeHtml(String(teamId ?? ""))}"${
-        teamSwatchStyle(team, String(teamId ?? "Unknown team"))
+        goalTeamDotStyle(String(teamId ?? "Unknown team"))
       } aria-label="${escapeHtml(accessibleName)}" title="${escapeHtml(accessibleName)}"><span data-ui="team-swatch" aria-hidden="true"></span></span>`;
     }
 

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -2739,19 +2739,7 @@
       return palette[hash % palette.length];
     }
 
-    function teamSwatchStyle(team, fallbackTeamId = "") {
-      const teamId = typeof team?.teamId === "string" && team.teamId.length > 0
-        ? team.teamId
-        : String(fallbackTeamId || "unknown");
-      const requestedColor = typeof team?.color === "string" ? team.color : "";
-      const color = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(requestedColor)
-        ? requestedColor
-        : fallbackTeamColor(teamId);
-
-      return ` style="--team-color: ${escapeHtml(color)}"`;
-    }
-
-    function goalTeamDotStyle(teamId) {
+    function resolvedTeamColors(extraTeam = null, fallbackTeamId = "") {
       const availableTeams = rosterTeams.length > 0 ? rosterTeams : scoreboardTeams;
       const teamsById = new Map();
       for (const team of availableTeams) {
@@ -2767,8 +2755,11 @@
           }
         }
       }
-      if (!teamsById.has(teamId)) {
-        teamsById.set(teamId, teamById(teamId) ?? { teamId, color: null });
+      const extraTeamId = typeof extraTeam?.teamId === "string" && extraTeam.teamId.length > 0
+        ? extraTeam.teamId
+        : String(fallbackTeamId || "");
+      if (extraTeamId.length > 0 && !teamsById.has(extraTeamId)) {
+        teamsById.set(extraTeamId, extraTeam ?? teamById(extraTeamId) ?? { teamId: extraTeamId, color: null });
       }
 
       const opaqueColor = (value) => {
@@ -2839,7 +2830,23 @@
         usedColors.add(color);
       }
 
-      return ` style="--team-color: ${escapeHtml(colors.get(teamId) ?? fallbackTeamColor(teamId))}"`;
+      return colors;
+    }
+
+    function teamSwatchStyle(team, fallbackTeamId = "") {
+      const teamId = typeof team?.teamId === "string" && team.teamId.length > 0
+        ? team.teamId
+        : String(fallbackTeamId || "unknown");
+      const color = resolvedTeamColors(team, teamId).get(teamId) ?? fallbackTeamColor(teamId);
+      return ` style="--team-color: ${escapeHtml(color)}"`;
+    }
+
+    function goalTeamDotStyle(teamId) {
+      const normalizedTeamId = String(teamId ?? "Unknown team");
+      const team = teamById(normalizedTeamId) ?? { teamId: normalizedTeamId, color: null };
+      const color = resolvedTeamColors(team, normalizedTeamId).get(normalizedTeamId)
+        ?? fallbackTeamColor(normalizedTeamId);
+      return ` style="--team-color: ${escapeHtml(color)}"`;
     }
 
     function resultTeams() {

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -2118,6 +2118,8 @@
     const goalConcedingTeamInput = document.getElementById("goal-conceding-team");
     const goalOwnGoalInput = document.getElementById("goal-own-goal");
     const goalScorerInput = document.getElementById("goal-scorer");
+    const goalAssistsDropdown = document.getElementById("goal-assists-dropdown");
+    const goalAssistsSummaryElement = document.getElementById("goal-assists-summary");
     const goalAssistsElement = document.getElementById("goal-assists");
     const goalFormNote = document.getElementById("goal-form-note");
     const saveGoalButton = root.querySelector('[data-action="save-goal"]');
@@ -2576,6 +2578,8 @@
         goalConcedingTeamInput instanceof HTMLSelectElement &&
         goalOwnGoalInput instanceof HTMLInputElement &&
         goalScorerInput instanceof HTMLSelectElement &&
+        goalAssistsDropdown instanceof HTMLDetailsElement &&
+        goalAssistsSummaryElement instanceof HTMLElement &&
         goalAssistsElement instanceof HTMLElement &&
         goalFormNote instanceof HTMLElement &&
         saveGoalButton instanceof HTMLButtonElement &&
@@ -2718,11 +2722,31 @@
       });
     }
 
-    function teamSwatchStyle(team) {
-      const color = typeof team.color === "string" && team.color.length > 0 ? team.color : "#d9f0e8";
-      if (!/^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(color)) {
-        return "";
+    function fallbackTeamColor(teamId) {
+      const knownColors = new Map([
+        ["red", "#d64545"],
+        ["blue", "#2f6fcb"],
+        ["yellow", "#d4a800"],
+      ]);
+      const knownColor = knownColors.get(teamId);
+      if (knownColor) {
+        return knownColor;
       }
+
+      const palette = ["#477a70", "#8a5b9b", "#b5663d", "#387c94", "#7a7139"];
+      const hash = [...String(teamId || "unknown")]
+        .reduce((value, character) => ((value * 31) + character.charCodeAt(0)) >>> 0, 0);
+      return palette[hash % palette.length];
+    }
+
+    function teamSwatchStyle(team, fallbackTeamId = "") {
+      const teamId = typeof team?.teamId === "string" && team.teamId.length > 0
+        ? team.teamId
+        : String(fallbackTeamId || "unknown");
+      const requestedColor = typeof team?.color === "string" ? team.color : "";
+      const color = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/.test(requestedColor)
+        ? requestedColor
+        : fallbackTeamColor(teamId);
 
       return ` style="--team-color: ${escapeHtml(color)}"`;
     }
@@ -2918,7 +2942,7 @@
     }
 
     function renderGoalAssistChoices(scorerPlayerId, seedAssistPlayerIds = null) {
-      if (!(goalAssistsElement instanceof HTMLElement)) {
+      if (!(goalAssistsElement instanceof HTMLElement) || !(goalAssistsSummaryElement instanceof HTMLElement)) {
         return;
       }
 
@@ -2928,7 +2952,23 @@
 
       if (rostered.length === 0) {
         goalAssistsElement.innerHTML = `<p data-ui="empty-note">No assist options yet.</p>`;
+        goalAssistsSummaryElement.textContent = "No options";
+        goalAssistsSummaryElement.removeAttribute("title");
         return;
+      }
+
+      const selectedNames = rostered
+        .filter((player) => selected.has(player.playerId))
+        .map((player) => player.nickname);
+      goalAssistsSummaryElement.textContent = selectedNames.length === 0
+        ? "Choose assists"
+        : selectedNames.length <= 2
+          ? selectedNames.join(", ")
+          : `${selectedNames.length} selected`;
+      if (selectedNames.length > 0) {
+        goalAssistsSummaryElement.title = selectedNames.join(", ");
+      } else {
+        goalAssistsSummaryElement.removeAttribute("title");
       }
 
       goalAssistsElement.innerHTML = rostered
@@ -2964,7 +3004,7 @@
         goalScoringTeamInput.value = "";
         goalScoringTeamInput.disabled = true;
       } else {
-        renderSelectOptions(goalScoringTeamInput, teamOptions, previousScoringTeamId, "Choose scoring team", null, true);
+        renderSelectOptions(goalScoringTeamInput, teamOptions, previousScoringTeamId, "Choose Team", null, true);
       }
 
       const scoringTeamId = ownGoal ? null : goalScoringTeamInput.value;
@@ -2975,7 +3015,7 @@
         goalConcedingTeamInput,
         concedingOptions,
         previousConcedingTeamId,
-        "Choose conceding team",
+        "Choose Team",
         null,
         true,
       );
@@ -3144,9 +3184,10 @@
       const name = typeof team?.name === "string" && team.name.length > 0
         ? team.name
         : String(teamId ?? "Unknown team");
-      return `<span data-ui="goal-team-chip" role="img" data-team-id="${escapeHtml(String(teamId ?? ""))}"${
-        team ? teamSwatchStyle(team) : ""
-      }${relationship ? ` aria-label="${escapeHtml(`${relationship}: ${name}`)}"` : ""}><span data-ui="team-swatch" aria-hidden="true"></span><span>${escapeHtml(name)}</span></span>`;
+      const accessibleName = relationship ? `${relationship}: ${name}` : name;
+      return `<span data-ui="goal-team-chip" data-display="dot" role="img" data-team-id="${escapeHtml(String(teamId ?? ""))}"${
+        teamSwatchStyle(team, String(teamId ?? "Unknown team"))
+      } aria-label="${escapeHtml(accessibleName)}" title="${escapeHtml(accessibleName)}"><span data-ui="team-swatch" aria-hidden="true"></span></span>`;
     }
 
     function goalDisplayTime(goal) {
@@ -3487,6 +3528,9 @@
         if (input instanceof HTMLInputElement) {
           input.checked = false;
         }
+      }
+      if (goalAssistsDropdown instanceof HTMLDetailsElement) {
+        goalAssistsDropdown.open = false;
       }
       renderLiveScoring({
         ownGoal: false,
@@ -4446,8 +4490,26 @@
         renderLiveScoring();
       });
 
-      goalAssistsElement.addEventListener("change", () => {
+      goalAssistsElement.addEventListener("change", (event) => {
+        const changedInput = event.target instanceof HTMLInputElement ? event.target : null;
+        const changedValue = changedInput?.value ?? "";
         renderGoalAssistChoices(goalScorerInput.value);
+        const replacement = changedValue
+          ? [...goalAssistsElement.querySelectorAll('input[type="checkbox"]')]
+              .find((input) => input instanceof HTMLInputElement && input.value === changedValue)
+          : null;
+        if (replacement instanceof HTMLInputElement) {
+          replacement.focus();
+        }
+      });
+
+      goalAssistsDropdown.addEventListener("keydown", (event) => {
+        if (event.key !== "Escape" || !goalAssistsDropdown.open) {
+          return;
+        }
+        event.preventDefault();
+        goalAssistsDropdown.open = false;
+        goalAssistsDropdown.querySelector("summary")?.focus();
       });
 
       saveGoalButton.addEventListener("click", async () => {

--- a/app/src/ui/setup-flow.js
+++ b/app/src/ui/setup-flow.js
@@ -2775,11 +2775,19 @@
         if (typeof value !== "string") {
           return null;
         }
-        const match = value.match(/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/);
+        const match = value.match(/^#([0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/);
         if (!match) {
           return null;
         }
         const hex = match[1].toLowerCase();
+        if (hex.length === 4) {
+          return hex[3] === "f"
+            ? `#${[...hex.slice(0, 3)].map((character) => `${character}${character}`).join("")}`
+            : null;
+        }
+        if (hex.length === 8) {
+          return hex.endsWith("ff") ? `#${hex.slice(0, 6)}` : null;
+        }
         return hex.length === 3
           ? `#${[...hex].map((character) => `${character}${character}`).join("")}`
           : `#${hex}`;
@@ -3045,9 +3053,7 @@
         .map((player) => player.nickname);
       goalAssistsSummaryElement.textContent = selectedNames.length === 0
         ? "Choose assists"
-        : selectedNames.length <= 2
-          ? selectedNames.join(", ")
-          : `${selectedNames.length} selected`;
+        : selectedNames.join(", ");
       if (selectedNames.length > 0) {
         goalAssistsSummaryElement.title = selectedNames.join(", ");
       } else {

--- a/app/src/ui/styles.css
+++ b/app/src/ui/styles.css
@@ -879,7 +879,7 @@ body {
 
   > summary {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto auto;
+    grid-template-columns: auto minmax(0, 1fr) auto;
     align-items: center;
     gap: 0.65rem;
     min-height: 2.75rem;
@@ -907,10 +907,9 @@ body {
 
 [data-ui="assist-summary"] {
   min-width: 0;
-  max-width: 65%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
+  text-align: right;
+  white-space: normal;
   color: var(--ink-soft);
   font-size: 0.78rem;
   font-weight: 700;

--- a/app/src/ui/styles.css
+++ b/app/src/ui/styles.css
@@ -876,6 +876,44 @@ body {
   border-radius: 8px;
   padding: 0.55rem;
   background: #fbfdfc;
+
+  > summary {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    align-items: center;
+    gap: 0.65rem;
+    min-height: 2.75rem;
+    list-style: none;
+
+    &::-webkit-details-marker {
+      display: none;
+    }
+
+    [data-icon="chevron-down"] {
+      width: 1rem;
+      height: 1rem;
+      transition: transform 160ms ease;
+    }
+  }
+
+  &[open] > summary {
+    margin-bottom: 0.45rem;
+
+    [data-icon="chevron-down"] {
+      transform: rotate(180deg);
+    }
+  }
+}
+
+[data-ui="assist-summary"] {
+  min-width: 0;
+  max-width: 65%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--ink-soft);
+  font-size: 0.78rem;
+  font-weight: 700;
 }
 
 [data-ui="run-latest-goals"],
@@ -1565,24 +1603,7 @@ body {
     }
 
     [data-ui="goal-team-chip"] {
-      min-width: 0;
-      max-width: 4.25rem;
-      flex: 0 1 auto;
-      gap: 0.18rem;
-      padding: 0.12rem 0.3rem;
-      font-size: 0.7rem;
-
-      > span:last-child {
-        min-width: 0;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-      }
-
-      [data-ui="team-swatch"] {
-        width: 0.5rem;
-        height: 0.5rem;
-      }
+      flex: 0 0 auto;
     }
 
     [data-ui="third-indicator"] {
@@ -1596,20 +1617,20 @@ body {
   --team-color: #8db8a9;
   display: inline-flex;
   align-items: center;
-  gap: 0.28rem;
-  border: 1px solid var(--team-color);
+  justify-content: center;
+  width: 0.9rem;
+  height: 0.9rem;
+  flex: 0 0 0.9rem;
+  border: 1px solid color-mix(in srgb, var(--team-color) 70%, #213a36);
   border-radius: 999px;
-  padding: 0.18rem 0.48rem;
-  background: color-mix(in srgb, var(--team-color) 15%, white);
-  color: var(--ink-strong);
-  font-size: 0.76rem;
-  font-weight: 850;
+  padding: 0;
+  background: var(--team-color);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--team-color) 18%, white);
 
   [data-ui="team-swatch"] {
-    width: 0.62rem;
-    height: 0.62rem;
+    width: 100%;
+    height: 100%;
     border-radius: 999px;
-    background: var(--team-color);
     box-shadow: inset 0 0 0 1px rgba(29, 42, 47, 0.2);
   }
 }


### PR DESCRIPTION
<!-- review-packet-version:1 -->

## Behavioural claim

Run scoring keeps multi-assist support inside a compact native dropdown, uses concise “Choose Team” placeholders, and reduces latest-goal team tokens to safe, accessible colour dots without changing scoring or own-goal semantics.

## Specification and acceptance evidence

| Acceptance criterion | Evidence | Result |
| --- | --- | --- |
| Assists are collapsed by default in a native dropdown while retaining multi-select checkboxes | Static layout assertions and live-scoring JSDOM scenario | PASS |
| Up to three assists can be selected and a fourth is disabled | Three-assist payload/cap assertions | PASS |
| Dropdown summary, checkbox focus, Escape close/focus, edit seed, failure retention, retry key, and committed reset remain coherent | Live-flow and correction-retry JSDOM assertions | PASS |
| Scoring and conceding team placeholders both read exactly “Choose Team” | Select option assertions | PASS |
| Latest goals show textless team dots with explicit scoring/conceding accessible names and tooltips | Normal, own-goal, malformed-identity assertions | PASS |
| Invalid/missing/malicious colors receive safe deterministic, visually distinguishable fallbacks | Known/hash fallback tests including prototype-key `constructor`; unsafe style rejection | PASS |
| Current-head CI, QA deployment, and independent Codex review complete | PR checks, QA run 31933741559, signed-in responsive QA, and exact-head Codex review at 129a60d | PASS |

## Scope boundaries

Included:
- Run goal form assist disclosure and summary.
- Team select placeholder copy.
- Latest-goal team-dot presentation and safe fallback coloring.

Excluded:
- Goal API/schema, maximum-assist rule, idempotency ownership, scoring calculations, and durable state.
- Final full-match-log team semantics and scoreboard/result presentation.

## Change classification

- Declared risk: `medium`
- [x] `application-behaviour` — Application or API behaviour
- [ ] `documentation-only` — Documentation only
- [ ] `tests-only` — Tests only
- [ ] `backlog-maintenance` — Canonical backlog maintenance
- [ ] `dependency-tooling` — Dependency or tooling
- [ ] `public-contract` — Public API or repository contract
- [ ] `data-migration` — Database schema or data migration
- [ ] `permission-trust-boundary` — Permission or trust boundary
- [ ] `durable-state-ownership` — Durable state or ownership
- [ ] `destructive-behaviour` — Destructive or difficult-to-reverse behaviour
- [ ] `new-production-dependency` — New production dependency
- [ ] `authentication-authorisation` — Authentication or authorisation
- [ ] `privacy-regulated-data` — Privacy or regulated data
- [ ] `infrastructure-production-configuration` — Infrastructure or deployment control
- [ ] `review-policy` — Review policy, packet, or workflow

## Architecture and invariants

- [x] `architecture:none`
- [ ] `architecture:documented`
- [ ] `architecture:judgement-required`

### Affected invariants

None. INV-005 remains unchanged: this PR changes controls and presentation only; scored, conceded, own-goal, and assist payload semantics are preserved.

### Architecture or decision record

No architecture boundary changes. Existing client form state and goal mutation paths remain responsible for assist selection and reset.

## Failure and rollback

### Failure behaviour

Validation/transport failures preserve the open dropdown, selected assists, summary, draft, and idempotency key. Committed operations reset and close the disclosure. Invalid team colors fall back to safe local colors rather than reaching inline styles.

### Rollback approach

Revert the PR commits through `129a60d` to restore the expanded assists area, longer placeholders, and labelled team chips. No data or API rollback is required.

### Rollback evidence

The diff is limited to UI markup/controller/CSS and tests; payload schemas and stored goal events are unchanged.

## Automated and agent review disposition

### Unresolved blocking findings

None.

### Addressed findings and evidence

Quality review identified ambiguous textless fallback dots and incomplete edit/retry disclosure evidence. Safe deterministic colors and focused malformed/edit/retry tests address both. Engineering identified inherited object-key lookup risk; the fallback table now uses `Map`, with a `constructor` team-ID regression. Independent Codex review additionally found three-name summary truncation, fully opaque alpha-hex handling, and mismatched named/team-dot fallback legends. The summary now wraps visibly, opaque alpha colors canonicalize safely, and one resolved color map drives named team surfaces and goal dots. All five review threads have evidence replies and are resolved; UX, quality, engineering, and exact-head Codex review found no remaining material issue.

### Rejected findings and evidence

None.

## Human judgement

- [x] `human-judgement:none`
- [ ] `human-judgement:required`

### Decision requiring judgement

None.

### Options considered

None.

### Reason selected

None.

### Reversal cost

None.

## Review focus

- Verify multi-assist selection/cap and failure/retry/reset lifecycle.
- Verify latest-goal dots are compact but remain understandable to assistive technology.
- Verify own goals expose no invented scoring team.
- Verify all fallback colors remain safe for malformed IDs/colors.
- Verify INV-005 calculations are untouched.

## Validation

- `npm run typecheck -w @3fc/app`
- `npm run test -w @3fc/app` — 93/93 after final fixes
- `npm run lint`
- `npm test` — contracts typecheck, API 269/269, app 93/93, review-gate 57/57
- `git diff --check`
- UX, engineering, and quality read-only reviews with clean final re-audits
- GitHub current-head checks — lint, unit, contracts, and merge-gate PASS at `129a60d`
- Deploy QA run `31933741559` — site/API deploy and health/site/core smoke PASS
- Signed-in QA — 320px assist summary shows all three names with zero page overflow; 390px named scoreboard swatches match every textless goal-dot color with zero page overflow
- Independent Codex exact-head review — no major issues at `129a60d`
